### PR TITLE
Add log breakpoint system

### DIFF
--- a/libraries/shared/src/Breakpoint.h
+++ b/libraries/shared/src/Breakpoint.h
@@ -1,0 +1,28 @@
+//
+//  Breakpoint.h
+//
+//
+//  Created by Dale Glass on 5/6/2022
+//  Copyright 2022 Dale Glass
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+
+// Software defined breakpoints, for aiding in debugging
+
+#pragma once
+
+#if defined(__GNUC__)
+    #include <csignal>
+    #define BREAKPOINT raise(SIGINT);
+#elif defined(__clang__)
+    #define BREAKPOINT __builtin_trap();
+#elif _MSC_VER && !__INTEL_COMPILER
+    #include <intrin.h>
+    #define BREAKPOINT __debugbreak();
+#else
+    #include "CrashHelpers.h"
+    #define BREAKPOINT crash::nullDeref();
+#endif

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -11,6 +11,7 @@
 //
 
 #include "LogHandler.h"
+#include "Breakpoint.h"
 
 #include <mutex>
 
@@ -216,6 +217,13 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
         _repeatCount++;
     }
 
+    if ( !_breakMessages.empty() ) {
+        for(const auto &str : _breakMessages) {
+            if (logMessage.contains(str)) {
+                BREAKPOINT
+            }
+        }
+    }
     _previousMessage = message;
 #ifdef Q_OS_WIN
     // On windows, this will output log lines into the Visual Studio "output" tab
@@ -261,4 +269,10 @@ void LogHandler::printRepeatedMessage(int messageID, LogMsgType type, const QMes
     }
 
     ++_repeatedMessageRecords[messageID].repeatCount;
+}
+
+
+void LogHandler::breakOnMessage(const char *message) {
+    QMutexLocker lock(&_mutex);
+    LogHandler::getInstance()._breakMessages.append(QString::fromUtf8(message));
 }

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -56,6 +56,24 @@ public:
 
     void setupRepeatedMessageFlusher();
 
+    /**
+     * @brief Break when a message that contains the specified string is logged
+     *
+     * This is a function intended to be invoked from inside a debugger. It should be of help when it's hard to put a breakpoint
+     * on the generating line because it comes from inlined code, or the interesting text is generated at runtime.
+     *
+     * Example usage:
+     *
+     * @code {.cpp}
+     * LogHandler::breakOnMessage("No instance available for");
+     * @endcode
+     *
+     * Then the debugger should be triggered as soon as a message containing that string is logged. Backtracking
+     * through the call stack should lead back to the source.
+     *
+     * @param str Text to match
+     */
+    static void breakOnMessage(const char *str);
 private:
     LogHandler();
     ~LogHandler() = default;
@@ -79,6 +97,8 @@ private:
         QString repeatString;
     };
     std::vector<RepeatedMessageRecord> _repeatedMessageRecords;
+
+    QStringList _breakMessages;
     static QRecursiveMutex _mutex;
 };
 

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -71,6 +71,9 @@ public:
      * Then the debugger should be triggered as soon as a message containing that string is logged. Backtracking
      * through the call stack should lead back to the source.
      *
+     * @note Support for creating a breakpoint in software is compiler and OS specific. If there's no support for
+     * creating a breakpoint on the current compiler/OS, then an abort will be triggered instead.
+     *
      * @param str Text to match
      */
     static void breakOnMessage(const char *str);


### PR DESCRIPTION
This creates a simple system for breaking into a debugger when a given message is logged.

Example of how to use with gdb:

```
gdb interface/interface
...
(gdb) start
...
(gdb) call LogHandler::breakOnMessage("No instance available")
(gdb) cont
```

gdb should then break during initialization, when the `DependencyManager::get(): No instance available for 8NodeList` message is logged (this is in master as of writing)
