### PR TITLE
Fix bug in naming animated screenshots since the change to PNG

### DIFF
--- a/interface/src/ui/SnapshotAnimated.cpp
+++ b/interface/src/ui/SnapshotAnimated.cpp
@@ -45,6 +45,7 @@ void SnapshotAnimated::saveSnapshotAnimated(QString pathStill, float aspectRatio
         SnapshotAnimated::snapshotStillPath = pathStill;
         SnapshotAnimated::snapshotAnimatedPath = pathStill;
         SnapshotAnimated::snapshotAnimatedPath.replace("jpg", "gif");
+        SnapshotAnimated::snapshotAnimatedPath.replace("png", "gif");
 
         // Ensure the snapshot timer is Precise (attempted millisecond precision)
         SnapshotAnimated::snapshotAnimatedTimer->setTimerType(Qt::PreciseTimer);
@@ -148,7 +149,7 @@ void SnapshotAnimated::processFrames() {
     GifEnd(&(SnapshotAnimated::snapshotAnimatedGifWriter));
 
     SnapshotAnimated::clearTempVariables();
-    
+
     // Update the "Share" dialog with the processed GIF.
     emit SnapshotAnimated::snapshotAnimatedDM->processingGifCompleted(SnapshotAnimated::snapshotAnimatedPath);
 }


### PR DESCRIPTION
Trivial fix.

This will be rewritten once the video encoding is working.

Closes #114.