### PR TITLE
Create App: Remove useless code causing: Uncaught ReferenceError: element is not defined

### DIFF
--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -3973,30 +3973,6 @@ function setZonesSelectionData(element, isEditable) {
     displaySelectedZones(element.id, isEditable);
 }
 
-function updateAllZoneSelect() {
-    let allZoneSelects = document.querySelectorAll(".zoneSelectList");
-    let i, j, name, propId, btnList;
-    for (i = 0; i < allZoneSelects.length; i++) {
-        btnList = "";
-        for (j = 0; j < zonesList.length; j++) {
-            if (zonesList[j].name === "") {
-                name = zonesList[j].id;
-            } else {
-                name = zonesList[j].name;
-            }
-            btnList += "<button class='menu-button' onClick='addZoneToZonesSelection(";
-            btnList += '"' + element.id + '"' + ", " + '"' + zonesList[j].id + '"' + ");'>" + name + "</button><br>";            
-        }
-        allZoneSelects[i].innerHTML = btnList;
-        propId = allZoneSelects[i].id.replace("zones-select-", "");
-        if (document.getElementById("multiZoneSelTools-" + propId).style.display === "block") {
-            displaySelectedZones(propId, true);
-        } else {
-            displaySelectedZones(propId, false);
-        }
-    }
-}
-
 /**
  * MATERIAL TARGET FUNCTIONS
  */
@@ -4741,7 +4717,6 @@ function loaded() {
                     }
                 } else if (data.type === 'zoneListRequest') {
                     zonesList = data.zones;
-                    updateAllZoneSelect();
                 }
             });
 


### PR DESCRIPTION
This removes some useless code that never worked for the **Multiple Zone Selector** component used for **renderWithZones**.
It was using an **element** variable that wasn't declared and set, that was causing the failure of the entire function (since probably the implementation)
The function was call to update the selector with any changes in the zone list.
But the selector is already rebuilt anyway at each click on the Add Zone button. 
It could also update the list by displaying a deleted zone as unknown.
But this was overkill, in addition that it has never worked without causing any real issues.

At least now, it will stop to cause error like this:
[DEBUG] [qml] [FlickableWebViewCore.qml] Web Entity JS message: file:///C:/Program%20Files/Overte%20-%20PR146/scripts/system/create/entityProperties/html/js/entityProperties.js 3988 Uncaught ReferenceError: element is not defined

