### PR TITLE
Reenable VCPKG sha512 check

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -119,7 +119,7 @@ endif()
             self.exe = os.path.join(self.path, 'vcpkg')
             self.bootstrapCmds = [ os.path.join(self.path, 'bootstrap-vcpkg.sh'), '-disableMetrics' ]
             self.vcpkgUrl = self.assets_url + '/dependencies/vcpkg/builds/vcpkg-linux-client.tgz%3FversionId=y7mct0gFicEXz5hJy3KROBugcLR56YWf'
-            self.vcpkgHash = '6a1ce47ef6621e699a4627e8821ad32528c82fce62a6939d35b205da2d299aaa405b5f392df4a9e5343dd6a296516e341105fbb2dd8b48864781d129d7fba10d'
+            self.vcpkgHash = '4f5f1b78d5ddb7aeb5b5212f0b77b5d2e8ba11e82518aaf8a777298f8f781948028afc4e4e9fb236c3e510b2d8ba6333deb16119dce1286d90edd006a68e5625'
             self.hostTriplet = 'x64-linux'
 
         if self.args.android:
@@ -207,7 +207,7 @@ endif()
                 hifi_utils.executeSubprocess(self.bootstrapCmds, folder=self.path, env=self.bootstrapEnv)
             else:
                 print("Fetching vcpkg from {} to {}".format(self.vcpkgUrl, self.path))
-                hifi_utils.downloadAndExtract(self.vcpkgUrl, self.path)
+                hifi_utils.downloadAndExtract(self.vcpkgUrl, self.path, self.vcpkgHash)
 
         print("Replacing port files")
         portsPath = os.path.join(self.path, 'ports')

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -101,9 +101,9 @@ endif()
                 self.prebuiltArchive = self.assets_url + "/dependencies/vcpkg/builds/vcpkg-win32.zip%3FversionId=3SF3mDC8dkQH1JP041m88xnYmWNzZflx"
         elif 'Darwin' == system:
             self.exe = os.path.join(self.path, 'vcpkg')
-            self.bootstrapCmds = [ os.path.join(self.path, 'bootstrap-vcpkg.sh'), '--allowAppleClang', '-disableMetrics' ]
-            self.vcpkgUrl = self.assets_url + '/dependencies/vcpkg/builds/vcpkg-osx-client.tgz%3FversionId=j0b4azo_zTlH_Q9DElEWOz1UMYZ2nqQw'
-            self.vcpkgHash = '519d666d02ef22b87c793f016ca412e70f92e1d55953c8f9bd4ee40f6d9f78c1df01a6ee293907718f3bbf24075cc35492fb216326dfc50712a95858e9cbcb4d'
+            self.bootstrapCmds = [ os.path.join(self.path, 'bootstrap-vcpkg.sh'), '-disableMetrics' ]
+            self.vcpkgUrl = self.assets_url + '/dependencies/vcpkg/vcpkg-osx-x86_64-2022.06.16.1.tar.xz'
+            self.vcpkgHash = '277f654b7525a7651eb3a0d426d01f4d1fbe87cfa9c1deebff5c055d5750c7c92b446fdbdbcdca2feaabefdd1778e5214750392f7ce083b2a6a7363c3f09f5a4'
             self.hostTriplet = 'x64-osx'
             # Potential fix for a vcpkg build issue on OSX (see https://github.com/microsoft/vcpkg/issues/9029)
             self.bootstrapEnv['CXXFLAGS'] = '-D_CTERMID_H_'


### PR DESCRIPTION
This PR reenables the VCPKG sha512 check and updates the macOS amd64 vcpkg package.