### PR TITLE
Re-coded to be more stable.

### DIFF
--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -75,9 +75,9 @@
         var hipsPosition = MyAvatar.getJointPosition("Hips");
         var eyesRelativeHeight = eyesPosition.y - hipsPosition.y;
         if (myLeftHand.translation.y > eyesRelativeHeight || myRightHand.translation.y > eyesRelativeHeight) {
+            audioFeedback.action();
             deleteAllExistingNotificationsDisplayed();
             notifications = [];
-            audioFeedback.action();
         }
     }
 

--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -12,6 +12,10 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 
 (function () {
+    Script.include([
+        "create/audioFeedback/audioFeedback.js"
+    ]);
+    
     var NOTIFICATIONS_MESSAGE_CHANNEL = "Hifi-Notifications";
     var SETTING_ACTIVATION_SNAPSHOT_NOTIFICATIONS = "snapshotNotifications";
     var NOTIFICATION_LIFE_DURATION = 10000; //10 seconds (in millisecond) before expiration.
@@ -54,13 +58,26 @@
     function mousePressEvent(event) {
         if (!isOnHMD) {
             var clickedOverlay = Overlays.getOverlayAtPoint({ x: event.x, y: event.y });
-            for (i = 0; i < notifications.length; i += 1) {
+            for (var i = 0; i < notifications.length; i += 1) {
                 if (clickedOverlay === notifications[i].overlayID || clickedOverlay === notifications[i].imageOverlayID) {
                     deleteSpecificNotification(i);
                     notifications.splice(i, 1);
                     newEventDetected = true;
                 }
             }
+        }
+    }
+
+    function checkHands() {
+        var myLeftHand = Controller.getPoseValue(Controller.Standard.LeftHand);
+        var myRightHand = Controller.getPoseValue(Controller.Standard.RightHand);
+        var eyesPosition = MyAvatar.getEyePosition();
+        var hipsPosition = MyAvatar.getJointPosition("Hips");
+        var eyesRelativeHeight = eyesPosition.y - hipsPosition.y;
+        if (myLeftHand.translation.y > eyesRelativeHeight || myRightHand.translation.y > eyesRelativeHeight) {
+            deleteAllExistingNotificationsDisplayed();
+            notifications = [];
+            audioFeedback.action();
         }
     }
 
@@ -309,6 +326,9 @@
                 renderNotifications(mostRecentRemainingTime);
                 newEventDetected = false;
             }
+        }
+        if (isOnHMD) {
+            checkHands();
         }
     }
 


### PR DESCRIPTION
This is a an almost complete re-coding of the notifications script. The previous version had too useless complexities and was computing each element position independently causing the notifications to be unstably displayed in HMD if the user moved. There was also too many array used to achieved this. It was a bit painful.

This new version use an invisible entity parented to the avatar as a "container" where the notification elements are parented to it, making the positioning easier and more stable if the avatar moves. I used only one array of objects to contain the the notification stack. There is also a better management of some signal to avoid useless computing when it wasn't necessary. I think the code is also more clear.

I got rid of the little x buttons to close the notification, it was on each element, you had to target a very small square surface with the mouse if you wanted to absolutely close a notification within the 10 second of their existence. Now you can close a notification simply by clicking on it (on all its surface) But as before, the close function works only on desktop mode. (Apparently it's relatively complex to get the id of the entity that you click on in HMD. Maybe one day.)

It's also easier now to adjust the scale of the notifications in HMD if we want too, (only one value to change in the script) The parenting using a container entity has also made all the notification UI in HMD scaling correctly according the avatar scale (it was free by parenting all those together).