### PR TITLE
Vircadia: Fixed sdl2 linking errors when built against new wayland.

### DIFF
--- a/cmake/ports/sdl2/fix-build-against-wayland-1_20.patch
+++ b/cmake/ports/sdl2/fix-build-against-wayland-1_20.patch
@@ -1,0 +1,28 @@
+diff -ur a/src/video/wayland/SDL_waylanddyn.h b/src/video/wayland/SDL_waylanddyn.h
+--- a/src/video/wayland/SDL_waylanddyn.h
++++ b/src/video/wayland/SDL_waylanddyn.h
+@@ -77,6 +77,9 @@
+ #define wl_proxy_add_listener (*WAYLAND_wl_proxy_add_listener)
+ #define wl_proxy_marshal_constructor (*WAYLAND_wl_proxy_marshal_constructor)
+ #define wl_proxy_marshal_constructor_versioned (*WAYLAND_wl_proxy_marshal_constructor_versioned)
++#define wl_proxy_marshal_flags (*WAYLAND_wl_proxy_marshal_flags)
++#define wl_proxy_marshal_array_flags (*WAYLAND_wl_proxy_marshal_array_flags)
++#define wl_proxy_get_version (*WAYLAND_wl_proxy_get_version)
+
+ #define wl_seat_interface (*WAYLAND_wl_seat_interface)
+ #define wl_surface_interface (*WAYLAND_wl_surface_interface)
+diff -ur a/src/video/wayland/SDL_waylandsym.h b/src/video/wayland/SDL_waylandsym.h
+--- a/src/video/wayland/SDL_waylandsym.h
++++ b/src/video/wayland/SDL_waylandsym.h
+@@ -70,6 +70,11 @@
+ SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_10)
+ SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor_versioned, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version, ...))
+
++SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_20)
++SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interfac, uint32_t version, uint32_t flags, ...))
++SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_array_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version,  uint32_t flags, union wl_argument *args))
++SDL_WAYLAND_SYM(uint32_t, wl_proxy_get_version, (struct wl_proxy *))
++
+ SDL_WAYLAND_INTERFACE(wl_seat_interface)
+ SDL_WAYLAND_INTERFACE(wl_surface_interface)
+ SDL_WAYLAND_INTERFACE(wl_shm_pool_interface)

--- a/cmake/ports/sdl2/portfile.cmake
+++ b/cmake/ports/sdl2/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         fix-arm64-headers.patch
         disable-hidapi-for-uwp.patch
         fix-space-in-path.patch
+        fix-build-against-wayland-1_20.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)


### PR DESCRIPTION
This is imported from #vircadia/vircadia#1576

It should fix issues with SDL on Linux, see the linked PR for details.

