### PR TITLE
rereouted xbox sticks, and made A and B flight-control buttons

### DIFF
--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -6,6 +6,11 @@
 		  "to": "Actions.TranslateZ"
         },
 
+        { "from": "Standard.RY",
+		  "when": ["!Application.InHMD", "Application.RightHandDominant"],
+		  "to": "Actions.Pitch"
+        },
+
         { "from": "Standard.LX",
           "when": [
             "Application.InHMD", "!Application.AdvancedMovement", "Application.RightHandDominant",
@@ -55,6 +60,11 @@
         { "from": "Standard.RY",
 		  "when": ["Application.LeftHandDominant", "!Standard.LY"],
 		  "to": "Actions.TranslateZ"
+        },
+
+        { "from": "Standard.LY",
+		  "when": ["!Application.InHMD", "Application.LeftHandDominant"],
+		  "to": "Actions.Pitch"
         },
 
         { "from": "Standard.RX",
@@ -108,6 +118,9 @@
 
         { "from": "Standard.LT", "to": "Actions.LeftHandClick" },
         { "from": "Standard.RT", "to": "Actions.RightHandClick" },
+
+        { "from": "Standard.A", "to": "Actions.VERTICAL_UP" },
+        { "from": "Standard.B", "to": "Actions.VERTICAL_DOWN" },
 
         { "from": "Standard.LeftHand", "to": "Actions.LeftHand" },
         { "from": "Standard.LeftHandThumb1", "to": "Actions.LeftHandThumb1"},

--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -119,8 +119,8 @@
         { "from": "Standard.LT", "to": "Actions.LeftHandClick" },
         { "from": "Standard.RT", "to": "Actions.RightHandClick" },
 
-        { "from": "Standard.A", "to": "Actions.VERTICAL_UP" },
-        { "from": "Standard.B", "to": "Actions.VERTICAL_DOWN" },
+        { "from": "Standard.A", "to": "Actions.Up" },
+        { "from": "Standard.B", "to": "Actions.Down" },
 
         { "from": "Standard.LeftHand", "to": "Actions.LeftHand" },
         { "from": "Standard.LeftHandThumb1", "to": "Actions.LeftHandThumb1"},

--- a/interface/resources/controllers/standard_navigation.json
+++ b/interface/resources/controllers/standard_navigation.json
@@ -6,7 +6,9 @@
         { "from": "Standard.DL", "to": "Actions.UiNavLateral", "filters": "invert" },
         { "from": "Standard.DR", "to": "Actions.UiNavLateral" },
         { "from": "Standard.LB", "to": "Actions.UiNavGroup","filters": "invert" },
-        { "from": "Standard.RB", "to": "Actions.UiNavGroup" }
+        { "from": "Standard.RB", "to": "Actions.UiNavGroup" },
+        { "from": [ "Standard.A", "Standard.X" ], "to": "Actions.UiNavSelect" },
+        { "from": [ "Standard.B", "Standard.Y" ], "to": "Actions.UiNavBack" }
     ]
 }
 

--- a/interface/resources/controllers/xbox.json
+++ b/interface/resources/controllers/xbox.json
@@ -4,7 +4,7 @@
         { "from": "GamePad.LY", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.LY" },
         { "from": "GamePad.LX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.LX" },
 
-        { "from": "GamePad.LT", "to": "Standard.LTClick",
+        { "from": "GamePad.LT", "to": "Standard.LT",
             "peek": true,
             "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
         },
@@ -15,7 +15,7 @@
         { "from": "GamePad.RX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.RX" },
         { "from": "GamePad.RY", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.RY" },
 
-        { "from": "GamePad.RT", "to": "Standard.RTClick",
+        { "from": "GamePad.RT", "to": "Standard.RT",
             "peek": true,
             "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
         },

--- a/interface/resources/controllers/xbox.json
+++ b/interface/resources/controllers/xbox.json
@@ -1,8 +1,8 @@
 {
     "name": "XBox to Standard",
     "channels": [
-        { "from": "GamePad.LY", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Actions.TranslateZ" },
-        { "from": "GamePad.LX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Actions.TranslateX" },
+        { "from": "GamePad.LY", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.LY" },
+        { "from": "GamePad.LX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.LX" },
 
         { "from": "GamePad.LT", "to": "Standard.LTClick",
             "peek": true,
@@ -12,29 +12,8 @@
         { "from": "GamePad.LB", "to": "Standard.LB" },
         { "from": "GamePad.LS", "to": "Standard.LS" },
 
-
-        { "from": "GamePad.RX",
-          "when": [ "Application.InHMD", "Application.SnapTurn" ],
-          "to": "Actions.StepYaw",
-          "filters":
-            [
-                { "type": "deadZone", "min": 0.15 },
-                "constrainToInteger",
-                { "type": "pulse", "interval": 0.25 },
-                { "type": "scale", "scale": 22.5 }
-            ]
-        },
-
-        { "from": "GamePad.RX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Actions.Yaw" },
-
-        { "from": "GamePad.RY",
-          "to": "Actions.VERTICAL_UP",
-          "filters":
-            [
-                { "type": "deadZone", "min": 0.95 },
-                "invert"
-            ]
-        },
+        { "from": "GamePad.RX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.RX" },
+        { "from": "GamePad.RY", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.RY" },
 
         { "from": "GamePad.RT", "to": "Standard.RTClick",
             "peek": true,
@@ -55,9 +34,6 @@
         { "from": "GamePad.A", "to": "Standard.A" },
         { "from": "GamePad.B", "to": "Standard.B" },
         { "from": "GamePad.X", "to": "Standard.X" },
-        { "from": "GamePad.Y", "to": "Standard.Y" },
-
-        { "from": [ "Standard.A", "Standard.X" ], "to": "Actions.UiNavSelect" },
-        { "from": [ "Standard.B", "Standard.Y" ], "to": "Actions.UiNavBack" }
+        { "from": "GamePad.Y", "to": "Standard.Y" }
     ]
 }

--- a/interface/resources/controllers/xbox.json
+++ b/interface/resources/controllers/xbox.json
@@ -4,7 +4,7 @@
         { "from": "GamePad.LY", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.LY" },
         { "from": "GamePad.LX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.LX" },
 
-        { "from": "GamePad.LT", "to": "Standard.LT",
+        { "from": "GamePad.LT", "to": "Standard.LTClick",
             "peek": true,
             "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
         },
@@ -15,7 +15,7 @@
         { "from": "GamePad.RX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.RX" },
         { "from": "GamePad.RY", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Standard.RY" },
 
-        { "from": "GamePad.RT", "to": "Standard.RT",
+        { "from": "GamePad.RT", "to": "Standard.RTClick",
             "peek": true,
             "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
         },

--- a/interface/resources/controllers/xbox_orig.json
+++ b/interface/resources/controllers/xbox_orig.json
@@ -1,0 +1,63 @@
+{
+    "name": "XBox to Standard",
+    "channels": [
+        { "from": "GamePad.LY", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Actions.TranslateZ" },
+        { "from": "GamePad.LX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Actions.TranslateX" },
+
+        { "from": "GamePad.LT", "to": "Standard.LTClick",
+            "peek": true,
+            "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
+        },
+        { "from": "GamePad.LT", "to": "Standard.LT" },
+        { "from": "GamePad.LB", "to": "Standard.LB" },
+        { "from": "GamePad.LS", "to": "Standard.LS" },
+
+
+        { "from": "GamePad.RX",
+          "when": [ "Application.InHMD", "Application.SnapTurn" ],
+          "to": "Actions.StepYaw",
+          "filters":
+            [
+                { "type": "deadZone", "min": 0.15 },
+                "constrainToInteger",
+                { "type": "pulse", "interval": 0.25 },
+                { "type": "scale", "scale": 22.5 }
+            ]
+        },
+
+        { "from": "GamePad.RX", "filters": { "type": "deadZone", "min": 0.05 }, "to": "Actions.Yaw" },
+
+        { "from": "GamePad.RY",
+          "to": "Actions.VERTICAL_UP",
+          "filters":
+            [
+                { "type": "deadZone", "min": 0.95 },
+                "invert"
+            ]
+        },
+
+        { "from": "GamePad.RT", "to": "Standard.RTClick",
+            "peek": true,
+            "filters": [ { "type": "hysteresis", "min": 0.85, "max": 0.9 } ]
+        },
+        { "from": "GamePad.RT", "to": "Standard.RT" },
+        { "from": "GamePad.RB", "to": "Standard.RB" },
+        { "from": "GamePad.RS", "to": "Standard.RS" },
+
+        { "from": "GamePad.Start", "to": "Standard.Start" },
+        { "from": "GamePad.Back", "to": "Actions.CycleCamera" },
+
+        { "from": "GamePad.DU", "to": "Standard.DU" },
+        { "from": "GamePad.DD", "to": "Standard.DD" },
+        { "from": "GamePad.DL", "to": "Standard.DL" },
+        { "from": "GamePad.DR", "to": "Standard.DR" },
+
+        { "from": "GamePad.A", "to": "Standard.A" },
+        { "from": "GamePad.B", "to": "Standard.B" },
+        { "from": "GamePad.X", "to": "Standard.X" },
+        { "from": "GamePad.Y", "to": "Standard.Y" },
+
+        { "from": [ "Standard.A", "Standard.X" ], "to": "Actions.UiNavSelect" },
+        { "from": [ "Standard.B", "Standard.Y" ], "to": "Actions.UiNavBack" }
+    ]
+}


### PR DESCRIPTION
this change effects both xbox and playstation controllers, as well as probably some controllers i don't have, but for the sake of brevity and since the file is called xbox.json, i'll just be saying "xbox."

previously, the sticks on xbox were not properly rerouted by scripts.  this is because xbox.json was mapping them straight to an action instead of to an input on the standard controller.  i also made the right stick's Y axis control camera pitch when not in HMD mode, since there was nothing doing that before.  instead, xbox's right stick would control vertical flight, which i have now mapped to A and B.