### PR TITLE
Fix OBJ-Serializer using wrong decimal separator

### DIFF
--- a/libraries/model-serializers/src/OBJSerializer.cpp
+++ b/libraries/model-serializers/src/OBJSerializer.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Seth Alves on 3/7/15.
 //  Copyright 2013 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -59,7 +60,11 @@ const hifi::ByteArray OBJTokenizer::getLineAsDatum() {
 }
 
 float OBJTokenizer::getFloat() {
-    return std::stof((nextToken() != OBJTokenizer::DATUM_TOKEN) ? nullptr : getDatum().data());
+    std::istringstream ss((nextToken() != OBJTokenizer::DATUM_TOKEN) ? nullptr : getDatum().data());
+    ss.imbue(std::locale::classic());
+    float f;
+    ss >> f;
+    return f;
 }
 
 int OBJTokenizer::nextToken(bool allowSpaceChar /*= false*/) {


### PR DESCRIPTION
This PR fixes the string to float conversion in the OBJ-Serializer for systems using anything other than a period as decimal separator.
Weirdly I have only been encountering the issue on AppImages, not on native builds.
The file I have tested this with is: https://cdn-1.vircadia.com/us-e-1/Bazaar/Worlds/HQ-HiFi/content/Small-Island-v4l/original/Small-Island-v4l-COLL-out.obj

Before:
![95403769-6cd72600-0913-11eb-9229-5bfb2284cf66](https://user-images.githubusercontent.com/11144627/185793807-038fcf62-e9f3-4e05-aa56-77fd4aaf3114.jpg)

After:
![overte-snap-by-JulianGro-on-2022-08-21_15-45-27](https://user-images.githubusercontent.com/11144627/185798207-10c8d79f-5154-448c-8fc9-11e9b3ab55fa.png)


An AppImage for testing is available here: https://data.moto9000.moe/overte_appimages/Overte-x86_64-PR172-538a80c.AppImage
