### PR TITLE
Places App - compatibility with Vircadia MS2 

### DIFF
--- a/scripts/system/places/places.js
+++ b/scripts/system/places/places.js
@@ -183,7 +183,7 @@
         
         for (var i = 0; i < metaverseServers.length; i++ ) {
             if (metaverseServers[i].fetch === true) {
-                extractedData = getContent(metaverseServers[i].url + "/api/v1/places?status=online" + "&acash=" + Math.floor(Math.random() * 999999));
+                extractedData = getContent(metaverseServers[i].url + "/api/v1/places?status=online&per_page=1000");
                 if (extractedData === "") {
                     metaverseServers[i].error = true;
                 } else {
@@ -332,6 +332,7 @@
     function getContent(url) {
         httpRequest = new XMLHttpRequest();
         httpRequest.open("GET", url, false); // false for synchronous request
+        httpRequest.setRequestHeader("Cache-Control", "no-cache");
         httpRequest.timeout = REQUEST_TIMEOUT;
         httpRequest.ontimeout=function(){ 
             return ""; 


### PR DESCRIPTION
These adjustment are to continue to support Vircadia in the place app, respecting our current Directory Server api.

It is now managing the "anti cached data" in the http request header (since Vircadia no more accept a "acash" parameter)
It also add the parameter "per_page=1000" since Vircadia changed the default to 10 on their side.
Using the parameter make this works equally for both: Overte DS1 and Vircadia MS2.

