### PR TITLE
Update GHA to macOS 11

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -36,7 +36,7 @@ jobs:
         include:
           - os: windows-2019
             build_type: full
-          - os: macOS-10.15
+          - os: macOS-11
             build_type: full
           - os: ubuntu-18.04
             build_type: full
@@ -67,7 +67,7 @@ jobs:
           echo "CMAKE_EXTRA=-DVIRCADIA_CPU_ARCHITECTURE=-msse3 -DBUILD_TOOLS:BOOLEAN=FALSE -DHIFI_PYTHON_EXEC:FILEPATH=$(which python3)" >> $GITHUB_ENV
         fi
         # Mac build variables
-        if [ "${{ matrix.os }}" = "macOS-10.15" ]; then
+        if [ "${{ matrix.os }}" = "macOS-11" ]; then
           echo "PYTHON_EXEC=python3" >> $GITHUB_ENV
           echo "ZIP_COMMAND=zip" >> $GITHUB_ENV
           echo "ZIP_ARGS=-r" >> $GITHUB_ENV

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -43,7 +43,7 @@ jobs:
           include:
             - os: windows-2019
               build_type: full
-            - os: macOS-10.15
+            - os: macOS-11
               build_type: full
             - os: ubuntu-18.04
               build_type: full
@@ -102,7 +102,7 @@ jobs:
         fi
 
         # Mac build variables
-        if [ "${{ matrix.os }}" = "macOS-10.15" ]; then
+        if [ "${{ matrix.os }}" = "macOS-11" ]; then
           echo "PYTHON_EXEC=python3" >> $GITHUB_ENV
           echo "INSTALLER_EXT=dmg" >> $GITHUB_ENV
           if [ "${{ matrix.build_type }}" = "full" ]; then
@@ -212,7 +212,7 @@ jobs:
       if: always()
       shell: bash
       run: |
-        if [ "${{ matrix.os }}" == "macOS-10.15" ]; then
+        if [ "${{ matrix.os }}" == "macOS-11" ]; then
           TAR=gtar
         else
           TAR=tar


### PR DESCRIPTION
macOS 10.15 runners are deprecated and GitHub disables them from time to time: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/