### PR TITLE
Change --ignore-gpu-blacklist to --ignore-gpu-blocklist

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, const char* argv[]) {
     auto format = getDefaultOpenGLSurfaceFormat();
     // Deal with some weirdness in the chromium context sharing on Mac.
     // The primary share context needs to be 3.2, so that the Chromium will
-    // succeed in it's creation of it's command stub contexts.  
+    // succeed in it's creation of it's command stub contexts.
     format.setVersion(3, 2);
     // This appears to resolve the issues with corrupted fonts on OSX.  No
     // idea why.
@@ -54,8 +54,8 @@ int main(int argc, const char* argv[]) {
     QSurfaceFormat::setDefaultFormat(format);
 #endif
 
-#if defined(Q_OS_WIN) 
-    // Check the minimum version of 
+#if defined(Q_OS_WIN)
+    // Check the minimum version of
     if (gl::getAvailableVersion() < gl::getRequiredVersion()) {
         MessageBoxA(nullptr, "Interface requires OpenGL 4.1 or higher", "Unsupported", MB_OK);
         return -1;
@@ -356,7 +356,7 @@ int main(int argc, const char* argv[]) {
         }
     }
 
-    // Early check for --traceFile argument 
+    // Early check for --traceFile argument
     auto tracer = DependencyManager::set<tracing::Tracer>();
     const char * traceFile = nullptr;
     float traceDuration = 0.0f;
@@ -370,7 +370,7 @@ int main(int argc, const char* argv[]) {
             return 1;
         }
     }
-   
+
     PROFILE_SYNC_BEGIN(startup, "main startup", "");
 
 #ifdef Q_OS_LINUX
@@ -378,8 +378,8 @@ int main(int argc, const char* argv[]) {
 #endif
 
 #if defined(USE_GLES) && defined(Q_OS_WIN)
-    // When using GLES on Windows, we can't create normal GL context in Qt, so 
-    // we force Qt to use angle.  This will cause the QML to be unable to be used 
+    // When using GLES on Windows, we can't create normal GL context in Qt, so
+    // we force Qt to use angle.  This will cause the QML to be unable to be used
     // in the output window, so QML should be disabled.
     qputenv("QT_ANGLE_PLATFORM", "d3d11");
     QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
@@ -550,7 +550,7 @@ int main(int argc, const char* argv[]) {
 
         // Extend argv to enable WebGL rendering
         std::vector<const char*> argvExtended(&argv[0], &argv[argc]);
-        argvExtended.push_back("--ignore-gpu-blacklist");
+        argvExtended.push_back("--ignore-gpu-blocklist");
 #ifdef Q_OS_ANDROID
         argvExtended.push_back("--suppress-settings-reset");
 #endif


### PR DESCRIPTION
The old option name was deprecated by Chromium. Fixes:

`[525529:525529:0622/194252.987422:ERROR:service_utils.cc(157)] --ignore-gpu-blacklist is deprecated and will be removed in 2020Q4, use --ignore-gpu-blocklist instead.`

The above message isn't part of the normal log, but something Chromium outputs on its own.