### PR TITLE
Change cmake policy CMP0074 to NEW

### DIFF
--- a/cmake/init.cmake
+++ b/cmake/init.cmake
@@ -11,7 +11,7 @@ if (POLICY CMP0042)
 endif ()
 
 if (POLICY CMP0074)
-  cmake_policy(SET CMP0074 OLD)
+  cmake_policy(SET CMP0074 NEW)
 endif ()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/policy/CMP0074.html

CMake says the old behavior is deprecated and will be removed. Everything seems to build OK with this setting so far.