### PR TITLE
Fix test build system enough to build some tests

### DIFF
--- a/tests/animation/CMakeLists.txt
+++ b/tests/animation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Declare dependencies
 macro (setup_testcase_dependencies)
   # link in the shared libraries
-  link_hifi_libraries(shared animation gpu fbx hfm graphics networking test-utils image)
+  link_hifi_libraries(shared animation gpu hfm graphics networking test-utils image)
 
   package_libraries_for_deployment()
 endmacro ()

--- a/tests/octree/CMakeLists.txt
+++ b/tests/octree/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Declare dependencies
 macro (setup_testcase_dependencies)
   # link in the shared libraries
-  link_hifi_libraries(shared test-utils octree gpu graphics fbx networking entities avatars audio animation script-engine physics)
+  link_hifi_libraries(shared test-utils octree gpu graphics networking entities avatars audio animation script-engine physics)
 
   package_libraries_for_deployment()
 endmacro ()


### PR DESCRIPTION
With this, some tests actually build. Run cmake like this:

`cmake ../overte -DBUILD_TESTS=ON`

Then build the tests:

`make all-tests`

A whole bunch still fail, but some work. They'll be under the tests/ subdirectory.
