### PR TITLE
Make the "Wrote KTX" message a debug one

### DIFF
--- a/libraries/material-networking/src/material-networking/KTXCache.cpp
+++ b/libraries/material-networking/src/material-networking/KTXCache.cpp
@@ -38,7 +38,7 @@ void KTXCache::initialize() {
 
 
 std::unique_ptr<File> KTXCache::createFile(Metadata&& metadata, const std::string& filepath) {
-    qCInfo(file_cache) << "Wrote KTX" << metadata.key.c_str();
+    qCDebug(file_cache) << "Wrote KTX" << metadata.key.c_str();
     return FileCache::createFile(std::move(metadata), filepath);
 }
 


### PR DESCRIPTION
Interface logs a lot of this:

`[INFO] [hifi.file_cache] Wrote KTX 50081c952d5d039b007e3ccaf5057968`

Changed it to debug, since it doesn't seem like particularly useful information and may result in hiding more interesting things happening.