### PR TITLE
Implement network serializer

### DIFF
--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -94,6 +94,8 @@ typedef std::shared_ptr< SphericalHarmonics > SHPointer;
 
 
 inline DataSerializer &operator<<(DataSerializer &ser, const SphericalHarmonics &h) {
+    DataSerializer::SizeTracker tracker(ser);
+
     ser << h.L00  << h.spare0;
     ser << h.L1m1 << h.spare1;
     ser << h.L10  << h.spare2;
@@ -107,6 +109,8 @@ inline DataSerializer &operator<<(DataSerializer &ser, const SphericalHarmonics 
 }
 
 inline DataDeserializer &operator>>(DataDeserializer &des, SphericalHarmonics &h) {
+    DataDeserializer::SizeTracker tracker(des);
+
     des >> h.L00  >> h.spare0;
     des >> h.L1m1 >> h.spare1;
     des >> h.L10  >> h.spare2;
@@ -238,6 +242,7 @@ protected:
 };
 
 inline DataSerializer &operator<<(DataSerializer &ser, const Sampler::Desc &d) {
+    DataSerializer::SizeTracker tracker(ser);
     ser << d._borderColor;
     ser << d._maxAnisotropy;
     ser << d._filter;
@@ -252,6 +257,7 @@ inline DataSerializer &operator<<(DataSerializer &ser, const Sampler::Desc &d) {
 }
 
 inline DataDeserializer &operator>>(DataDeserializer &dsr, Sampler::Desc &d) {
+    DataDeserializer::SizeTracker tracker(dsr);
     dsr >> d._borderColor;
     dsr >> d._maxAnisotropy;
     dsr >> d._filter;

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -92,6 +92,33 @@ public:
 };
 typedef std::shared_ptr< SphericalHarmonics > SHPointer;
 
+
+inline SerDes &operator<<(SerDes &ser, const SphericalHarmonics &h) {
+    ser << h.L00  << h.spare0;
+    ser << h.L1m1 << h.spare1;
+    ser << h.L10  << h.spare2;
+    ser << h.L11  << h.spare3;
+    ser << h.L2m2 << h.spare4;
+    ser << h.L2m1 << h.spare5;
+    ser << h.L20  << h.spare6;
+    ser << h.L21  << h.spare7;
+    ser << h.L22  << h.spare8;
+    return ser;
+}
+
+inline SerDes &operator>>(SerDes &des, SphericalHarmonics &h) {
+    des >> h.L00  >> h.spare0;
+    des >> h.L1m1 >> h.spare1;
+    des >> h.L10  >> h.spare2;
+    des >> h.L11  >> h.spare3;
+    des >> h.L2m2 >> h.spare4;
+    des >> h.L2m1 >> h.spare5;
+    des >> h.L20  >> h.spare6;
+    des >> h.L21  >> h.spare7;
+    des >> h.L22  >> h.spare8;
+    return des;
+}
+
 class Sampler {
 public:
 

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -93,7 +93,7 @@ public:
 typedef std::shared_ptr< SphericalHarmonics > SHPointer;
 
 
-inline SerDes &operator<<(SerDes &ser, const SphericalHarmonics &h) {
+inline DataSerializer &operator<<(DataSerializer &ser, const SphericalHarmonics &h) {
     ser << h.L00  << h.spare0;
     ser << h.L1m1 << h.spare1;
     ser << h.L10  << h.spare2;
@@ -106,7 +106,7 @@ inline SerDes &operator<<(SerDes &ser, const SphericalHarmonics &h) {
     return ser;
 }
 
-inline SerDes &operator>>(SerDes &des, SphericalHarmonics &h) {
+inline DataDeserializer &operator>>(DataDeserializer &des, SphericalHarmonics &h) {
     des >> h.L00  >> h.spare0;
     des >> h.L1m1 >> h.spare1;
     des >> h.L10  >> h.spare2;
@@ -185,7 +185,7 @@ public:
                 _maxMip == other._maxMip;
         }
 
-        SerDes &operator<<(SerDes &dsd) {
+        DataSerializer &operator<<(DataSerializer &dsd) {
             dsd << _borderColor;
             dsd << _maxAnisotropy;
             dsd << _filter;
@@ -237,7 +237,7 @@ protected:
     friend class Deserializer;
 };
 
-inline SerDes &operator<<(SerDes &ser, const Sampler::Desc &d) {
+inline DataSerializer &operator<<(DataSerializer &ser, const Sampler::Desc &d) {
     ser << d._borderColor;
     ser << d._maxAnisotropy;
     ser << d._filter;
@@ -251,7 +251,7 @@ inline SerDes &operator<<(SerDes &ser, const Sampler::Desc &d) {
     return ser;
 }
 
-inline SerDes &operator>>(SerDes &dsr, Sampler::Desc &d) {
+inline DataDeserializer &operator>>(DataDeserializer &dsr, Sampler::Desc &d) {
     dsr >> d._borderColor;
     dsr >> d._maxAnisotropy;
     dsr >> d._filter;

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -64,19 +64,16 @@ struct GPUKTXPayload {
     void serialize(DataSerializer &ser) {
 
         ser << CURRENT_VERSION;
-        ser.addPadding(1);
 
         ser << _samplerDesc;
 
         uint32_t usageData = (uint32_t)_usage._flags.to_ulong();
         ser << usageData;
         ser << ((uint8_t)_usageType);
-        ser.addPadding(1);
         ser << _originalSize;
 
+        ser.addPadding(PADDING);
 
-        // The +1 is here because we're adding the CURRENT_VERSION at the top, but since it's declared as a static
-        // const, it's not actually part of the class' size.
         assert(ser.length() == GPUKTXPayload::SIZE);
     }
 
@@ -109,7 +106,7 @@ struct GPUKTXPayload {
         dsr >> _samplerDesc;
 
         dsr >> usageData;
-        _usage._flags = gpu::Texture::Usage::Flags(usageData);
+        _usage = gpu::Texture::Usage(usageData);
 
         dsr >> usagetype;
         dsr.skipPadding(1);

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -47,12 +47,15 @@ struct GPUKTXPayload {
         ser << CURRENT_VERSION;
         ser << _samplerDesc;
 
+        qCWarning(gpulogging) << "Offsets: " << offsetof(struct GPUKTXPayload, _samplerDesc) << offsetof(struct GPUKTXPayload, _usage) << offsetof(struct GPUKTXPayload, _usageType) << offsetof(struct GPUKTXPayload, _originalSize);
         uint32 usageData = _usage._flags.to_ulong();
         ser << usageData;
 
         ser << (char)_usageType;
         ser << _originalSize;
         ser.addPadding(PADDING);
+
+        assert(ser.length() == GPUKTXPayload::SIZE);
     }
 
     bool unserialize(DataDeserializer &dsr) {
@@ -65,6 +68,9 @@ struct GPUKTXPayload {
         if (version > CURRENT_VERSION) {
             // If we try to load a version that we don't know how to parse,
             // it will render incorrectly
+            qCWarning(gpulogging) << "KTX version" << version << "is newer than our own," << CURRENT_VERSION;
+            qCWarning(gpulogging) << "Offsets: " << offsetof(struct GPUKTXPayload, _samplerDesc) << offsetof(struct GPUKTXPayload, _usage) << offsetof(struct GPUKTXPayload, _usageType) << offsetof(struct GPUKTXPayload, _originalSize);
+            qCWarning(gpulogging) << dsr;
             return false;
         }
 

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -53,6 +53,14 @@ struct GPUKTXPayload {
     TextureUsageType _usageType;
     glm::ivec2 _originalSize { 0, 0 };
 
+    /**
+     * @brief Serialize the KTX payload
+     *
+     * @warning Be careful modifying this code, as it influences baked assets.
+     * Backwards compatibility must be maintained.
+     *
+     * @param ser Destination serializer
+     */
     void serialize(DataSerializer &ser) {
 
         ser << CURRENT_VERSION;
@@ -72,6 +80,16 @@ struct GPUKTXPayload {
         assert(ser.length() == GPUKTXPayload::SIZE);
     }
 
+    /**
+     * @brief Deserialize the KTX payload
+     *
+     * @warning Be careful modifying this code, as it influences baked assets.
+     * Backwards compatibility must be maintained.
+     *
+     * @param dsr Deserializer object
+     * @return true Successful
+     * @return false Version check failed
+     */
     bool unserialize(DataDeserializer &dsr) {
         Version version = 0;
         uint32_t usageData = 0;

--- a/libraries/gpu/src/gpu/Texture_ktx.cpp
+++ b/libraries/gpu/src/gpu/Texture_ktx.cpp
@@ -43,7 +43,7 @@ struct GPUKTXPayload {
     TextureUsageType _usageType;
     glm::ivec2 _originalSize { 0, 0 };
 
-    void serialize(SerDes &ser) {
+    void serialize(DataSerializer &ser) {
         ser << CURRENT_VERSION;
         ser << _samplerDesc;
 
@@ -55,7 +55,7 @@ struct GPUKTXPayload {
         ser.addPadding(PADDING);
     }
 
-    bool unserialize(SerDes &dsr) {
+    bool unserialize(DataDeserializer &dsr) {
         Version version = 0;
         uint32 usageData;
         uint8_t usagetype = 0;
@@ -88,7 +88,7 @@ struct GPUKTXPayload {
         auto found = std::find_if(keyValues.begin(), keyValues.end(), isGPUKTX);
         if (found != keyValues.end()) {
             auto value = found->_value;
-            SerDes dsr(value.data(), value.size());
+            DataDeserializer dsr(value.data(), value.size());
             return payload.unserialize(dsr);
         }
         return false;
@@ -109,13 +109,13 @@ struct IrradianceKTXPayload {
 
     SphericalHarmonics _irradianceSH;
 
-    void serialize(SerDes &ser) const {
+    void serialize(DataSerializer &ser) const {
         ser << CURRENT_VERSION;
         ser << _irradianceSH;
         ser.addPadding(PADDING);
     }
 
-    bool unserialize(SerDes &des) {
+    bool unserialize(DataDeserializer &des) {
         Version version;
         if (des.length() != SIZE) {
             return false;
@@ -138,7 +138,7 @@ struct IrradianceKTXPayload {
         auto found = std::find_if(keyValues.begin(), keyValues.end(), isIrradianceKTX);
         if (found != keyValues.end()) {
             auto value = found->_value;
-            SerDes des(value.data(), value.size());
+            DataDeserializer des(value.data(), value.size());
             return payload.unserialize(des);
         }
         return false;
@@ -449,7 +449,7 @@ ktx::KTXUniquePointer Texture::serialize(const Texture& texture, const glm::ivec
     gpuKeyval._originalSize = originalSize;
 
     Byte keyvalPayload[GPUKTXPayload::SIZE];
-    SerDes ser(keyvalPayload, sizeof(keyvalPayload));
+    DataSerializer ser(keyvalPayload, sizeof(keyvalPayload));
 
     gpuKeyval.serialize(ser);
 
@@ -461,7 +461,7 @@ ktx::KTXUniquePointer Texture::serialize(const Texture& texture, const glm::ivec
         irradianceKeyval._irradianceSH = *texture.getIrradiance();
 
         Byte irradianceKeyvalPayload[IrradianceKTXPayload::SIZE];
-        SerDes ser(irradianceKeyvalPayload, sizeof(irradianceKeyvalPayload));
+        DataSerializer ser(irradianceKeyvalPayload, sizeof(irradianceKeyvalPayload));
         irradianceKeyval.serialize(ser);
 
         keyValues.emplace_back(IrradianceKTXPayload::KEY, (uint32)IrradianceKTXPayload::SIZE, (ktx::Byte*) &irradianceKeyvalPayload);

--- a/libraries/octree/src/OctreePacketData.cpp
+++ b/libraries/octree/src/OctreePacketData.cpp
@@ -17,6 +17,7 @@
 #include "OctreeLogging.h"
 #include "NumericalConstants.h"
 #include <glm/gtc/type_ptr.hpp>
+#include "SerDes.h"
 
 bool OctreePacketData::_debug = false;
 AtomicUIntStat OctreePacketData::_totalBytesOfOctalCodes { 0 };
@@ -812,10 +813,10 @@ int OctreePacketData::unpackDataFromBytes(const unsigned char* dataBytes, QByteA
 }
 
 int OctreePacketData::unpackDataFromBytes(const unsigned char* dataBytes, AACube& result) {
-    aaCubeData cube;
-    memcpy(&cube, dataBytes, sizeof(aaCubeData));
-    result = AACube(cube.corner, cube.scale);
-    return sizeof(aaCubeData);
+    DataDeserializer des(dataBytes, sizeof(aaCubeData));
+    des >> result;
+
+    return des.length();
 }
 
 int OctreePacketData::unpackDataFromBytes(const unsigned char* dataBytes, QRect& result) {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1905,9 +1905,7 @@ void Blender::run() {
         blendedMeshSizes.push_back(numVertsInMesh);
 
         // initialize offsets to zero
-        for(BlendshapeOffsetUnpacked &bou : unpackedBlendshapeOffsets) {
-            bou.clear();
-        }
+        memset(unpackedBlendshapeOffsets.data(), 0, numVertsInMesh * sizeof(BlendshapeOffsetUnpacked));
 
         // for each blendshape in this mesh, accumulate the offsets into unpackedBlendshapeOffsets.
         const float NORMAL_COEFFICIENT_SCALE = 0.01f;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1905,7 +1905,9 @@ void Blender::run() {
         blendedMeshSizes.push_back(numVertsInMesh);
 
         // initialize offsets to zero
-        memset(unpackedBlendshapeOffsets.data(), 0, numVertsInMesh * sizeof(BlendshapeOffsetUnpacked));
+        for(BlendshapeOffsetUnpacked &bou : unpackedBlendshapeOffsets) {
+            bou.clear();
+        }
 
         // for each blendshape in this mesh, accumulate the offsets into unpackedBlendshapeOffsets.
         const float NORMAL_COEFFICIENT_SCALE = 0.01f;

--- a/libraries/shared/src/AACube.h
+++ b/libraries/shared/src/AACube.h
@@ -20,6 +20,7 @@
 #include <QDebug>
 
 #include "BoxBase.h"
+#include "SerDes.h"
 
 class AABox;
 class Extents;
@@ -80,6 +81,10 @@ private:
 
     glm::vec3 _corner;
     float _scale;
+
+    friend DataSerializer& operator<<(DataSerializer &ser, const AACube &cube);
+    friend DataDeserializer& operator>>(DataDeserializer &des, AACube &cube);
+
 };
 
 inline bool operator==(const AACube& a, const AACube& b) {
@@ -99,5 +104,16 @@ inline QDebug operator<<(QDebug debug, const AACube& cube) {
     return debug;
 }
 
+inline DataSerializer& operator<<(DataSerializer &ser, const AACube &cube) {
+    ser << cube._corner;
+    ser << cube._scale;
+    return ser;
+}
+
+inline DataDeserializer& operator>>(DataDeserializer &des, AACube &cube) {
+    des >> cube._corner;
+    des >> cube._scale;
+    return des;
+}
 
 #endif // hifi_AACube_h

--- a/libraries/shared/src/BlendshapeConstants.h
+++ b/libraries/shared/src/BlendshapeConstants.h
@@ -122,6 +122,25 @@ struct BlendshapeOffsetUnpacked {
     float positionOffsetX, positionOffsetY, positionOffsetZ;
     float normalOffsetX, normalOffsetY, normalOffsetZ;
     float tangentOffsetX, tangentOffsetY, tangentOffsetZ;
+
+    /**
+     * @brief Set all components of all the offsets to zero
+     *
+     * @note glm::vec3 is not trivially copyable, so it's not correct to clear it with memset.
+     */
+    void clear() {
+        positionOffsetX = 0.0f;
+        positionOffsetY = 0.0f;
+        positionOffsetZ = 0.0f;
+
+        normalOffsetX = 0.0f;
+        normalOffsetY = 0.0f;
+        normalOffsetZ = 0.0f;
+
+        tangentOffsetX = 0.0f;
+        tangentOffsetY = 0.0f;
+        tangentOffsetZ = 0.0f;
+    }
 };
 
 using BlendshapeOffset = BlendshapeOffsetPacked;

--- a/libraries/shared/src/SerDes.cpp
+++ b/libraries/shared/src/SerDes.cpp
@@ -3,7 +3,7 @@
 //
 //
 //  Created by Dale Glass on 5/6/2022
-//  Copyright 2022 Dale Glass
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SerDes.cpp
+++ b/libraries/shared/src/SerDes.cpp
@@ -12,10 +12,10 @@
 #include <cctype>
 
 #include "SerDes.h"
-const int  SerDes::DEFAULT_SIZE;
-const char SerDes::PADDING_CHAR;
+const int  DataSerializer::DEFAULT_SIZE;
+const char DataSerializer::PADDING_CHAR;
 
-QDebug operator<<(QDebug debug, const SerDes &ds) {
+QDebug operator<<(QDebug debug, const DataSerializer &ds) {
     debug << "{ capacity =" << ds.capacity() << "; length = " << ds.length() << "; pos = " << ds.pos() << "}";
     debug << "\n";
 
@@ -54,7 +54,7 @@ QDebug operator<<(QDebug debug, const SerDes &ds) {
 }
 
 
-void SerDes::changeAllocation(size_t new_size) {
+void DataSerializer::changeAllocation(size_t new_size) {
     while ( _capacity < new_size) {
         _capacity *= 2;
     }

--- a/libraries/shared/src/SerDes.cpp
+++ b/libraries/shared/src/SerDes.cpp
@@ -17,7 +17,7 @@ const char DataSerializer::PADDING_CHAR;
 
 
 static void dumpHex(QDebug &debug, const char*buf, size_t len) {
-  QString literal;
+    QString literal;
     QString hex;
 
     for(size_t i=0;i<len;i++) {

--- a/libraries/shared/src/SerDes.cpp
+++ b/libraries/shared/src/SerDes.cpp
@@ -1,0 +1,70 @@
+//
+//  SerDes.h
+//
+//
+//  Created by Dale Glass on 5/6/2022
+//  Copyright 2022 Dale Glass
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include <cctype>
+
+#include "SerDes.h"
+const int  SerDes::DEFAULT_SIZE;
+const char SerDes::PADDING_CHAR;
+
+QDebug operator<<(QDebug debug, const SerDes &ds) {
+    debug << "{ capacity =" << ds.capacity() << "; length = " << ds.length() << "; pos = " << ds.pos() << "}";
+    debug << "\n";
+
+    QString literal;
+    QString hex;
+
+    for(size_t i=0;i<ds.length();i++) {
+        char c = ds._store[i];
+
+        if (std::isalnum(c)) {
+            literal.append(c);
+        } else {
+            literal.append(".");
+        }
+
+        QString hnum = QString::number( static_cast<unsigned char>(c), 16 );
+        if ( hnum.length() == 1 ) {
+            hnum.prepend("0");
+        }
+
+        hex.append(hnum  + " ");
+
+        if ( literal.length() == 16 || (i+1 == ds.length()) ) {
+            while( literal.length() < 16 ) {
+                literal.append(" ");
+                hex.append("   ");
+            }
+
+            debug << literal << "  " << hex << "\n";
+            literal.clear();
+            hex.clear();
+        }
+    }
+
+    return debug;
+}
+
+
+void SerDes::changeAllocation(size_t new_size) {
+    while ( _capacity < new_size) {
+        _capacity *= 2;
+    }
+
+    char *new_buf = new char[_capacity];
+    assert( *new_buf );
+
+    memcpy(new_buf, _store, _length);
+    char *prev_buf = _store;
+    _store = new_buf;
+
+    delete []prev_buf;
+}

--- a/libraries/shared/src/SerDes.cpp
+++ b/libraries/shared/src/SerDes.cpp
@@ -15,15 +15,13 @@
 const int  DataSerializer::DEFAULT_SIZE;
 const char DataSerializer::PADDING_CHAR;
 
-QDebug operator<<(QDebug debug, const DataSerializer &ds) {
-    debug << "{ capacity =" << ds.capacity() << "; length = " << ds.length() << "; pos = " << ds.pos() << "}";
-    debug << "\n";
 
-    QString literal;
+static void dumpHex(QDebug &debug, const char*buf, size_t len) {
+  QString literal;
     QString hex;
 
-    for(size_t i=0;i<ds.length();i++) {
-        char c = ds._store[i];
+    for(size_t i=0;i<len;i++) {
+        char c = buf[i];
 
         if (std::isalnum(c)) {
             literal.append(c);
@@ -38,7 +36,7 @@ QDebug operator<<(QDebug debug, const DataSerializer &ds) {
 
         hex.append(hnum  + " ");
 
-        if ( literal.length() == 16 || (i+1 == ds.length()) ) {
+        if ( literal.length() == 16 || (i+1 == len) ) {
             while( literal.length() < 16 ) {
                 literal.append(" ");
                 hex.append("   ");
@@ -49,7 +47,24 @@ QDebug operator<<(QDebug debug, const DataSerializer &ds) {
             hex.clear();
         }
     }
+}
 
+
+QDebug operator<<(QDebug debug, const DataSerializer &ser) {
+    debug << "{ capacity =" << ser.capacity() << "; length = " << ser.length() << "; pos = " << ser.pos() << "}";
+    debug << "\n";
+
+    dumpHex(debug, ser.buffer(), ser.length());
+    return debug;
+}
+
+
+QDebug operator<<(QDebug debug, const DataDeserializer &des) {
+    debug << "{ length = " << des.length() << "; pos = " << des.pos() << "}";
+    debug << "\n";
+
+
+    dumpHex(debug, des.buffer(), des.length());
     return debug;
 }
 

--- a/libraries/shared/src/SerDes.h
+++ b/libraries/shared/src/SerDes.h
@@ -3,7 +3,7 @@
 //
 //
 //  Created by Dale Glass on 5/6/2022
-//  Copyright 2022 Dale Glass
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SerDes.h
+++ b/libraries/shared/src/SerDes.h
@@ -105,7 +105,7 @@ class DataSerializer {
          *
          * Since this is mostly intended to be used for networking, we default to the largest probable MTU here.
          */
-        static const int  DEFAULT_SIZE = 1500;
+        static const int DEFAULT_SIZE = 1500;
 
         /**
          * @brief Character to use for padding.
@@ -113,7 +113,7 @@ class DataSerializer {
          * Padding should be ignored, so it doesn't matter what we go with here, but it can be useful to set it
          * to something that would be distinctive in a dump.
          */
-        static const char PADDING_CHAR = 0xAA;
+        static const char PADDING_CHAR = (char)0xAA;
 
         /**
          * @brief Construct a dynamically allocated serializer

--- a/libraries/shared/src/SerDes.h
+++ b/libraries/shared/src/SerDes.h
@@ -1,0 +1,382 @@
+//
+//  SerDes.h
+//
+//
+//  Created by Dale Glass on 5/6/2022
+//  Copyright 2022 Dale Glass
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#pragma once
+#include <string>
+#include <cstring>
+#include <QtCore/QByteArray>
+#include <QDebug>
+#include <glm/glm.hpp>
+
+/**
+ * @brief Data serializer/deserializer
+ *
+ * When encoding, this class takes in data and encodes it into a buffer. No attempt is made to store version numbers, lengths,
+ * or any other metadata. It's entirely up to the user to use the class in such a way that the process can be
+ * correctly reversed if variable-length or optional fields are used.
+ *
+ * It can operate both on an internal, dynamically-allocated buffer, or an externally provided, fixed-size one.
+ *
+ * If an external store is used, the class will refuse to add data once capacity is reached and set the overflow flag.
+ *
+ * When decoding, this class operates on a fixed size buffer. If an attempt to read past the end is made, the read fails,
+ * and the overflow flag is set.
+ *
+ * The class was written for the maximum simplicity possible and inline friendliness.
+ */
+class SerDes {
+    public:
+        // This class is aimed at network serialization, so we assume we're going to deal
+        // with something MTU-sized by default.
+        static const int  DEFAULT_SIZE = 1500;
+        static const char PADDING_CHAR = 0xAA;
+
+        /**
+         * @brief Construct a dynamically allocated serializer
+         *
+         * If constructed this way, an internal buffer will be dynamically allocated and grown as needed.
+         *
+         * The default buffer size is 1500 bytes, based on the assumption that it will be used to construct
+         * network packets.
+         */
+        SerDes() {
+            _capacity = DEFAULT_SIZE;
+            _pos = 0;
+            _length = 0;
+            _store = new char[_capacity];
+        }
+
+        /**
+         * @brief Construct a statically allocated serializer
+         *
+         * If constructed this way, the external buffer will be used to store data. The class will refuse to
+         * keep adding data if the maximum length is reached, and set the overflow flag.
+         *
+         * The flag can be read with isOverflow()
+         *
+         * @param externalStore External data store
+         * @param storeLength Length of the data store
+         */
+        SerDes(char *externalStore, size_t storeLength) {
+            _capacity = storeLength;
+            _length = storeLength;
+            _pos = 0;
+            _storeIsExternal = true;
+            _store = externalStore;
+        }
+
+        SerDes(uint8_t *externalStore, size_t storeLength) : SerDes((char*)externalStore, storeLength) {
+
+        }
+
+        SerDes(const SerDes &) = delete;
+        SerDes &operator=(const SerDes &) = delete;
+
+
+
+        ~SerDes() {
+            if (!_storeIsExternal) {
+                delete[] _store;
+            }
+        }
+
+        void addPadding(size_t bytes) {
+            if (!extendBy(bytes)) {
+                return;
+            }
+
+            // Fill padding with something recognizable. Will keep valgrind happier.
+            memset(&_store[_pos], PADDING_CHAR, bytes);
+            _pos += bytes;
+        }
+
+        SerDes &operator<<(uint8_t c) {
+            return *this << int8_t(c);
+        }
+
+        SerDes &operator<<(int8_t c) {
+            if (!extendBy(1)) {
+                return *this;
+            }
+
+            _store[_pos++] = c;
+            return *this;
+        }
+
+        SerDes &operator>>(uint8_t &c) {
+            return *this >> reinterpret_cast<int8_t&>(c);
+        }
+
+        SerDes &operator>>(int8_t &c) {
+            if ( _pos < _length ) {
+                c = _store[_pos++];
+            } else {
+                _overflow = true;
+                qCritical() << "Deserializer trying to read past end of input, reading 8 bits from position " << _pos << ", length " << _length;
+            }
+
+            return *this;
+        }
+
+        ///////////////////////////////////////////////////////////
+
+        SerDes &operator<<(uint16_t val) {
+            return *this << int16_t(val);
+        }
+
+        SerDes &operator<<(int16_t val) {
+            if (!extendBy(sizeof(val))) {
+                return *this;
+            }
+
+            memcpy(&_store[_pos], (char*)&val, sizeof(val));
+            _pos += sizeof(val);
+            return *this;
+        }
+
+        SerDes &operator>>(uint16_t &val) {
+            return *this >> reinterpret_cast<int16_t&>(val);
+        }
+
+        SerDes &operator>>(int16_t &val) {
+            if ( _pos + sizeof(val) <= _length ) {
+                memcpy((char*)&val, &_store[_pos], sizeof(val));
+                _pos += sizeof(val);
+            } else {
+                _overflow = true;
+                qCritical() << "Deserializer trying to read past end of input, reading 16 bits from position " << _pos << ", length " << _length;
+            }
+
+            return *this;
+        }
+
+        ///////////////////////////////////////////////////////////
+
+        SerDes &operator<<(uint32_t val) {
+            return *this << int32_t(val);
+        }
+
+        SerDes &operator<<(int32_t val) {
+            if (!extendBy(sizeof(val))) {
+                return *this;
+            }
+
+            memcpy(&_store[_pos], (char*)&val, sizeof(val));
+            _pos += sizeof(val);
+            return *this;
+        }
+
+        SerDes &operator>>(uint32_t &val) {
+            return *this >> reinterpret_cast<int32_t&>(val);
+        }
+
+        SerDes &operator>>(int32_t &val) {
+            if ( _pos + sizeof(val) <= _length ) {
+                memcpy((char*)&val, &_store[_pos], sizeof(val));
+                _pos += sizeof(val);
+            } else {
+                _overflow = true;
+                qCritical() << "Deserializer trying to read past end of input, reading 32 bits from position " << _pos << ", length " << _length;
+            }
+            return *this;
+        }
+
+
+        ///////////////////////////////////////////////////////////
+
+        SerDes &operator<<(glm::vec3 val) {
+            size_t sz = sizeof(val.x);
+            if (!extendBy(sz*3)) {
+                return *this;
+            }
+
+            memcpy(&_store[_pos       ], (char*)&val.x, sz);
+            memcpy(&_store[_pos + sz  ], (char*)&val.y, sz);
+            memcpy(&_store[_pos + sz*2], (char*)&val.z, sz);
+
+            _pos += sz*3;
+            return *this;
+        }
+
+        SerDes &operator>>(glm::vec3 &val) {
+            size_t sz = sizeof(val.x);
+
+            if ( _pos + sz*3 <= _length ) {
+                memcpy((char*)&val.x, &_store[_pos       ], sz);
+                memcpy((char*)&val.y, &_store[_pos + sz  ], sz);
+                memcpy((char*)&val.z, &_store[_pos + sz*2], sz);
+
+                _pos += sz*3;
+            } else {
+                _overflow = true;
+                qCritical() << "Deserializer trying to read past end of input, reading glm::vec3 from position " << _pos << ", length " << _length;
+            }
+            return *this;
+        }
+
+        ///////////////////////////////////////////////////////////
+
+        SerDes &operator<<(glm::vec4 val) {
+            size_t sz = sizeof(val.x);
+            if (!extendBy(sz*4)) {
+                return *this;
+            }
+
+            memcpy(&_store[_pos       ], (char*)&val.x, sz);
+            memcpy(&_store[_pos + sz  ], (char*)&val.y, sz);
+            memcpy(&_store[_pos + sz*2], (char*)&val.z, sz);
+            memcpy(&_store[_pos + sz*3], (char*)&val.w, sz);
+
+            _pos += sz*3;
+            return *this;
+        }
+
+        SerDes &operator>>(glm::vec4 &val) {
+            size_t sz = sizeof(val.x);
+
+            if ( _pos + sz*4 <= _length ) {
+                memcpy((char*)&val.x, &_store[_pos       ], sz);
+                memcpy((char*)&val.y, &_store[_pos + sz  ], sz);
+                memcpy((char*)&val.z, &_store[_pos + sz*2], sz);
+                memcpy((char*)&val.w, &_store[_pos + sz*3], sz);
+
+                _pos += sz*3;
+            } else {
+                _overflow = true;
+                qCritical() << "Deserializer trying to read past end of input, reading glm::vec3 from position " << _pos << ", length " << _length;
+            }
+            return *this;
+        }
+
+        ///////////////////////////////////////////////////////////
+
+        SerDes &operator<<(glm::ivec2 val) {
+            size_t sz = sizeof(val.x);
+            if (!extendBy(sz*2)) {
+                return *this;
+            }
+
+            memcpy(&_store[_pos       ], (char*)&val.x, sz);
+            memcpy(&_store[_pos + sz  ], (char*)&val.y, sz);
+
+            _pos += sz*2;
+            return *this;
+        }
+
+        SerDes &operator>>(glm::ivec2 &val) {
+            size_t sz = sizeof(val.x);
+
+            if ( _pos + sz*2 <= _length ) {
+                memcpy((char*)&val.x, &_store[_pos       ], sz);
+                memcpy((char*)&val.y, &_store[_pos + sz  ], sz);
+
+                _pos += sz*2;
+            } else {
+                _overflow = true;
+                qCritical() << "Deserializer trying to read past end of input, reading glm::ivec2 from position " << _pos << ", length " << _length;
+            }
+            return *this;
+        }
+        ///////////////////////////////////////////////////////////
+
+        SerDes &operator<<(const char *val) {
+            size_t len = strlen(val)+1;
+            extendBy(len);
+            memcpy(&_store[_pos], val, len);
+            _pos += len;
+            return *this;
+        }
+
+        SerDes &operator<<(const QString &val) {
+            return *this << val.toUtf8().constData();
+        }
+
+
+        ///////////////////////////////////////////////////////////
+
+        /**
+         * @brief Current position in the buffer. Starts at 0.
+         *
+         * @return size_t
+         */
+        size_t pos() const { return _pos; }
+
+        /**
+         * @brief Last position that was written to in the buffer. Starts at 0.
+         *
+         * @return size_t
+         */
+        size_t length() const { return _length; }
+
+        /**
+         * @brief Current capacity of the buffer.
+         *
+         * If the buffer is dynamically allocated, it can grow.
+         *
+         * If the buffer is static, this is a fixed limit.
+         *
+         * @return size_t
+         */
+        size_t capacity() const { return _capacity; }
+
+        /**
+         * @brief Whether there's any data in the buffer
+         *
+         * @return true Something has been written
+         * @return false The buffer is empty
+         */
+        bool isEmpty() const { return _length == 0; }
+
+        /**
+         * @brief The buffer size limit has been reached
+         *
+         * This can only return true for a statically allocated buffer.
+         *
+         * @return true Limit reached
+         * @return false There is still room
+         */
+        bool isOverflow() const { return _overflow; }
+
+        /**
+         * @brief Reset the serializer to the start, clear overflow bit.
+         *
+         */
+        void rewind() { _pos = 0; _overflow = false; }
+
+        friend QDebug operator<<(QDebug debug, const SerDes &ds);
+
+    private:
+        bool extendBy(size_t bytes) {
+            //qDebug() << "Extend by" << bytes;
+
+            if ( _capacity < _length + bytes) {
+                if ( _storeIsExternal ) {
+                    _overflow = true;
+                    return false;
+                }
+
+                changeAllocation(_length + bytes);
+            }
+
+            _length += bytes;
+            return true;
+        }
+
+        // This is split up here to try to make the class as inline-friendly as possible.
+        void changeAllocation(size_t new_size);
+
+        char *_store;
+        bool _storeIsExternal = false;
+        bool _overflow = false;
+        size_t _capacity = 0;
+        size_t _length = 0;
+        size_t _pos = 0;
+};

--- a/libraries/shared/src/SerDes.h
+++ b/libraries/shared/src/SerDes.h
@@ -345,6 +345,42 @@ class SerDes {
         ///////////////////////////////////////////////////////////
 
         /**
+         * @brief Add an float to the output
+         *
+         * @param val  Value to add
+         * @return SerDes& This object
+         */
+        SerDes &operator<<(float val) {
+            if (!extendBy(sizeof(val))) {
+                return *this;
+            }
+
+            memcpy(&_store[_pos], (char*)&val, sizeof(val));
+            _pos += sizeof(val);
+            return *this;
+        }
+
+        /**
+         * @brief Read an float from the buffer
+         *
+         * @param val Value to read
+         * @return SerDes& This object
+         */
+        SerDes &operator>>(float &val) {
+            if ( _pos + sizeof(val) <= _length ) {
+                memcpy((char*)&val, &_store[_pos], sizeof(val));
+                _pos += sizeof(val);
+            } else {
+                _overflow = true;
+                qCritical() << "Deserializer trying to read past end of input, reading float from position " << _pos << ", length " << _length;
+            }
+            return *this;
+        }
+
+        ///////////////////////////////////////////////////////////
+
+
+        /**
          * @brief Add an glm::vec3 to the output
          *
          * @param val  Value to add

--- a/libraries/shared/src/SerDes.h
+++ b/libraries/shared/src/SerDes.h
@@ -103,7 +103,7 @@ class DataSerializer {
          */
         DataSerializer(char *externalStore, size_t storeLength) {
             _capacity = storeLength;
-            _length = storeLength;
+            _length = 0;
             _pos = 0;
             _storeIsExternal = true;
             _store = externalStore;
@@ -430,7 +430,7 @@ class DataSerializer {
 
             if ( _capacity < _length + bytes) {
                 if ( _storeIsExternal ) {
-                    qCritical() << "Serializer trying to write past end of input, writing" << bytes << "bytes for" << type_name << " from position " << _pos << ", length " << _length;
+                    qCritical() << "Serializer trying to write past end of output buffer, writing" << bytes << "bytes for" << type_name << " from position " << _pos << ", length " << _length;
                     _overflow = true;
                     return false;
                 }

--- a/libraries/shared/src/SerDes.h
+++ b/libraries/shared/src/SerDes.h
@@ -235,7 +235,7 @@ class SerDes {
             memcpy(&_store[_pos + sz*2], (char*)&val.z, sz);
             memcpy(&_store[_pos + sz*3], (char*)&val.w, sz);
 
-            _pos += sz*3;
+            _pos += sz*4;
             return *this;
         }
 
@@ -248,7 +248,7 @@ class SerDes {
                 memcpy((char*)&val.z, &_store[_pos + sz*2], sz);
                 memcpy((char*)&val.w, &_store[_pos + sz*3], sz);
 
-                _pos += sz*3;
+                _pos += sz*4;
             } else {
                 _overflow = true;
                 qCritical() << "Deserializer trying to read past end of input, reading glm::vec3 from position " << _pos << ", length " << _length;

--- a/tests/ktx/src/KtxTests.cpp
+++ b/tests/ktx/src/KtxTests.cpp
@@ -16,7 +16,9 @@
 #include <gpu/Texture.h>
 #include <image/Image.h>
 #include <image/TextureProcessing.h>
-
+#include "SerDes.h"
+#include "KTX.h"
+#include "Texture_ktx.cpp"
 
 QTEST_GUILESS_MAIN(KtxTests)
 
@@ -30,6 +32,19 @@ QString getRootPath() {
     });
     return result;
 }
+
+#if 0
+ktx::Byte* serializeSPH(ktx::Byte* data, const gpu::IrradianceKTXPayload &payload) const {
+    *(ktx::IrradianceKTXPayload::Version*)data = IrradianceKTXPayload::CURRENT_VERSION;
+    data += sizeof(ktx::IrradianceKTXPayload::Version);
+
+    memcpy(data, &payload._irradianceSH, sizeof(ktx::SphericalHarmonics));
+    data += sizeof(SphericalHarmonics);
+
+    return data + PADDING;
+}
+#endif
+
 
 void KtxTests::initTestCase() {
 }
@@ -146,6 +161,14 @@ void KtxTests::testKtxSerialization() {
     }
     testTexture->setKtxBacking(TEST_IMAGE_KTX.fileName().toStdString());
 }
+
+
+void KtxTests::testKtxNewSerializationSphericalHarmonics() {
+    DataSerializer ser;
+
+
+}
+
 
 #if 0
 

--- a/tests/ktx/src/KtxTests.cpp
+++ b/tests/ktx/src/KtxTests.cpp
@@ -17,8 +17,7 @@
 #include <image/Image.h>
 #include <image/TextureProcessing.h>
 #include "SerDes.h"
-#include "KTX.h"
-#include "Texture_ktx.cpp"
+
 
 QTEST_GUILESS_MAIN(KtxTests)
 

--- a/tests/ktx/src/KtxTests.h
+++ b/tests/ktx/src/KtxTests.h
@@ -16,6 +16,7 @@ private slots:
     void testKtxEvalFunctions();
     void testKhronosCompressionFunctions();
     void testKtxSerialization();
+    void testKtxNewSerializationSphericalHarmonics();
 };
 
 

--- a/tests/shared/src/SerializerTests.cpp
+++ b/tests/shared/src/SerializerTests.cpp
@@ -20,14 +20,18 @@ void SerializerTests::initTestCase() {
 }
 
 void SerializerTests::testCreate() {
-    SerDes s;
+    DataSerializer s;
     QCOMPARE(s.length(), 0);
-    QCOMPARE(s.capacity(), SerDes::DEFAULT_SIZE);
+    QCOMPARE(s.capacity(), DataSerializer::DEFAULT_SIZE);
     QCOMPARE(s.isEmpty(), true);
+
+
+    DataDeserializer d(s);
+    QCOMPARE(d.length(), 0);
 }
 
 void SerializerTests::testAdd() {
-    SerDes s;
+    DataSerializer s;
     s << (qint8)1;
     QCOMPARE(s.length(), 1);
     QCOMPARE(s.isEmpty(), false);
@@ -62,7 +66,7 @@ void SerializerTests::testAdd() {
 }
 
 void SerializerTests::testAddAndRead() {
-    SerDes s;
+    DataSerializer s;
     glm::vec3 v3_a{1.f, 3.1415f, 2.71828f};
     glm::vec3 v3_b;
     glm::vec4 v4_a{3.1415f, 2.71828f, 1.4142f, 1.6180f};
@@ -84,17 +88,17 @@ void SerializerTests::testAddAndRead() {
     qint16 i16;
     qint32 i32;
 
-    s.rewind();
+    DataDeserializer d(s);
 
-    s >> i8;
-    s >> i16;
-    s >> i32;
-    s >> v3_b;
-    s >> v4_b;
-    s >> iv2_b;
-    s >> f_b;
+    d >> i8;
+    d >> i16;
+    d >> i32;
+    d >> v3_b;
+    d >> v4_b;
+    d >> iv2_b;
+    d >> f_b;
 
-    qDebug() << s;
+    qDebug() << d;
 
     QCOMPARE(i8, (qint8)1);
     QCOMPARE(i16, (qint16)0xaabb);
@@ -106,22 +110,23 @@ void SerializerTests::testAddAndRead() {
 }
 
 void SerializerTests::testReadPastEnd() {
-    SerDes s;
+    DataSerializer s;
     qint8 i8;
     qint16 i16;
     s << (qint8)1;
-    s.rewind();
-    s >> i8;
-    QCOMPARE(s.pos(), 1);
 
-    s.rewind();
-    s >> i16;
-    QCOMPARE(s.pos(), 0);
+    DataDeserializer d(s);
+    d >> i8;
+    QCOMPARE(d.pos(), 1);
+
+    d.rewind();
+    d >> i16;
+    QCOMPARE(d.pos(), 0);
 }
 
 void SerializerTests::benchmarkEncodingDynamicAlloc() {
     QBENCHMARK {
-        SerDes s;
+        DataSerializer s;
         glm::vec3 v3_a{1.f, 3.1415f, 2.71828f};
         glm::vec3 v3_b;
         glm::vec4 v4_a{3.1415f, 2.71828f, 1.4142f, 1.6180f};
@@ -142,7 +147,7 @@ void SerializerTests::benchmarkEncodingStaticAlloc() {
     char buf[1024];
 
     QBENCHMARK {
-        SerDes s(buf, sizeof(buf));
+        DataSerializer s(buf, sizeof(buf));
         glm::vec3 v3_a{1.f, 3.1415f, 2.71828f};
         glm::vec3 v3_b;
         glm::vec4 v4_a{3.1415f, 2.71828f, 1.4142f, 1.6180f};
@@ -161,7 +166,7 @@ void SerializerTests::benchmarkEncodingStaticAlloc() {
 
 
 void SerializerTests::benchmarkDecoding() {
-    SerDes s;
+    DataSerializer s;
     qint8 q8 = 1;
     qint16 q16 = 0xaabb;
     qint32 q32 = 0xccddeeff;
@@ -182,13 +187,13 @@ void SerializerTests::benchmarkDecoding() {
 
 
     QBENCHMARK {
-        s.rewind();
-        s >> q8;
-        s >> q16;
-        s >> q32;
-        s >> v3_a;
-        s >> v4_a;
-        s >> iv2_a;
+        DataDeserializer d(s);
+        d >> q8;
+        d >> q16;
+        d >> q32;
+        d >> v3_a;
+        d >> v4_a;
+        d >> iv2_a;
     }
 }
 

--- a/tests/shared/src/SerializerTests.cpp
+++ b/tests/shared/src/SerializerTests.cpp
@@ -124,6 +124,35 @@ void SerializerTests::testReadPastEnd() {
     QCOMPARE(d.pos(), 0);
 }
 
+void SerializerTests::testWritePastEnd() {
+    qint8 i8 = 255;
+    qint16 i16 = 65535;
+
+
+    char buf[16];
+
+
+    // 1 byte buffer, we can write 1 byte
+    memset(buf, 0, sizeof(buf));
+    DataSerializer s1(buf, 1);
+    s1 << i8;
+    QCOMPARE(s1.pos(), 1);
+    QCOMPARE(s1.isOverflow(), false);
+    QCOMPARE(buf[0], i8);
+
+    // 1 byte buffer, we can't write 2 bytes
+    memset(buf, 0, sizeof(buf));
+    DataSerializer s2(buf, 1);
+    s2 << i16;
+    QCOMPARE(s2.pos(), 0);
+    QCOMPARE(s2.isOverflow(), true);
+    QCOMPARE(buf[0], 0); // We didn't write
+    QCOMPARE(buf[1], 0);
+}
+
+
+
+
 void SerializerTests::benchmarkEncodingDynamicAlloc() {
     QBENCHMARK {
         DataSerializer s;

--- a/tests/shared/src/SerializerTests.cpp
+++ b/tests/shared/src/SerializerTests.cpp
@@ -111,6 +111,79 @@ void SerializerTests::testReadPastEnd() {
     QCOMPARE(s.pos(), 0);
 }
 
+void SerializerTests::benchmarkEncodingDynamicAlloc() {
+    QBENCHMARK {
+        SerDes s;
+        glm::vec3 v3_a{1.f, 3.1415f, 2.71828f};
+        glm::vec3 v3_b;
+        glm::vec4 v4_a{3.1415f, 2.71828f, 1.4142f, 1.6180f};
+        glm::vec4 v4_b;
+        glm::ivec2 iv2_a{10, 24};
+        glm::ivec2 iv2_b;
+
+        s << (qint8)1;
+        s << (qint16)0xaabb;
+        s << (qint32)0xccddeeff;
+        s << v3_a;
+        s << v4_a;
+        s << iv2_a;
+    }
+}
+
+void SerializerTests::benchmarkEncodingStaticAlloc() {
+    char buf[1024];
+
+    QBENCHMARK {
+        SerDes s(buf, sizeof(buf));
+        glm::vec3 v3_a{1.f, 3.1415f, 2.71828f};
+        glm::vec3 v3_b;
+        glm::vec4 v4_a{3.1415f, 2.71828f, 1.4142f, 1.6180f};
+        glm::vec4 v4_b;
+        glm::ivec2 iv2_a{10, 24};
+        glm::ivec2 iv2_b;
+
+        s << (qint8)1;
+        s << (qint16)0xaabb;
+        s << (qint32)0xccddeeff;
+        s << v3_a;
+        s << v4_a;
+        s << iv2_a;
+    }
+}
+
+
+void SerializerTests::benchmarkDecoding() {
+    SerDes s;
+    qint8 q8 = 1;
+    qint16 q16 = 0xaabb;
+    qint32 q32 = 0xccddeeff;
+
+    glm::vec3 v3_a{1.f, 3.1415f, 2.71828f};
+    glm::vec3 v3_b;
+    glm::vec4 v4_a{3.1415f, 2.71828f, 1.4142f, 1.6180f};
+    glm::vec4 v4_b;
+    glm::ivec2 iv2_a{10, 24};
+    glm::ivec2 iv2_b;
+
+    s << q8;
+    s << q16;
+    s << q32;
+    s << v3_a;
+    s << v4_a;
+    s << iv2_a;
+
+
+    QBENCHMARK {
+        s.rewind();
+        s >> q8;
+        s >> q16;
+        s >> q32;
+        s >> v3_a;
+        s >> v4_a;
+        s >> iv2_a;
+    }
+}
+
 
 void SerializerTests::cleanupTestCase() {
 }

--- a/tests/shared/src/SerializerTests.cpp
+++ b/tests/shared/src/SerializerTests.cpp
@@ -60,13 +60,19 @@ void SerializerTests::testAdd() {
 
 void SerializerTests::testAddAndRead() {
     SerDes s;
-    glm::vec3 v{1.f, 3.1415f, 2.71828f};
-    glm::vec3 v2;
+    glm::vec3 v3_a{1.f, 3.1415f, 2.71828f};
+    glm::vec3 v3_b;
+    glm::vec4 v4_a{3.1415f, 2.71828f, 1.4142f, 1.6180f};
+    glm::vec4 v4_b;
+    glm::ivec2 iv2_a{10, 24};
+    glm::ivec2 iv2_b;
 
     s << (qint8)1;
     s << (qint16)0xaabb;
     s << (qint32)0xccddeeff;
-    s << v;
+    s << v3_a;
+    s << v4_a;
+    s << iv2_a;
 
     qint8 i8;
     qint16 i16;
@@ -77,14 +83,18 @@ void SerializerTests::testAddAndRead() {
     s >> i8;
     s >> i16;
     s >> i32;
-    s >> v2;
+    s >> v3_b;
+    s >> v4_b;
+    s >> iv2_b;
 
     qDebug() << s;
 
     QCOMPARE(i8, (qint8)1);
     QCOMPARE(i16, (qint16)0xaabb);
     QCOMPARE(i32, (qint32)0xccddeeff);
-    QCOMPARE(v, v2);
+    QCOMPARE(v3_a, v3_b);
+    QCOMPARE(v4_a, v4_b);
+    QCOMPARE(iv2_a, iv2_b);
 }
 
 void SerializerTests::testReadPastEnd() {

--- a/tests/shared/src/SerializerTests.cpp
+++ b/tests/shared/src/SerializerTests.cpp
@@ -54,6 +54,9 @@ void SerializerTests::testAdd() {
     s << v;
     QCOMPARE(s.length(), 40);
 
+    s << 1.2345f;
+    QCOMPARE(s.length(), 44);
+
 
     qDebug() << s;
 }
@@ -66,6 +69,8 @@ void SerializerTests::testAddAndRead() {
     glm::vec4 v4_b;
     glm::ivec2 iv2_a{10, 24};
     glm::ivec2 iv2_b;
+    float f_a = 1.2345f;
+    float f_b;
 
     s << (qint8)1;
     s << (qint16)0xaabb;
@@ -73,6 +78,7 @@ void SerializerTests::testAddAndRead() {
     s << v3_a;
     s << v4_a;
     s << iv2_a;
+    s << f_a;
 
     qint8 i8;
     qint16 i16;
@@ -86,6 +92,7 @@ void SerializerTests::testAddAndRead() {
     s >> v3_b;
     s >> v4_b;
     s >> iv2_b;
+    s >> f_b;
 
     qDebug() << s;
 
@@ -95,6 +102,7 @@ void SerializerTests::testAddAndRead() {
     QCOMPARE(v3_a, v3_b);
     QCOMPARE(v4_a, v4_b);
     QCOMPARE(iv2_a, iv2_b);
+    QCOMPARE(f_a, f_b);
 }
 
 void SerializerTests::testReadPastEnd() {

--- a/tests/shared/src/SerializerTests.cpp
+++ b/tests/shared/src/SerializerTests.cpp
@@ -1,0 +1,107 @@
+//
+//  SerializerTests.cpp
+//
+//  Copyright 2022 Dale Glass
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+
+#include "SerializerTests.h"
+#include <SerDes.h>
+#include <QDebug>
+#include <glm/glm.hpp>
+
+QTEST_GUILESS_MAIN(SerializerTests)
+
+
+void SerializerTests::initTestCase() {
+}
+
+void SerializerTests::testCreate() {
+    SerDes s;
+    QCOMPARE(s.length(), 0);
+    QCOMPARE(s.capacity(), SerDes::DEFAULT_SIZE);
+    QCOMPARE(s.isEmpty(), true);
+}
+
+void SerializerTests::testAdd() {
+    SerDes s;
+    s << (qint8)1;
+    QCOMPARE(s.length(), 1);
+    QCOMPARE(s.isEmpty(), false);
+
+    s << (quint8)-1;
+    QCOMPARE(s.length(), 2);
+
+    s << (qint16)0xaabb;
+    QCOMPARE(s.length(), 4);
+
+    s << (quint16)-18000;
+    QCOMPARE(s.length(), 6);
+
+    s << (qint32)0xCCDDEEFF;
+    QCOMPARE(s.length(), 10);
+
+    s << (quint32)-1818000000;
+    QCOMPARE(s.length(), 14);
+
+    s << "Hello, world!";
+    QCOMPARE(s.length(), 28);
+
+    glm::vec3 v{1.f,2.f,3.f};
+    s << v;
+    QCOMPARE(s.length(), 40);
+
+
+    qDebug() << s;
+}
+
+void SerializerTests::testAddAndRead() {
+    SerDes s;
+    glm::vec3 v{1.f, 3.1415f, 2.71828f};
+    glm::vec3 v2;
+
+    s << (qint8)1;
+    s << (qint16)0xaabb;
+    s << (qint32)0xccddeeff;
+    s << v;
+
+    qint8 i8;
+    qint16 i16;
+    qint32 i32;
+
+    s.rewind();
+
+    s >> i8;
+    s >> i16;
+    s >> i32;
+    s >> v2;
+
+    qDebug() << s;
+
+    QCOMPARE(i8, (qint8)1);
+    QCOMPARE(i16, (qint16)0xaabb);
+    QCOMPARE(i32, (qint32)0xccddeeff);
+    QCOMPARE(v, v2);
+}
+
+void SerializerTests::testReadPastEnd() {
+    SerDes s;
+    qint8 i8;
+    qint16 i16;
+    s << (qint8)1;
+    s.rewind();
+    s >> i8;
+    QCOMPARE(s.pos(), 1);
+
+    s.rewind();
+    s >> i16;
+    QCOMPARE(s.pos(), 0);
+}
+
+
+void SerializerTests::cleanupTestCase() {
+}
+

--- a/tests/shared/src/SerializerTests.h
+++ b/tests/shared/src/SerializerTests.h
@@ -21,6 +21,9 @@ private slots:
     void testAdd();
     void testAddAndRead();
     void testReadPastEnd();
+    void benchmarkEncodingDynamicAlloc();
+    void benchmarkEncodingStaticAlloc();
+    void benchmarkDecoding();
     void cleanupTestCase();
 private:
 

--- a/tests/shared/src/SerializerTests.h
+++ b/tests/shared/src/SerializerTests.h
@@ -21,6 +21,7 @@ private slots:
     void testAdd();
     void testAddAndRead();
     void testReadPastEnd();
+    void testWritePastEnd();
     void benchmarkEncodingDynamicAlloc();
     void benchmarkEncodingStaticAlloc();
     void benchmarkDecoding();

--- a/tests/shared/src/SerializerTests.h
+++ b/tests/shared/src/SerializerTests.h
@@ -1,0 +1,29 @@
+//
+//  ResourceTests.h
+//
+//  Copyright 2015 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef overte_SerializerTests_h
+#define overte_SerializerTests_h
+
+#include <QtTest/QtTest>
+#include <QtCore/QTemporaryDir>
+
+class SerializerTests : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase();
+    void testCreate();
+    void testAdd();
+    void testAddAndRead();
+    void testReadPastEnd();
+    void cleanupTestCase();
+private:
+
+};
+
+#endif // overte_SerializerTests_h


### PR DESCRIPTION
This is the last part of the build warnings fix. It deals with the issue of glm classes not being trivially copyable, and therefore not being possible to correctly copy with memcpy.

It also makes the code a bit cleaner, by taking a bunch of fiddly offset-tracking code and moving it into a class.

The code was made with the aim to make it as amenable to inlining as possible.