### PR TITLE
Show the filename when a texture fails to load

### DIFF
--- a/libraries/image/src/image/TextureProcessing.cpp
+++ b/libraries/image/src/image/TextureProcessing.cpp
@@ -353,7 +353,7 @@ std::pair<gpu::TexturePointer, glm::ivec2> processImage(std::shared_ptr<QIODevic
     // Validate that the image loaded
     if (imageWidth == 0 || imageHeight == 0 || image.getFormat() == Image::Format_Invalid) {
         QString reason(image.getFormat() == Image::Format_Invalid ? "(Invalid Format)" : "(Size is invalid)");
-        qCWarning(imagelogging) << "Failed to load:" << qPrintable(reason);
+        qCWarning(imagelogging) << "Failed to load"  << QString::fromStdString(filename) << ":" << qPrintable(reason);
         return { nullptr, { imageWidth, imageHeight } };
     }
 


### PR DESCRIPTION
Before:

`[06/20 10:38:00] [WARNING] [hifi.image] Failed to load: (Invalid Format)`

after:

`[06/20 23:11:39] [WARNING] [hifi.image] Failed to load "http://oaktown.pl/voidboy_1/voidboy.gltf" : (Invalid Format)`