### PR TITLE
Disable Android CI builds

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -48,9 +48,10 @@ jobs:
             - os: ubuntu-18.04
               build_type: full
               apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-distro
-            - os: ubuntu-18.04
-              build_type: android
-              apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 python3-github python3-distro
+            # Android builds are currently failing
+            #- os: ubuntu-18.04
+            #  build_type: android
+            #  apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 python3-github python3-distro
             # Do not change the names of self-hosted runners without knowing what you are doing, as they correspond to labels that have to be set on the runner.
             - os: self-hosted_debian-11_aarch64
               build_type: full


### PR DESCRIPTION
This PR disables Android CI builds, as they have been failing for over a year now.
If anyone actually works on Android, they just have to uncomment the lines again.