### PR TITLE
Download dependencies from overte.org

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/_env")
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/_env")
 
 # Base URL for externally downloaded files
-set(EXTERNAL_BUILD_ASSETS "https://athena-public.s3.amazonaws.com")
+set(EXTERNAL_BUILD_ASSETS "https://build-deps.overte.org")
 
 if( DEFINED ENV{EXTERNAL_BUILD_ASSETS} )
     set(EXTERNAL_BUILD_ASSETS "$ENV{EXTERNAL_BUILD_ASSETS}")

--- a/tools/qt-builder/README.md
+++ b/tools/qt-builder/README.md
@@ -281,7 +281,7 @@ find . -name \*.prl -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
 ```bash
 tar -Jcvf qt5-install-5.15.2-ubuntu-18.04-amd64.tar.xz qt5-install
 ```
-2.  Upload qt5-install-5.15.2-ubuntu-18.04-amd64.tar.xz to https://athena-public.s3.amazonaws.com/dependencies/vcpkg/
+2.  Upload qt5-install-5.15.2-ubuntu-18.04-amd64.tar.xz to https://build-deps.overte.org/dependencies/vcpkg/
 
 
 


### PR DESCRIPTION
This stops using the old S3 bucket and allows for more flexible hosting

Closes #115 