### PR TITLE
Fixed allowed QML sources to point at our community apps server

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3212,7 +3212,7 @@ void Application::showLoginScreen() {
 #endif
 }
 
-static const QUrl AUTHORIZED_EXTERNAL_QML_SOURCE { "https://cdn.vircadia.com/community-apps/applications" };
+static const QUrl AUTHORIZED_EXTERNAL_QML_SOURCE { "https://more.overte.org/applications" };
 
 void Application::initializeUi() {
 


### PR DESCRIPTION
Trusted QML sources pointed at wrong URL, causing Spectator Camera QML to get blocked.
Already tested on Linux.