### PR TITLE
Fix paths for importing images and opening directories

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4168,7 +4168,11 @@ void Application::loadErrorDomain(QUrl domainURL) {
 bool Application::importImage(const QString& urlString) {
     qCDebug(interfaceapp) << "An image file has been dropped in";
     QString filepath(urlString);
+#if defined(Q_OS_WIN)
     filepath.remove("file:///");
+#else
+    filepath.remove("file://");
+#endif
     addAssetToWorld(filepath, "", false, false);
     return true;
 }
@@ -9530,7 +9534,11 @@ void Application::openDirectory(const QString& path) {
     }
 
     QString dirPath = path;
+#if defined(Q_OS_WIN)
     const QString FILE_SCHEME = "file:///";
+#else
+    const QString FILE_SCHEME = "file://";
+#endif
     if (dirPath.startsWith(FILE_SCHEME)) {
         dirPath.remove(0, FILE_SCHEME.length());
     }


### PR DESCRIPTION
Continuation of https://github.com/overte-org/overte/pull/142
Needs to be tested on Windows.

The problem here is actually kind of interesting.
On Linux the root `/` is not part of the `file:///` URL, because they only contain absolute paths anyways and it would be redundant information. Because of this converting a `file:///` URL to a "normal" path requires us to add a `/` in front to tell the system that this is an absolute path.
Windows doesn't need this extra step because removing the `file:///` leaves what Windows will interpret as an absolute path already.