### PR TITLE
Update NVTT

### DIFF
--- a/cmake/ports/nvtt/CONTROL
+++ b/cmake/ports/nvtt/CONTROL
@@ -1,3 +1,3 @@
 Source: nvtt
-Version: 330c4d56274a0f602a5c70596e2eb670a4ed56c2
+Version: 2.1.3
 Description: Texture processing tools with support for Direct3D 10 and 11 formats.

--- a/cmake/ports/nvtt/portfile.cmake
+++ b/cmake/ports/nvtt/portfile.cmake
@@ -9,9 +9,9 @@ include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO vircadia/nvidia-texture-tools
-    REF d8b7a98aeb177b5eddb76571183bbd2f95d54e6c
-    SHA512 ea15ffd19eb1e14c8ebd62f8d7de3df1ecf6c18a339025f4a0e13419717d510903fc126ec6d1bdfbb5a2f4525a922412b72318bc8dd55dd000481a3924fbfcd4
+    REPO JulianGro/nvidia-texture-tools
+    REF 4c022091ad5dae8964052cadcc506c10e6956442
+    SHA512 dcae327f40e25408fdca73f01bc0555f38b0e9d6bf19adc87532e03365e3b4f6f12a6bcdd7dd27c7af3a5579b9ddd086a5f9c7ee7abd0d0f55c707db8666a780
     HEAD_REF master
 )
 
@@ -20,6 +20,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DBUILD_TESTS=OFF
         -DBUILD_TOOLS=OFF
+        -DUSE_CUDA=FALSE  # Do not use CUDA even if available
 )
 
 vcpkg_install_cmake()
@@ -27,7 +28,7 @@ vcpkg_install_cmake()
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/bin ${CURRENT_PACKAGES_DIR}/debug/bin)
 endif()
-    
+
 vcpkg_copy_pdbs()
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)


### PR DESCRIPTION
This updates us to a proper version of NVTT. I have taken discontinued upstream and done some maintainance work here https://github.com/JulianGro/nvidia-texture-tools
I only tested this on Linux amd64.

Fixes #163 and should allow building on Apple M1 (untested).