### PR TITLE
Initial support for a directory with test scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,6 @@
-# If we're running under the gradle build, HIFI_ANDROID will be set here, but
-# ANDROID will not be set until after the `project` statement.  This is the *ONLY*
-# place you need to use `HIFI_ANDROID` instead of `ANDROID`
-if (WIN32 AND NOT HIFI_ANDROID)
-  cmake_minimum_required(VERSION 3.7)
-else()
-  cmake_minimum_required(VERSION 3.2)
-endif()
 
+# 3.14 is the minimum version that supports symlinks on Windows
+cmake_minimum_required(VERSION 3.14)
 
 # Passing of variables to vcpkg
 #

--- a/tests/script-engine/CMakeLists.txt
+++ b/tests/script-engine/CMakeLists.txt
@@ -5,6 +5,25 @@ macro (setup_testcase_dependencies)
   link_hifi_libraries(shared test-utils script-engine networking)
 
   package_libraries_for_deployment()
+
+
+  # The test system is a bit unusual in how it works, and generates targets on its own.
+  # This macro will be called for each of them, so we want to add stuff only to the
+  # right targets.
+  if("${TARGET_NAME}" STREQUAL "script-engine-ScriptEngineTests")
+
+    # We're going with a symlink here for ease of development -- can change the test
+    # without recompiling. We probably never are going to package the tests, or use
+    # them outside of development.
+    #
+    # Symlinks should also work fine on Windows. They're a supported feature, though
+    # a very rarely used one.
+    add_custom_command(TARGET "${TARGET_NAME}" POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E create_symlink
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/tests"
+        "${CMAKE_CURRENT_BINARY_DIR}/tests"
+    )
+  endif()
 endmacro ()
 
 setup_hifi_testcase(Network)

--- a/tests/script-engine/src/ScriptEngineTests.cpp
+++ b/tests/script-engine/src/ScriptEngineTests.cpp
@@ -76,10 +76,16 @@ void ScriptEngineTests::scriptTest() {
     QVERIFY(!ac.isNull());
 
 
-    ac->loadOneScript("test1.js");
-    //ac->loadOneScript("test-missing.js");
-    //ac->loadOneScript("test-hello.js");
-    //ac->loadOneScript("test-divide-by-zero.js");
+    QDir testScriptsDir("tests");
+    QStringList testScripts = testScriptsDir.entryList(QStringList() << "*.js", QDir::Files);
+    testScripts.sort();
+
+    for(QString script : testScripts) {
+        script = "tests/" + script;
+        qInfo() << "Running test script: " << script;
+        ac->loadOneScript(script);
+    }
+
     qDebug() << ac->getRunning();
 
 

--- a/tests/script-engine/src/tests/001_test_print.js
+++ b/tests/script-engine/src/tests/001_test_print.js
@@ -1,0 +1,4 @@
+var v = 1; 
+for (v = 1; v < 30; v++){
+  print(v);
+}

--- a/tests/script-engine/src/tests/002_console_log.js
+++ b/tests/script-engine/src/tests/002_console_log.js
@@ -1,0 +1,1 @@
+console.log("I'm testing!");


### PR DESCRIPTION
This way there's no need to rebuild the test every time. Script dir is symlinked from the source into the binary dir.