### PR TITLE
add canViewAssetURLs domain permissions

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1,5 +1,5 @@
 {
-  "version": 2.6,
+  "version": 2.7,
   "settings": [
     {
       "name": "metaverse",
@@ -461,6 +461,13 @@
               "type": "checkbox",
               "editable": true,
               "default": false
+            },
+            {
+              "name": "id_can_view_asset_urls",
+              "label": "View Asset URLs",
+              "type": "checkbox",
+              "editable": true,
+              "default": false
             }
           ],
           "non-deletable-row-key": "permissions_id",
@@ -491,6 +498,7 @@
                 "id_can_rez_tmp_certified": true,
                 "id_can_write_to_asset_server": true,
                 "id_can_get_and_set_private_user_data": true,
+                "id_can_view_asset_urls": true,
                 "permissions_id": "localhost"
             },
             {
@@ -634,6 +642,13 @@
               "type": "checkbox",
               "editable": true,
               "default": false
+            },
+            {
+              "name": "id_can_view_asset_urls",
+              "label": "View Asset URLs",
+              "type": "checkbox",
+              "editable": true,
+              "default": false
             }
           ]
         },
@@ -767,6 +782,13 @@
               "type": "checkbox",
               "editable": true,
               "default": false
+            },
+            {
+              "name": "id_can_view_asset_urls",
+              "label": "View Asset URLs",
+              "type": "checkbox",
+              "editable": true,
+              "default": false
             }
           ]
         },
@@ -870,6 +892,13 @@
             {
               "name": "id_can_get_and_set_private_user_data",
               "label": "Get and Set Private User Data",
+              "type": "checkbox",
+              "editable": true,
+              "default": false
+            },
+            {
+              "name": "id_can_view_asset_urls",
+              "label": "View Asset URLs",
               "type": "checkbox",
               "editable": true,
               "default": false
@@ -979,6 +1008,13 @@
               "type": "checkbox",
               "editable": true,
               "default": false
+            },
+            {
+              "name": "id_can_view_asset_urls",
+              "label": "View Asset URLs",
+              "type": "checkbox",
+              "editable": true,
+              "default": false
             }
           ]
         },
@@ -1079,13 +1115,20 @@
               "editable": true,
               "default": false
             },
-              {
-                "name": "id_can_get_and_set_private_user_data",
-                "label": "Get and Set Private User Data",
-                "type": "checkbox",
-                "editable": true,
-                "default": false
-              }
+            {
+              "name": "id_can_get_and_set_private_user_data",
+              "label": "Get and Set Private User Data",
+              "type": "checkbox",
+              "editable": true,
+              "default": false
+            },
+            {
+              "name": "id_can_view_asset_urls",
+              "label": "View Asset URLs",
+              "type": "checkbox",
+              "editable": true,
+              "default": false
+            }
           ]
         },
         {
@@ -1188,6 +1231,13 @@
             {
               "name": "id_can_get_and_set_private_user_data",
               "label": "Get and Set Private User Data",
+              "type": "checkbox",
+              "editable": true,
+              "default": false
+            },
+            {
+              "name": "id_can_view_asset_urls",
+              "label": "View Asset URLs",
               "type": "checkbox",
               "editable": true,
               "default": false

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -354,6 +354,7 @@ void DomainGatekeeper::updateNodePermissions() {
             userPerms.permissions |= NodePermissions::Permission::canReplaceDomainContent;
             userPerms.permissions |= NodePermissions::Permission::canGetAndSetPrivateUserData;
             userPerms.permissions |= NodePermissions::Permission::canRezAvatarEntities;
+            userPerms.permissions |= NodePermissions::Permission::canViewAssetURLs;
         } else {
             // at this point we don't have a sending socket for packets from this node - assume it is the active socket
             // or the public socket if we haven't activated a socket for the node yet
@@ -450,6 +451,7 @@ SharedNodePointer DomainGatekeeper::processAssignmentConnectRequest(const NodeCo
     userPerms.permissions |= NodePermissions::Permission::canReplaceDomainContent;
     userPerms.permissions |= NodePermissions::Permission::canGetAndSetPrivateUserData;
     userPerms.permissions |= NodePermissions::Permission::canRezAvatarEntities;
+    userPerms.permissions |= NodePermissions::Permission::canViewAssetURLs;
     newNode->setPermissions(userPerms);
     return newNode;
 }

--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -553,6 +553,29 @@ void DomainServerSettingsManager::setupConfigMap(const QString& userConfigFilena
 
         // No migration needed to version 2.6.
 
+        if (oldVersion < 2.7) {
+            // Default values for new canViewAssetURLs permission.
+            unpackPermissions();
+            std::list<std::unordered_map<NodePermissionsKey, NodePermissionsPointer>> permissionsSets{
+                _standardAgentPermissions.get(),
+                _agentPermissions.get(),
+                _ipPermissions.get(),
+                _macPermissions.get(),
+                _machineFingerprintPermissions.get(),
+                _groupPermissions.get(),
+                _groupForbiddens.get()
+            };
+            foreach (auto permissionsSet, permissionsSets) {
+                for (auto entry : permissionsSet) {
+                    const auto& userKey = entry.first;
+                    if (permissionsSet[userKey]->can(NodePermissions::Permission::canConnectToDomain)) {
+                        permissionsSet[userKey]->set(NodePermissions::Permission::canViewAssetURLs);
+                    }
+                }
+            }
+            packPermissions();
+        }
+
         // write the current description version to our settings
         *versionVariant = _descriptionVersion;
 

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1659,6 +1659,14 @@ float AvatarData::getUpdateRate(const QString& rateName) const {
     return 0.0f;
 }
 
+QString AvatarData::getSkeletonModelURLFromScript() const {
+    if (DependencyManager::get<NodeList>()->getThisNodeCanViewAssetURLs()) {
+        return _skeletonModelURL.toString();
+    } else {
+        return QString();
+    }
+}
+
 int AvatarData::getAverageBytesReceivedPerSecond() const {
     return lrint(_averageBytesReceived.getAverageSampleValuePerSecond());
 }

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1361,7 +1361,7 @@ public:
      */
     Q_INVOKABLE virtual void detachAll(const QString& modelURL, const QString& jointName = QString());
 
-    QString getSkeletonModelURLFromScript() const { return _skeletonModelURL.toString(); }
+    QString getSkeletonModelURLFromScript() const;
     void setSkeletonModelURLFromScript(const QString& skeletonModelString) { setSkeletonModelURL(QUrl(skeletonModelString)); }
 
     void setOwningAvatarMixer(const QWeakPointer<Node>& owningAvatarMixer) { _owningAvatarMixer = owningAvatarMixer; }

--- a/libraries/avatars/src/ScriptAvatarData.cpp
+++ b/libraries/avatars/src/ScriptAvatarData.cpp
@@ -11,6 +11,8 @@
 
 #include "ScriptAvatarData.h"
 
+#include <NodeList.h>
+
 ScriptAvatarData::ScriptAvatarData(AvatarSharedPointer avatarData) :
     _avatarData(avatarData)
 {
@@ -181,7 +183,9 @@ bool ScriptAvatarData::getLookAtSnappingEnabled() const {
 // START
 //
 QString ScriptAvatarData::getSkeletonModelURLFromScript() const {
-    if (AvatarSharedPointer sharedAvatarData = _avatarData.lock()) {
+    auto nodeList = DependencyManager::get<NodeList>();
+    AvatarSharedPointer sharedAvatarData = _avatarData.lock();
+    if (sharedAvatarData && nodeList->getThisNodeCanViewAssetURLs()) {
         return sharedAvatarData->getSkeletonModelURLFromScript();
     } else {
         return QString();

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -1590,6 +1590,8 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
         return properties;
     }
 
+    auto nodeList = DependencyManager::get<NodeList>();
+
     if (_idSet && (!psuedoPropertyFlagsActive || psueudoPropertyFlags.test(EntityPsuedoPropertyFlag::ID))) {
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER_ALWAYS(id, _id.toString());
     }
@@ -1658,7 +1660,7 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     COPY_PROXY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_COLLISION_MASK, collisionMask, collidesWith, getCollisionMaskAsString());
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_DYNAMIC, dynamic);
     COPY_PROXY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_DYNAMIC, dynamic, collisionsWillMove, getDynamic()); // legacy support
-    COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_COLLISION_SOUND_URL, collisionSoundURL);
+    COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_COLLISION_SOUND_URL, collisionSoundURL);
     COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_ACTION_DATA, actionData);
 
     // Cloning
@@ -1698,7 +1700,7 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     // Particles only
     if (_type == EntityTypes::ParticleEffect) {
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_SHAPE_TYPE, shapeType, getShapeTypeAsString());
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_COMPOUND_SHAPE_URL, compoundShapeURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_COMPOUND_SHAPE_URL, compoundShapeURL);
         COPY_PROPERTY_TO_QSCRIPTVALUE_TYPED(PROP_COLOR, color, u8vec3Color);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_ALPHA, alpha);
         _pulse.copyToScriptValue(_desiredProperties, properties, engine, skipDefaults, defaultEntityProperties);
@@ -1748,11 +1750,11 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     // Models only
     if (_type == EntityTypes::Model) {
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_SHAPE_TYPE, shapeType, getShapeTypeAsString());
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_COMPOUND_SHAPE_URL, compoundShapeURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_COMPOUND_SHAPE_URL, compoundShapeURL);
         COPY_PROPERTY_TO_QSCRIPTVALUE_TYPED(PROP_COLOR, color, u8vec3Color);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_TEXTURES, textures);
 
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_MODEL_URL, modelURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_MODEL_URL, modelURL);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_MODEL_SCALE, modelScale);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_JOINT_ROTATIONS_SET, jointRotationsSet);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_JOINT_ROTATIONS, jointRotations);
@@ -1817,7 +1819,7 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
     // Zones only
     if (_type == EntityTypes::Zone) {
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_SHAPE_TYPE, shapeType, getShapeTypeAsString());
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_COMPOUND_SHAPE_URL, compoundShapeURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_COMPOUND_SHAPE_URL, compoundShapeURL);
 
         if (!psuedoPropertyFlagsButDesiredEmpty) {
             _keyLight.copyToScriptValue(_desiredProperties, properties, engine, skipDefaults, defaultEntityProperties);
@@ -1829,7 +1831,7 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
 
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_FLYING_ALLOWED, flyingAllowed);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_GHOSTING_ALLOWED, ghostingAllowed);
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_FILTER_URL, filterURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_FILTER_URL, filterURL);
 
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_KEY_LIGHT_MODE, keyLightMode, getKeyLightModeAsString());
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_AMBIENT_LIGHT_MODE, ambientLightMode, getAmbientLightModeAsString());
@@ -1846,9 +1848,9 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_ALPHA, alpha);
         _pulse.copyToScriptValue(_desiredProperties, properties, engine, skipDefaults, defaultEntityProperties);
 
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_SOURCE_URL, sourceUrl);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_SOURCE_URL, sourceUrl);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_DPI, dpi);
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_SCRIPT_URL, scriptURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_SCRIPT_URL, scriptURL);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_MAX_FPS, maxFPS);
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_INPUT_MODE, inputMode, getInputModeAsString());
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_SHOW_KEYBOARD_FOCUS_HIGHLIGHT, showKeyboardFocusHighlight);
@@ -1861,9 +1863,9 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_VOXEL_VOLUME_SIZE, voxelVolumeSize);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_VOXEL_DATA, voxelData);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_VOXEL_SURFACE_STYLE, voxelSurfaceStyle);
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_X_TEXTURE_URL, xTextureURL);
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_Y_TEXTURE_URL, yTextureURL);
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_Z_TEXTURE_URL, zTextureURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_X_TEXTURE_URL, xTextureURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_Y_TEXTURE_URL, yTextureURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_Z_TEXTURE_URL, zTextureURL);
 
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_X_N_NEIGHBOR_ID, xNNeighborID);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_Y_N_NEIGHBOR_ID, yNNeighborID);
@@ -1897,7 +1899,7 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
 
     // Materials
     if (_type == EntityTypes::Material) {
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_MATERIAL_URL, materialURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_MATERIAL_URL, materialURL);
         COPY_PROPERTY_TO_QSCRIPTVALUE_GETTER(PROP_MATERIAL_MAPPING_MODE, materialMappingMode, getMaterialMappingModeAsString());
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_MATERIAL_PRIORITY, priority);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_PARENT_MATERIAL_NAME, parentMaterialName);
@@ -1914,13 +1916,13 @@ QScriptValue EntityItemProperties::copyToScriptValue(QScriptEngine* engine, bool
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_ALPHA, alpha);
         _pulse.copyToScriptValue(_desiredProperties, properties, engine, skipDefaults, defaultEntityProperties);
 
-        COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_IMAGE_URL, imageURL);
+        COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(PROP_IMAGE_URL, imageURL);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_EMISSIVE, emissive);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_KEEP_ASPECT_RATIO, keepAspectRatio);
         COPY_PROPERTY_TO_QSCRIPTVALUE(PROP_SUB_IMAGE, subImage);
 
         // Handle conversions to old 'textures' property from "imageURL"
-        if (((!psuedoPropertyFlagsButDesiredEmpty && _desiredProperties.isEmpty()) || _desiredProperties.getHasProperty(PROP_IMAGE_URL)) &&
+        if (nodeList->getThisNodeCanViewAssetURLs() && ((!psuedoPropertyFlagsButDesiredEmpty && _desiredProperties.isEmpty()) || _desiredProperties.getHasProperty(PROP_IMAGE_URL)) &&
                 (!skipDefaults || defaultEntityProperties._imageURL != _imageURL)) {
             QScriptValue textures = engine->newObject();
             textures.setProperty("tex.picture", _imageURL);

--- a/libraries/entities/src/EntityItemPropertiesMacros.h
+++ b/libraries/entities/src/EntityItemPropertiesMacros.h
@@ -213,6 +213,13 @@ inline QScriptValue convertScriptValue(QScriptEngine* e, const AACube& v) { retu
         properties.setProperty(#P, V); \
     }
 
+#define COPY_PROPERTY_TO_QSCRIPTVALUE_IF_URL_PERMISSION(p,P) \
+    if (nodeList->getThisNodeCanViewAssetURLs() && ((!psuedoPropertyFlagsButDesiredEmpty && _desiredProperties.isEmpty()) || _desiredProperties.getHasProperty(p)) && \
+        (!skipDefaults || defaultEntityProperties._##P != _##P)) { \
+        QScriptValue V = convertScriptValue(engine, _##P); \
+        properties.setProperty(#P, V); \
+    }
+
 typedef QVector<glm::vec3> qVectorVec3;
 typedef QVector<glm::quat> qVectorQuat;
 typedef QVector<bool> qVectorBool;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -58,6 +58,7 @@ EntityScriptingInterface::EntityScriptingInterface(bool bidOnSimulationOwnership
     connect(nodeList.data(), &NodeList::canWriteAssetsChanged, this, &EntityScriptingInterface::canWriteAssetsChanged);
     connect(nodeList.data(), &NodeList::canGetAndSetPrivateUserDataChanged, this, &EntityScriptingInterface::canGetAndSetPrivateUserDataChanged);
     connect(nodeList.data(), &NodeList::canRezAvatarEntitiesChanged, this, &EntityScriptingInterface::canRezAvatarEntitiesChanged);
+    connect(nodeList.data(), &NodeList::canViewAssetURLsChanged, this, &EntityScriptingInterface::canViewAssetURLsChanged);
 
     auto& packetReceiver = nodeList->getPacketReceiver();
     packetReceiver.registerListener(PacketType::EntityScriptCallMethod,
@@ -118,6 +119,11 @@ bool EntityScriptingInterface::canGetAndSetPrivateUserData() {
 bool EntityScriptingInterface::canRezAvatarEntities() {
     auto nodeList = DependencyManager::get<NodeList>();
     return nodeList->getThisNodeCanRezAvatarEntities();
+}
+
+bool EntityScriptingInterface::canViewAssetURLs() {
+    auto nodeList = DependencyManager::get<NodeList>();
+    return nodeList->getThisNodeCanViewAssetURLs();
 }
 
 void EntityScriptingInterface::setEntityTree(EntityTreePointer elementTree) {

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -300,6 +300,14 @@ public slots:
     Q_INVOKABLE bool canRezAvatarEntities();
 
     /*@jsdoc
+     * Checks whether or not the script can view asset URLs
+     * @function Entities.canViewAssetURLs
+     * @returns {boolean} <code>true</code> if the domain server will allow the script to view asset URLs,
+     *     otherwise <code>false</code>.
+     */
+    Q_INVOKABLE bool canViewAssetURLs();
+
+    /*@jsdoc
      * <p>How an entity is hosted and sent to others for display.</p>
      * <table>
      *   <thead>
@@ -2279,6 +2287,14 @@ signals:
      */
     void canRezAvatarEntitiesChanged(bool canRezAvatarEntities);
 
+    /*@jsdoc
+     * Triggered when your ability to view asset URLs is changed.
+     * @function Entities.canViewAssetURLsChanged
+     * @param {boolean} canViewAssetURLs - <code>true</code> if the script can view asset URLs,
+     *     <code>false</code> if it can't.
+     * @returns {Signal}
+     */
+    void canViewAssetURLsChanged(bool canViewAssetURLs);
 
     /*@jsdoc
      * Triggered when a mouse button is clicked while the mouse cursor is on an entity, or a controller trigger is fully 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -205,6 +205,10 @@ void LimitedNodeList::setPermissions(const NodePermissions& newPermissions) {
         newPermissions.can(NodePermissions::Permission::canRezAvatarEntities)) {
         emit canRezAvatarEntitiesChanged(_permissions.can(NodePermissions::Permission::canRezAvatarEntities));
     }
+    if (originalPermissions.can(NodePermissions::Permission::canViewAssetURLs) !=
+        newPermissions.can(NodePermissions::Permission::canViewAssetURLs)) {
+        emit canViewAssetURLsChanged(_permissions.can(NodePermissions::Permission::canViewAssetURLs));
+    }
 }
 
 void LimitedNodeList::setSocketLocalPort(SocketType socketType, quint16 socketLocalPort) {

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -134,6 +134,7 @@ public:
     bool getThisNodeCanReplaceContent() const { return _permissions.can(NodePermissions::Permission::canReplaceDomainContent); }
     bool getThisNodeCanGetAndSetPrivateUserData() const { return _permissions.can(NodePermissions::Permission::canGetAndSetPrivateUserData); }
     bool getThisNodeCanRezAvatarEntities() const { return _permissions.can(NodePermissions::Permission::canRezAvatarEntities); }
+    bool getThisNodeCanViewAssetURLs() const { return _permissions.can(NodePermissions::Permission::canViewAssetURLs); }
 
     quint16 getSocketLocalPort(SocketType socketType) const { return _nodeSocket.localPort(socketType); }
     Q_INVOKABLE void setSocketLocalPort(SocketType socketType, quint16 socketLocalPort);
@@ -396,6 +397,7 @@ signals:
     void canReplaceContentChanged(bool canReplaceContent);
     void canGetAndSetPrivateUserDataChanged(bool canGetAndSetPrivateUserData);
     void canRezAvatarEntitiesChanged(bool canRezAvatarEntities);
+    void canViewAssetURLsChanged(bool canViewAssetURLs);
 
 protected slots:
     void connectedForLocalSocketTest();

--- a/libraries/networking/src/Node.h
+++ b/libraries/networking/src/Node.h
@@ -86,6 +86,7 @@ public:
     bool getCanReplaceContent() const { return _permissions.can(NodePermissions::Permission::canReplaceDomainContent); }
     bool getCanGetAndSetPrivateUserData() const { return _permissions.can(NodePermissions::Permission::canGetAndSetPrivateUserData); }
     bool getCanRezAvatarEntities() const { return _permissions.can(NodePermissions::Permission::canRezAvatarEntities); }
+    bool getCanViewAssetURLs() const { return _permissions.can(NodePermissions::Permission::canViewAssetURLs); }
 
     using NodesIgnoredPair = std::pair<std::vector<QUuid>, bool>;
 

--- a/libraries/networking/src/NodePermissions.cpp
+++ b/libraries/networking/src/NodePermissions.cpp
@@ -70,6 +70,7 @@ NodePermissions::NodePermissions(QMap<QString, QVariant> perms) {
     permissions |= perms["id_can_replace_content"].toBool() ? Permission::canReplaceDomainContent : Permission::none;
     permissions |= perms["id_can_get_and_set_private_user_data"].toBool() ? 
         Permission::canGetAndSetPrivateUserData : Permission::none;
+    permissions |= perms["id_can_view_asset_urls"].toBool() ? Permission::canViewAssetURLs : Permission::none;
 }
 
 QVariant NodePermissions::toVariant(QHash<QUuid, GroupRank> groupRanks) {
@@ -99,6 +100,7 @@ QVariant NodePermissions::toVariant(QHash<QUuid, GroupRank> groupRanks) {
     values["id_can_kick"] = can(Permission::canKick);
     values["id_can_replace_content"] = can(Permission::canReplaceDomainContent);
     values["id_can_get_and_set_private_user_data"] = can(Permission::canGetAndSetPrivateUserData);
+    values["id_can_view_asset_urls"] = can(Permission::canViewAssetURLs);
     return QVariant(values);
 }
 
@@ -176,6 +178,9 @@ QDebug operator<<(QDebug debug, const NodePermissions& perms) {
     }
     if (perms.can(NodePermissions::Permission::canGetAndSetPrivateUserData)) {
         debug << " get-and-set-private-user-data";
+    }
+    if (perms.can(NodePermissions::Permission::canViewAssetURLs)) {
+        debug << " can-view-asset-urls";
     }
     debug.nospace() << "]";
     return debug.nospace();

--- a/libraries/networking/src/NodePermissions.h
+++ b/libraries/networking/src/NodePermissions.h
@@ -81,7 +81,8 @@ public:
         canRezPermanentCertifiedEntities = 256,
         canRezTemporaryCertifiedEntities = 512,
         canGetAndSetPrivateUserData = 1024,
-        canRezAvatarEntities = 2048
+        canRezAvatarEntities = 2048,
+        canViewAssetURLs = 4096
     };
     Q_DECLARE_FLAGS(Permissions, Permission)
     Permissions permissions;


### PR DESCRIPTION
this is completely untested and I've never touched this area of the code before but *theoretically*:

this adds a new set of permissions to the domain server for who can view asset URLs on your domain from a script.  this includes any entity property that is a URL and any avatar skeletonModelURL.  it's possible that this will break scripts for those without permissions if the scripts rely on those URLs, and obviously the check is completely on the client so hacked clients could get around it but it's still an extra layer of content protection

would appreciate help testing this