### PR TITLE
Fix replace avatar url option

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1453,8 +1453,8 @@ Application::Application(
     // If someone specifies both --avatarURL and --replaceAvatarURL,
     // the replaceAvatarURL wins.  So only set the _overrideUrl if this
     // does have a non-empty string.
-    if (parser.isSet("replaceAvatarURL")) {
-        QString replaceURL = parser.value("replaceAvatarURL");
+    if (parser.isSet("replace-avatar-url")) {
+        QString replaceURL = parser.value("replace-avatar-url");
         _avatarOverrideUrl = QUrl::fromUserInput(replaceURL);
         _saveAvatarOverrideUrl = true;
     }


### PR DESCRIPTION
Fixes:


`[WARNING] [default] QCommandLineParser: option not defined: "replaceAvatarURL"`
