### PR TITLE
Migrate the more app URL to Overte

### DIFF
--- a/scripts/system/more/app-more.js
+++ b/scripts/system/more/app-more.js
@@ -5,8 +5,9 @@
 //
 //  Created by Keb Helion, February 2020.
 //  Copyright 2020 Vircadia contributors.
+//  Copyright 2022 Overte e.V.
 //
-//  This script adds a "More Apps" selector to Vircadia to allow the user to add optional functionalities to the tablet.
+//  This script adds a "More Apps" selector to Overte to allow the user to add optional functionalities to the tablet.
 //  This application has been designed to work directly from the Github repository.
 //
 //  Distributed under the Apache License, Version 2.0.
@@ -56,7 +57,7 @@
         var runningScriptJson;
         for (var j = 0; j < currentlyRunningScripts.length; j++) {
             runningScriptJson = currentlyRunningScripts[j].url;
-            if (runningScriptJson.indexOf("https://cdn.vircadia.com/community-apps/applications") !== -1) {
+            if (runningScriptJson.indexOf("https://more.overte.org/applications") !== -1) {
                 newMessage += "_" + runningScriptJson;
             }
         }

--- a/scripts/system/more/more.html
+++ b/scripts/system/more/more.html
@@ -4,9 +4,10 @@
 //
 //  Created by Keb Helion, February 2020.
 //  Copyright 2020 Vircadia contributors.
+//  Copyright 2022 Overte e.V.
 //
-//  App maintained in: https://github.com/vircadia/community-apps
-//  App copied to: https://github.com/vircadia/vircadia
+//  App maintained in: https://github.com/overte-org/community-apps
+//  App copied to: https://github.com/overte-org/overte
 //
 //
 //  Distributed under the Apache License, Version 2.0.
@@ -54,7 +55,7 @@
             var currentPath = window.location.protocol + "//" + window.location.host + window.location.pathname;
             var developmentMode = window.location.toString().split("?")[1];
             var rootPath;    
-            var metadataScriptSrc = "https://cdn.vircadia.com/community-apps/applications/metadata.js";
+            var metadataScriptSrc = "https://more.overte.org/applications/metadata.js";
             
             if (developmentMode === "dev") { // Development mode loads locally, if not, load from repo.
                 console.info("Setting applications to local.")
@@ -64,7 +65,7 @@
             } else {
                 console.info("Setting applications to remote URL.")
                 console.info("Loading metadata remotely.");
-                rootPath = "https://cdn.vircadia.com/community-apps/applications/";
+                rootPath = "https://more.overte.org/applications/";
             }
 
             //Search
@@ -168,7 +169,7 @@
         </div>
         <hr>
         <p class="mainDesc">Want to contribute and add your own app?<br>
-        Read the <a href="https://cdn.vircadia.com/community-apps/web/index.html">guide</a>!</p>
+        Read the <a href="https://overte-org.github.io/community-apps/web/index.html">guide</a>!</p>
         <script>        
              function monitorEnter(e) {
                 var code = (e.keyCode ? e.keyCode : e.which);


### PR DESCRIPTION
Migrate the more app URL to Overte

Note: To have this working, you need to have previously
merged the PR #1 in the overte-org/community-apps repository
AND have proceeded to its copy in the subdomain more.overte.org
It will take all this set to be working.
