### PR TITLE
Update GitHub Actions to Ubuntu 20.04

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -232,6 +232,7 @@ jobs:
       run: cat ./_CPack_Packages/win64/NSIS/NSISOutput.log
 
     - name: Upload artifact
+      if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')  # Automatic Linux packaging is not implemented
       shell: bash
       working-directory: ${{runner.workspace}}/build
       env:

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -38,7 +38,7 @@ jobs:
             build_type: full
           - os: macOS-10.15
             build_type: full
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             build_type: full
             apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-github python3-distro
       fail-fast: false

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -322,6 +322,7 @@ jobs:
       run: cat ./_CPack_Packages/win64/NSIS/NSISOutput.log
 
     - name: Upload Artifact
+      if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')  # Automatic Linux packaging is not implemented
       shell: bash
       working-directory: ${{runner.workspace}}/build
       env:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -45,9 +45,9 @@ jobs:
               build_type: full
             - os: macOS-10.15
               build_type: full
-            - os: ubuntu-18.04
+            - os: ubuntu-20.04
               build_type: full
-              apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-distro
+              apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion3 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-distro
             # Android builds are currently failing
             #- os: ubuntu-18.04
             #  build_type: android


### PR DESCRIPTION
GitHub Actions hosted Ubuntu 18.04 runners are being deprecated. 
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
This PR moves us to Ubuntu 20.04.


(I did not actually know this was happening when I added that Ubuntu 20.04 package three days ago)