### PR TITLE
Implement Journald logging

### DIFF
--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -107,6 +107,9 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     const QCommandLineOption parentPIDOption(PARENT_PID_OPTION, "PID of the parent process", "parent-pid");
     parser.addOption(parentPIDOption);
 
+    const QCommandLineOption logOption("logOptions", "Logging options, comma separated: color,nocolor,process_id,thread_id,milliseconds,keep_repeats,journald,nojournald", "options");
+    parser.addOption(logOption);
+
     if (!parser.parse(QCoreApplication::arguments())) {
         std::cout << parser.errorText().toStdString() << std::endl; // Avoid Qt log spam
         parser.showHelp();
@@ -121,6 +124,15 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     if (parser.isSet(helpOption)) {
         parser.showHelp();
         Q_UNREACHABLE();
+    }
+
+    // We want to configure the logging system as early as possible
+    auto &logHandler = LogHandler::getInstance();
+    if (parser.isSet(logOption)) {
+        if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+            parser.showHelp();
+            Q_UNREACHABLE();
+        }
     }
 
     const QVariantMap argumentVariantMap = HifiConfigVariantMap::mergeCLParametersWithJSONConfig(arguments());

--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -130,6 +130,7 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     auto &logHandler = LogHandler::getInstance();
     if (parser.isSet(logOption)) {
         if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+            QCoreApplication mockApp(argc, const_cast<char**>(argv)); // required for call to showHelp()
             parser.showHelp();
             Q_UNREACHABLE();
         }

--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -129,7 +129,7 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     // We want to configure the logging system as early as possible
     auto &logHandler = LogHandler::getInstance();
     if (parser.isSet(logOption)) {
-        if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+        if (!logHandler.parseOptions(parser.value(logOption).toUtf8(), logOption.names().first())) {
             QCoreApplication mockApp(argc, const_cast<char**>(argv)); // required for call to showHelp()
             parser.showHelp();
             Q_UNREACHABLE();

--- a/cmake/modules/FindJournald.cmake
+++ b/cmake/modules/FindJournald.cmake
@@ -1,0 +1,45 @@
+# - Try to find Journald library.
+# Once done this will define
+#
+#  JOURNALD_FOUND - system has Journald
+#  JOURNALD_INCLUDE_DIR - the Journald include directory
+#  JOURNALD_LIBRARIES - Link these to use Journald
+#  JOURNALD_DEFINITIONS - Compiler switches required for using Journald
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+# Copyright (c) 2015 David Edmundson
+#
+
+# use pkg-config to get the directories and then use these values
+# in the FIND_PATH() and FIND_LIBRARY() calls
+find_package(PkgConfig)
+pkg_check_modules(PC_JOURNALD QUIET systemd)
+
+set(JOURNALD_FOUND ${PC_JOURNALD_FOUND})
+set(JOURNALD_DEFINITIONS ${PC_JOURNALD_CFLAGS_OTHER})
+
+find_path(JOURNALD_INCLUDE_DIR NAMES systemd/sd-journal.h
+  PATHS
+  ${PC_JOURNALD_INCLUDEDIR}
+  ${PC_JOURNALD_INCLUDE_DIRS}
+)
+
+find_library(JOURNALD_LIBRARY NAMES systemd
+  PATHS
+  ${PC_JOURNALD_LIBDIR}
+  ${PC_JOURNALD_LIBRARY_DIRS}
+)
+
+set(JOURNALD_LIBRARIES ${JOURNALD_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Journald DEFAULT_MSG JOURNALD_LIBRARY JOURNALD_INCLUDE_DIR)
+
+include(FeatureSummary)
+set_package_properties(Journald PROPERTIES URL https://github.com/systemd
+  DESCRIPTION "Systemd logging daemon")
+
+# show the JOURNALD_INCLUDE_DIR and JOURNALD_LIBRARY variables only in the advanced view
+mark_as_advanced(JOURNALD_INCLUDE_DIR JOURNALD_LIBRARY)

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -414,6 +414,9 @@ void DomainServer::parseCommandLine(int argc, char* argv[]) {
     const QCommandLineOption parentPIDOption(PARENT_PID_OPTION, "PID of the parent process", "parent-pid");
     parser.addOption(parentPIDOption);
 
+    const QCommandLineOption logOption("logOptions", "Logging options, comma separated: color,nocolor,process_id,thread_id,milliseconds,keep_repeats,journald,nojournald", "options");
+    parser.addOption(logOption);
+
 
     QStringList arguments;
     for (int i = 0; i < argc; ++i) {
@@ -434,6 +437,15 @@ void DomainServer::parseCommandLine(int argc, char* argv[]) {
         QCoreApplication mockApp(argc, argv); // required for call to showHelp()
         parser.showHelp();
         Q_UNREACHABLE();
+    }
+
+    // We want to configure the logging system as early as possible
+    auto &logHandler = LogHandler::getInstance();
+    if (parser.isSet(logOption)) {
+        if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+            parser.showHelp();
+            Q_UNREACHABLE();
+        }
     }
 
     if (parser.isSet(iceServerAddressOption)) {

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -443,6 +443,7 @@ void DomainServer::parseCommandLine(int argc, char* argv[]) {
     auto &logHandler = LogHandler::getInstance();
     if (parser.isSet(logOption)) {
         if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+            QCoreApplication mockApp(argc, const_cast<char**>(argv)); // required for call to showHelp()
             parser.showHelp();
             Q_UNREACHABLE();
         }

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -442,7 +442,7 @@ void DomainServer::parseCommandLine(int argc, char* argv[]) {
     // We want to configure the logging system as early as possible
     auto &logHandler = LogHandler::getInstance();
     if (parser.isSet(logOption)) {
-        if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+        if (!logHandler.parseOptions(parser.value(logOption).toUtf8(), logOption.names().first())) {
             QCoreApplication mockApp(argc, const_cast<char**>(argv)); // required for call to showHelp()
             parser.showHelp();
             Q_UNREACHABLE();

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -312,6 +312,7 @@ int main(int argc, const char* argv[]) {
     auto &logHandler = LogHandler::getInstance();
     if (parser.isSet(logOption)) {
         if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+            QCoreApplication mockApp(argc, const_cast<char**>(argv)); // required for call to showHelp()
             parser.showHelp();
             Q_UNREACHABLE();
         }

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -30,8 +30,8 @@
 #include "InterfaceLogging.h"
 #include "UserActivityLogger.h"
 #include "MainWindow.h"
-
 #include "Profile.h"
+#include "LogHandler.h"
 
 #ifdef Q_OS_WIN
 #include <Windows.h>
@@ -45,7 +45,7 @@ int main(int argc, const char* argv[]) {
     auto format = getDefaultOpenGLSurfaceFormat();
     // Deal with some weirdness in the chromium context sharing on Mac.
     // The primary share context needs to be 3.2, so that the Chromium will
-    // succeed in it's creation of it's command stub contexts.  
+    // succeed in it's creation of it's command stub contexts.
     format.setVersion(3, 2);
     // This appears to resolve the issues with corrupted fonts on OSX.  No
     // idea why.
@@ -54,8 +54,8 @@ int main(int argc, const char* argv[]) {
     QSurfaceFormat::setDefaultFormat(format);
 #endif
 
-#if defined(Q_OS_WIN) 
-    // Check the minimum version of 
+#if defined(Q_OS_WIN)
+    // Check the minimum version of
     if (gl::getAvailableVersion() < gl::getRequiredVersion()) {
         MessageBoxA(nullptr, "Interface requires OpenGL 4.1 or higher", "Unsupported", MB_OK);
         return -1;
@@ -63,6 +63,9 @@ int main(int argc, const char* argv[]) {
 #endif
 
     setupHifiApplication(BuildInfo::INTERFACE_NAME);
+
+    // Journald by default in user applications is probably a bit too modern still.
+    LogHandler::getInstance().setShouldUseJournald(false);
 
     QCommandLineParser parser;
     parser.setApplicationDescription("Overte -- A free/libre and open-source metaverse client");
@@ -237,6 +240,11 @@ int main(int argc, const char* argv[]) {
        "fast-heartbeat",
        "Change stats polling interval from 10000ms to 1000ms."
     );
+    QCommandLineOption logOption(
+        "logOptions",
+        "Logging options, comma separated: color,nocolor,process_id,thread_id,milliseconds,keep_repeats,journald,nojournald",
+        "options"
+    );
     // "--qmljsdebugger", which appears in output from "--help-all".
     // Those below don't seem to be optional.
     //     --ignore-gpu-blacklist
@@ -277,6 +285,7 @@ int main(int argc, const char* argv[]) {
     parser.addOption(testResultsLocationOption);
     parser.addOption(quitWhenFinishedOption);
     parser.addOption(fastHeartbeatOption);
+    parser.addOption(logOption);
 
     QString applicationPath;
     // A temporary application instance is needed to get the location of the running executable
@@ -297,6 +306,15 @@ int main(int argc, const char* argv[]) {
 #else
         applicationPath = QCoreApplication::applicationDirPath();
 #endif
+    }
+
+    // We want to configure the logging system as early as possible
+    auto &logHandler = LogHandler::getInstance();
+    if (parser.isSet(logOption)) {
+        if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+            parser.showHelp();
+            Q_UNREACHABLE();
+        }
     }
 
     // Act on arguments for early termination.
@@ -356,7 +374,7 @@ int main(int argc, const char* argv[]) {
         }
     }
 
-    // Early check for --traceFile argument 
+    // Early check for --traceFile argument
     auto tracer = DependencyManager::set<tracing::Tracer>();
     const char * traceFile = nullptr;
     float traceDuration = 0.0f;
@@ -370,7 +388,7 @@ int main(int argc, const char* argv[]) {
             return 1;
         }
     }
-   
+
     PROFILE_SYNC_BEGIN(startup, "main startup", "");
 
 #ifdef Q_OS_LINUX
@@ -378,8 +396,8 @@ int main(int argc, const char* argv[]) {
 #endif
 
 #if defined(USE_GLES) && defined(Q_OS_WIN)
-    // When using GLES on Windows, we can't create normal GL context in Qt, so 
-    // we force Qt to use angle.  This will cause the QML to be unable to be used 
+    // When using GLES on Windows, we can't create normal GL context in Qt, so
+    // we force Qt to use angle.  This will cause the QML to be unable to be used
     // in the output window, so QML should be disabled.
     qputenv("QT_ANGLE_PLATFORM", "d3d11");
     QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -311,7 +311,7 @@ int main(int argc, const char* argv[]) {
     // We want to configure the logging system as early as possible
     auto &logHandler = LogHandler::getInstance();
     if (parser.isSet(logOption)) {
-        if (!logHandler.parseOptions(parser.value(logOption).toUtf8())) {
+        if (!logHandler.parseOptions(parser.value(logOption).toUtf8(), logOption.names().first())) {
             QCoreApplication mockApp(argc, const_cast<char**>(argv)); // required for call to showHelp()
             parser.showHelp();
             Q_UNREACHABLE();

--- a/libraries/shared/CMakeLists.txt
+++ b/libraries/shared/CMakeLists.txt
@@ -21,6 +21,16 @@ if (APPLE)
     target_link_libraries(${TARGET_NAME} ${FRAMEWORK_IOKIT} ${CORE_FOUNDATION} ${OpenGL})
 endif()
 
+if (UNIX AND NOT APPLE)
+    find_package(Journald)
+
+    if (${JOURNALD_FOUND})
+        target_link_libraries(${TARGET_NAME} ${JOURNALD_LIBRARIES})
+        target_include_directories(${TARGET_NAME} PRIVATE ${JOURNALD_INCLUDE_DIR})
+        target_compile_definitions(${TARGET_NAME} PUBLIC HAS_JOURNALD)
+    endif()
+endif()
+
 target_zlib()
 target_nsight()
 target_json()

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -283,17 +283,6 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
             addString(fields, sd_target);
         }
 
-
-/*
-        int retval = sd_journal_send_with_location(sd_file.toUtf8().constData(),
-                                                   sd_line.toUtf8().constData(),
-                                                   context.function == NULL ? "(unknown)" : context.function,
-                                                   "MESSAGE=%s", message.toUtf8().constData(),
-                                                   "PRIORITY=%i", priority,
-                                                   "CATEGORY=%s", context.category,
-                                                   "TID=%i", threadID,
-                                                   NULL);
-*/
         int retval = sd_journal_sendv_with_location(sd_file.constData(),
                                                     sd_line.constData(),
                                                     context.function == NULL ? "(unknown)" : context.function,

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -76,6 +76,8 @@ LogHandler::LogHandler() {
             _shouldDisplayMilliseconds = true;
         } else if (option == "keep_repeats") {
             _keepRepeats = true;
+        } else if (option == "journald") {
+            _useJournald = true;
         } else if (option == "nojournald") {
             _useJournald = false;
         } else if (option != "") {

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -61,7 +61,7 @@ LogHandler::LogHandler() {
     _useJournald = true;
 #endif
 
-    parseOptions(logOptions);
+    parseOptions(logOptions, "VIRCADIA_LOG_OPTIONS");
 }
 
 const char* stringForLogType(LogMsgType msgType) {
@@ -121,7 +121,7 @@ const QString DATE_STRING_FORMAT = "MM/dd hh:mm:ss";
 // the following will produce 11/18 13:55:36.999
 const QString DATE_STRING_FORMAT_WITH_MILLISECONDS = "MM/dd hh:mm:ss.zzz";
 
-bool LogHandler::parseOptions(QString logOptions) {
+bool LogHandler::parseOptions(const QString& logOptions, const QString& paramName) {
     QMutexLocker lock(&_mutex);
     auto optionList = logOptions.split(",");
 
@@ -145,7 +145,7 @@ bool LogHandler::parseOptions(QString logOptions) {
         } else if (option == "nojournald") {
             _useJournald = false;
         } else if (option != "") {
-            fprintf(stdout, "Unrecognized option in VIRCADIA_LOG_OPTIONS: '%s'\n", option.toUtf8().constData());
+            fprintf(stderr, "Unrecognized option in %s: '%s'\n", paramName.toUtf8().constData(), option.toUtf8().constData());
             return false;
         }
     }

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -271,7 +271,7 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
         QByteArray sd_priority = QString("PRIORITY=%1").arg(priority).toUtf8();
         QByteArray sd_category = QString("CATEGORY=%1").arg(context.category).toUtf8();
         QByteArray sd_tid = QString("TID=%1").arg((qlonglong)QThread::currentThreadId()).toUtf8();
-        QByteArray sd_target = QString("TARGET=%1").arg(_targetName).toUtf8();
+        QByteArray sd_target = QString("COMPONENT=%1").arg(_targetName).toUtf8();
 
         std::vector<struct iovec> fields;
         addString(fields, sd_message);

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -31,24 +31,82 @@ enum LogMsgType {
     LogSuppressed = 100
 };
 
-/// Handles custom message handling and sending of stats/logs to Logstash instance
+///
+
+/**
+ * @brief Handles custom message handling and sending of stats/logs to Logstash instance
+ *
+ */
 class LogHandler : public QObject {
     Q_OBJECT
 public:
+    /**
+     * @brief Returns the one instance of the LogHandler object
+     *
+     * @return LogHandler&
+     */
     static LogHandler& getInstance();
 
-    /// sets the target name to output via the verboseMessageHandler, called once before logging begins
-    /// \param targetName the desired target name to output in logs
+    /**
+     * @brief Set the Target Name to output via the verboseMessageHandler
+     *
+     * Called once before logging begins
+     *
+     * @param targetName the desired target name to output in logs
+     */
     void setTargetName(const QString& targetName);
 
+    /**
+     * @brief Set whether to output the process ID
+     *
+     * @note This has no effect when logging with journald, the PID is always logged
+     *
+     * @param shouldOutputProcessID Whether to output the PID
+     */
     void setShouldOutputProcessID(bool shouldOutputProcessID);
+
+    /**
+     * @brief Set whether to output the thread ID
+     *
+     * @param shouldOutputThreadID
+     */
     void setShouldOutputThreadID(bool shouldOutputThreadID);
+
+    /**
+     * @brief Set whether to display timestamps with milliseconds
+     *
+     * @param shouldDisplayMilliseconds
+     */
     void setShouldDisplayMilliseconds(bool shouldDisplayMilliseconds);
+
+    /**
+     * @brief Set whether to use Journald, if it's available
+     *
+     * @param shouldUseJournald Whether to use journald
+     */
+    void setShouldUseJournald(bool shouldUseJournald);
+
+    /**
+     * @brief Whether Journald is available on this version/system.
+     *
+     * Support is available depending on compile options and only on Linux.
+     *
+     * @return true Journald is available
+     * @return false Journald is not available
+     */
+    bool isJournaldAvailable() const;
 
     QString printMessage(LogMsgType type, const QMessageLogContext& context, const QString &message);
 
-    /// a qtMessageHandler that can be hooked up to a target that links to Qt
-    /// prints various process, message type, and time information
+    /**
+     * @brief A qtMessageHandler that can be hooked up to a target that links to Qt
+     *
+     * Prints various process, message type, and time information
+     *
+     * @param type  Log message type
+     * @param context Context of the log message (source file, line, function)
+     * @param message Log message
+     */
     static void verboseMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &message);
 
     int newRepeatedMessageID();
@@ -89,6 +147,7 @@ private:
     bool _shouldDisplayMilliseconds { false };
     bool _useColor { false };
     bool _keepRepeats { false };
+    bool _useJournald { false };
 
     QString _previousMessage;
     int _repeatCount { 0 };

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -48,8 +48,20 @@ public:
     static LogHandler& getInstance();
 
     /**
-     * @brief Set the Target Name to output via the verboseMessageHandler
+     * @brief Parse logging options
      *
+     * This parses the logging settings in the environment variable, or from the commandline
+     *
+     * @param options Option list
+     * @return true Option list was parsed successfully
+     * @return false There was an error
+     */
+    bool parseOptions(QString options);
+
+    /**
+     * @brief Set the name of the component that's producing log output
+     *
+     * For instance, "assignment-client", "audio-mixer", etc.
      * Called once before logging begins
      *
      * @param targetName the desired target name to output in logs
@@ -96,6 +108,16 @@ public:
      */
     bool isJournaldAvailable() const;
 
+    /**
+     * @brief Process a log message
+     *
+     * This writes it to a file, logs it to the console, or sends it to journald.
+     *
+     * @param type  Log message type
+     * @param context Context of the log message (source file, line, function)
+     * @param message Log message
+     * @return QString The log message's text with added severity and timestamp
+     */
     QString printMessage(LogMsgType type, const QMessageLogContext& context, const QString &message);
 
     /**

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -53,10 +53,11 @@ public:
      * This parses the logging settings in the environment variable, or from the commandline
      *
      * @param options Option list
+     * @param paramName Name of the log option, for error reporting.
      * @return true Option list was parsed successfully
      * @return false There was an error
      */
-    bool parseOptions(QString options);
+    bool parseOptions(const QString& options, const QString &paramName);
 
     /**
      * @brief Set the name of the component that's producing log output


### PR DESCRIPTION
This adds logging with journald.

It's only enabled on Linux, and only if the library can be found. It can also be toggled on/off at runtime via the `VIRCADIA_LOG_OPTIONS` variable, or the newly added `--logOptions` parameter.

If support is built in, it defaults to on in the domain server and assignment client and to off on the interface.

The main point of this is that it writes all the fields to journald separately, so that for instance it's possible to easily filter the log by category. It also always logs the filename, line of code and function name where the log was emitted, as well as the thread ID.

A future plan is to add additional metadata fields to the logs.

This also adds a bunch of documentation to the LogHandler class.