### PR TITLE
Change standard automatic networking setting

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -22,7 +22,7 @@
           "name": "automatic_networking",
           "label": "Automatic Networking",
           "help": "This defines how other nodes in the Metaverse will be able to reach your domain-server.<br/>If you don't want to deal with any network settings, use full automatic networking.",
-          "default": "disabled",
+          "default": "full",
           "type": "select",
           "options": [
             {


### PR DESCRIPTION
Setting "None" causes issues when registering a place on the Metaverse server. See https://github.com/overte-org/metaverse-dashboard/issues/4
I would also argue that the standard setting should be the one that has the best chance of actually working.