### PR TITLE
Optimize settings system

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -719,8 +719,6 @@ private:
 
     bool _notifiedPacketVersionMismatchThisDomain;
 
-    ConditionalGuard _settingsGuard;
-
     GLCanvas* _glWidget{ nullptr };
 
     typedef bool (Application::* AcceptURLMethod)(const QString &);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -481,7 +481,7 @@ public slots:
     void setIsInterstitialMode(bool interstitialMode);
 
     void updateVerboseLogging();
-    
+
     void setCachebustRequire();
 
     void changeViewAsNeeded(float boomLength);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -5,6 +5,7 @@
 //  Created by Andrzej Kapolka on 5/10/13.
 //  Copyright 2013 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/interface/src/scripting/SettingsScriptingInterface.cpp
+++ b/interface/src/scripting/SettingsScriptingInterface.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Brad Hefta-Gaub on 2/25/14.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/interface/src/scripting/SettingsScriptingInterface.h
+++ b/interface/src/scripting/SettingsScriptingInterface.h
@@ -4,6 +4,7 @@
 //
 //  Created by Brad Hefta-Gaub on 3/22/14.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -37,7 +38,7 @@ public slots:
      * @function Settings.getValue
      * @param {string} key - The name of the setting.
      * @param {string|number|boolean|object} [defaultValue=""] - The value to return if the setting doesn't exist.
-     * @returns {string|number|boolean|object} The value stored in the named setting if it exists, otherwise the 
+     * @returns {string|number|boolean|object} The value stored in the named setting if it exists, otherwise the
      *     <code>defaultValue</code>.
      * @example <caption>Retrieve non-existent setting values.</caption>
      * var value1 = Settings.getValue("Script Example/Nonexistent Key");
@@ -50,11 +51,11 @@ public slots:
     QVariant getValue(const QString& setting, const QVariant& defaultValue);
 
     /*@jsdoc
-     * Stores a value in a named setting. If the setting already exists, its value is overwritten. If the value is 
+     * Stores a value in a named setting. If the setting already exists, its value is overwritten. If the value is
      * <code>null</code> or <code>undefined</code>, the setting is deleted.
      * @function Settings.setValue
      * @param {string} key - The name of the setting. Be sure to use a unique name if creating a new setting.
-     * @param {string|number|boolean|object|undefined} value - The value to store in the setting. If <code>null</code> or 
+     * @param {string|number|boolean|object|undefined} value - The value to store in the setting. If <code>null</code> or
      *     <code>undefined</code> is specified, the setting is deleted.
      * @example <caption>Store and retrieve an object value.</caption>
      * Settings.setValue("Script Example/My Key", { x: 0, y: 10, z: 0 });

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by AndrewMeadows 2015.10.05
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -15,6 +15,7 @@
 #include <math.h>
 
 
+Q_LOGGING_CATEGORY(settings_handle, "settings.handle")
 
 const QString Settings::firstRun { "firstRun" };
 

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -34,13 +34,11 @@ void Settings::remove(const QString& key) {
     _manager->remove(key);
 }
 
-QStringList Settings::childGroups() const {
-    return _manager->childGroups();
-}
+// QStringList Settings::childGroups() const {
+// }
 
-QStringList Settings::childKeys() const {
-    return _manager->childKeys();
-}
+// QStringList Settings::childKeys() const {
+// }
 
 QStringList Settings::allKeys() const {
     return _manager->allKeys();
@@ -52,37 +50,56 @@ bool Settings::contains(const QString& key) const {
 }
 
 int Settings::beginReadArray(const QString& prefix) {
-    return _manager->beginReadArray(prefix);
+    _groups.push(Group(prefix));
+    _groupPrefix = getGroupPrefix();
+    int size = _manager->value(_groupPrefix + "/size", -1).toInt();
+    _groups.top().setSize(size);
+    return size;
 }
 
 void Settings::beginWriteArray(const QString& prefix, int size) {
-    _manager->beginWriteArray(prefix, size);
+    _groups.push(Group(prefix));
+    _groupPrefix = getGroupPrefix();
+    _manager->setValue(_groupPrefix + "/size", size);
+
+    _groups.top().setSize(size);
+    _groups.top().setIndex(0);
+
+    _groupPrefix = getGroupPrefix();
 }
 
 void Settings::endArray() {
-    _manager->endArray();
-}
-
-void Settings::setArrayIndex(int i) {
-    _manager->setArrayIndex(i);
-}
-
-void Settings::beginGroup(const QString& prefix) {
-    _manager->beginGroup(prefix);
-}
-
-void Settings::endGroup() {
-    _manager->endGroup();
-}
-
-void Settings::setValue(const QString& name, const QVariant& value) {
-    if (_manager->value(name) != value) {
-        _manager->setValue(name, value);
+    if (!_groups.empty()) {
+        _groups.pop();
+        _groupPrefix = getGroupPrefix();
     }
 }
 
+void Settings::setArrayIndex(int i) {
+    if (!_groups.empty()) {
+        _groups.top().setIndex(i);
+        _groupPrefix = getGroupPrefix();
+    }
+}
+
+void Settings::beginGroup(const QString& prefix) {
+    _groups.push(Group(prefix));
+    _groupPrefix = getGroupPrefix();
+}
+
+void Settings::endGroup() {
+    _groups.pop();
+    _groupPrefix = getGroupPrefix();
+}
+
+void Settings::setValue(const QString& name, const QVariant& value) {
+    QString fullPath = getPath(name);
+    _manager->setValue(fullPath, value);
+}
+
 QVariant Settings::value(const QString& name, const QVariant& defaultValue) const {
-    return _manager->value(name, defaultValue);
+    QString fullPath = getPath(name);
+    return _manager->value(fullPath, defaultValue);
 }
 
 
@@ -153,3 +170,31 @@ void Settings::getQuatValueIfValid(const QString& name, glm::quat& quatValue) {
     endGroup();
 }
 
+QString Settings::getGroupPrefix() const {
+    QString ret;
+
+    for(Group g : _groups) {
+        if (!ret.isEmpty()) {
+            ret.append("/");
+        }
+
+        ret.append(g.name());
+
+        if ( g.isArray() ) {
+            // QSettings indexes arrays from 1
+            ret.append(QString("/%1").arg(g.index() + 1));
+        }
+    }
+
+    return ret;
+}
+
+QString Settings::getPath(const QString &key) const {
+    QString ret = _groupPrefix;
+    if (!ret.isEmpty() ) {
+        ret.append("/");
+    }
+
+    ret.append(key);
+    return ret;
+}

--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -20,12 +20,15 @@
 #include <QtCore/QReadWriteLock>
 #include <QtCore/QSharedPointer>
 #include <QtCore/QDebug>
+#include <QLoggingCategory>
 
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 
 #include "SettingInterface.h"
 
+
+Q_DECLARE_LOGGING_CATEGORY(settings_handle)
 
 /**
  * @brief QSettings analog
@@ -309,7 +312,7 @@ namespace Setting {
         void deprecate() {
             if (_isSet) {
                 if (get() != getDefault()) {
-                    qInfo().nospace() << "[DEPRECATION NOTICE] " << _key << "(" << get() << ") has been deprecated, and has no effect";
+                    qCInfo(settings_handle).nospace() << "[DEPRECATION NOTICE] " << _key << "(" << get() << ") has been deprecated, and has no effect";
                 } else {
                     remove();
                 }

--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -4,6 +4,7 @@
 //
 //  Created by Clement on 1/18/15.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SettingHelpers.cpp
+++ b/libraries/shared/src/SettingHelpers.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Clement on 9/13/16.
 //  Copyright 2016 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -23,13 +23,15 @@
 #include "SharedUtil.h"
 #include "ThreadHelpers.h"
 
+Q_LOGGING_CATEGORY(settings_interface, "settings.interface")
+
 namespace Setting {
     // This should only run as a post-routine in the QCoreApplication destructor
     void cleanupSettingsSaveThread() {
         auto globalManager = DependencyManager::get<Manager>();
         Q_ASSERT(qApp && globalManager);
 
-        globalManager->forceSave();
+        globalManager->terminateThread();
         qCDebug(shared) << "Settings thread stopped.";
     }
 

--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Clement on 2/2/15.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -29,17 +29,7 @@ namespace Setting {
         auto globalManager = DependencyManager::get<Manager>();
         Q_ASSERT(qApp && globalManager);
 
-        // Grab the settings thread to shut it down
-        QThread* settingsManagerThread = globalManager->thread();
-
-        // Quit the settings manager thread and wait for it so we
-        // don't get concurrent accesses when we save all settings below
-        settingsManagerThread->quit();
-        settingsManagerThread->wait();
-
-        // [IMPORTANT] Save all settings when the QApplication goes down
-        globalManager->saveAll();
-
+        globalManager->forceSave();
         qCDebug(shared) << "Settings thread stopped.";
     }
 
@@ -48,37 +38,6 @@ namespace Setting {
         auto globalManager = DependencyManager::get<Manager>();
         Q_ASSERT(qApp && globalManager);
 
-        // Let's set up the settings private instance on its own thread
-        QThread* thread = new QThread(qApp);
-        Q_CHECK_PTR(thread);
-        thread->setObjectName("Settings Thread");
-
-        // Setup setting periodical save timer
-        QObject::connect(thread, &QThread::started, globalManager.data(), [globalManager] {
-            setThreadName("Settings Save Thread");
-            globalManager->startTimer();
-        });
-        QObject::connect(thread, &QThread::finished, globalManager.data(), &Manager::stopTimer);
-
-        // Setup manager threading affinity
-        // This makes the timer fire on the settings thread so we don't block the main
-        // thread with a lot of file I/O.
-        // We bring back the manager to the main thread when the QApplication goes down
-        globalManager->moveToThread(thread);
-        QObject::connect(thread, &QThread::finished, globalManager.data(), [] {
-            auto globalManager = DependencyManager::get<Manager>();
-            Q_ASSERT(qApp && globalManager);
-
-            // Move manager back to the main thread (has to be done on owning thread)
-            globalManager->moveToThread(qApp->thread());
-        });
-
-        // Start the settings save thread
-        thread->start();
-        qCDebug(shared) << "Settings thread started.";
-
-        // Register cleanupSettingsSaveThread to run inside QCoreApplication's destructor.
-        // This will cleanup the settings thread and save all settings before shut down.
         qAddPostRoutine(cleanupSettingsSaveThread);
     }
 
@@ -115,7 +74,7 @@ namespace Setting {
             // in an assignment-client - the QSettings backing we use for this means persistence of these
             // settings from an AC (when there can be multiple terminating at same time on one machine)
             // is currently not supported
-            qWarning() << "Setting::Interface::init() for key" << _key << "- Manager not yet created." << 
+            qWarning() << "Setting::Interface::init() for key" << _key << "- Manager not yet created." <<
                 "Settings persistence disabled.";
         } else {
             _manager = DependencyManager::get<Manager>();
@@ -127,7 +86,7 @@ namespace Setting {
             } else {
                 qWarning() << "Settings interface used after manager destroyed";
             }
-        
+
             // Load value from disk
             load();
         }
@@ -144,20 +103,20 @@ namespace Setting {
         }
     }
 
-    
+
     void Interface::maybeInit() const {
         if (!_isInitialized) {
             const_cast<Interface*>(this)->init();
         }
     }
-    
+
     void Interface::save() {
         auto manager = _manager.lock();
         if (manager) {
             manager->saveSetting(this);
         }
     }
-    
+
     void Interface::load() {
         auto manager = _manager.lock();
         if (manager) {

--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -74,7 +74,7 @@ namespace Setting {
             // in an assignment-client - the QSettings backing we use for this means persistence of these
             // settings from an AC (when there can be multiple terminating at same time on one machine)
             // is currently not supported
-            qWarning() << "Setting::Interface::init() for key" << _key << "- Manager not yet created." <<
+            qCWarning(settings_interface) << "Setting::Interface::init() for key" << _key << "- Manager not yet created." <<
                 "Settings persistence disabled.";
         } else {
             _manager = DependencyManager::get<Manager>();
@@ -84,11 +84,12 @@ namespace Setting {
                 manager->registerHandle(this);
                 _isInitialized = true;
             } else {
-                qWarning() << "Settings interface used after manager destroyed";
+                qCWarning(settings_interface) << "Settings interface used after manager destroyed";
             }
 
             // Load value from disk
             load();
+            //qCDebug(settings_interface) << "Setting" << this->getKey() << "initialized to" << getVariant();
         }
     }
 
@@ -106,6 +107,7 @@ namespace Setting {
 
     void Interface::maybeInit() const {
         if (!_isInitialized) {
+            //qCDebug(settings_interface) << "Initializing setting" << this->getKey();
             const_cast<Interface*>(this)->init();
         }
     }

--- a/libraries/shared/src/SettingInterface.h
+++ b/libraries/shared/src/SettingInterface.h
@@ -28,11 +28,11 @@ namespace Setting {
     class Interface {
     public:
         const QString& getKey() const { return _key; }
-        bool isSet() const { return _isSet; } 
+        bool isSet() const { return _isSet; }
 
         virtual void setVariant(const QVariant& variant) = 0;
         virtual QVariant getVariant() = 0;
-        
+
     protected:
         Interface(const QString& key) : _key(key) {}
         virtual ~Interface() = default;

--- a/libraries/shared/src/SettingInterface.h
+++ b/libraries/shared/src/SettingInterface.h
@@ -4,6 +4,7 @@
 //
 //  Created by Clement on 2/2/15.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SettingInterface.h
+++ b/libraries/shared/src/SettingInterface.h
@@ -16,6 +16,9 @@
 #include <QtCore/QWeakPointer>
 #include <QtCore/QString>
 #include <QtCore/QVariant>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(settings_interface)
 
 namespace Setting {
     class Manager;
@@ -37,7 +40,7 @@ namespace Setting {
         void init();
         void maybeInit() const;
         void deinit();
-        
+
         void save();
         void load();
 
@@ -46,7 +49,7 @@ namespace Setting {
 
     private:
         mutable bool _isInitialized = false;
-        
+
         friend class Manager;
         mutable QWeakPointer<Manager> _manager;
     };

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -120,6 +120,17 @@ namespace Setting {
         }
     }
 
+    /**
+     * @brief Forces saving the current configuration
+     *
+     * @warning This function is for testing only, should only be called from the test suite.
+     */
+    void Manager::forceSave() {
+        withWriteLock([&] {
+             _qSettings.sync();
+        });
+    }
+
     QString Manager::fileName() const {
         return resultWithReadLock<QString>([&] {
             return _qSettings.fileName();

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -127,7 +127,7 @@ namespace Setting {
      */
     void Manager::forceSave() {
         withWriteLock([&] {
-             _qSettings.sync();
+             _qSettings->sync();
         });
     }
 

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Clement on 2/2/15.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -19,11 +19,60 @@
 
 namespace Setting {
 
+
+    void WriteWorker::start() {
+        // QSettings seems to have some issues with moving to a new thread.
+        // Make sure the object is only created once the thread is already up and running.
+        init();
+    }
+
+    void WriteWorker::setValue(const QString &key, const QVariant &value) {
+        //qDebug() << "Setting config " << key << "to" << value;
+        init();
+        _qSettings->setValue(key, value);
+    }
+
+    void WriteWorker::removeKey(const QString &key) {
+        init();
+        _qSettings->remove(key);
+    }
+
+    void WriteWorker::sync() {
+        //qDebug() << "Forcing settings sync";
+        init();
+        _qSettings->sync();
+    }
+
+    Manager::Manager(QObject *parent) {
+        WriteWorker *worker = new WriteWorker();
+
+        // We operate purely from memory, and forward all changes to a thread that has writing the
+        // settings as its only job.
+
+        qDebug() << "Initializing settings write thread";
+
+        _workerThread.setObjectName("Settings Writer");
+        worker->moveToThread(&_workerThread);
+        connect(&_workerThread, &QThread::started, worker, &WriteWorker::start, Qt::QueuedConnection);
+        connect(&_workerThread, &QThread::finished, worker, &QObject::deleteLater, Qt::QueuedConnection);
+        connect(this, &Manager::valueChanged, worker, &WriteWorker::setValue, Qt::QueuedConnection);
+        connect(this, &Manager::keyRemoved, worker, &WriteWorker::removeKey, Qt::QueuedConnection);
+        connect(this, &Manager::syncRequested, worker, &WriteWorker::sync, Qt::QueuedConnection);
+        _workerThread.start();
+
+        // Load all current settings
+        QSettings settings;
+        _fileName = settings.fileName();
+
+        for(QString key : settings.allKeys()) {
+            qDebug() << "Loaded key" << key << "with value" << settings.value(key);
+            _settings[key] = settings.value(key);
+        }
+    }
+
+
     Manager::~Manager() {
-        // Cleanup timer
-        stopTimer();
-        delete _saveTimer;
-        _saveTimer = nullptr;
+
     }
 
     // Custom deleter does nothing, because we need to shutdown later than the dependency manager
@@ -48,12 +97,8 @@ namespace Setting {
     void Manager::loadSetting(Interface* handle) {
         const auto& key = handle->getKey();
         withWriteLock([&] {
-            QVariant loadedValue;
-            if (_pendingChanges.contains(key) && _pendingChanges[key] != UNSET_VALUE) {
-                loadedValue = _pendingChanges[key];
-            } else {
-                loadedValue = _qSettings.value(key);
-            }
+            QVariant loadedValue = _settings[key];
+
             if (loadedValue.isValid()) {
                 handle->setVariant(loadedValue);
             }
@@ -69,56 +114,10 @@ namespace Setting {
         }
 
         withWriteLock([&] {
-            _pendingChanges[key] = handleValue;
+            _settings[key] = handleValue;
         });
     }
 
-    static const int SAVE_INTERVAL_MSEC = 5 * 1000; // 5 sec
-    void Manager::startTimer() {
-        if (!_saveTimer) {
-            _saveTimer = new QTimer(this);
-            Q_CHECK_PTR(_saveTimer);
-            _saveTimer->setSingleShot(true); // We will restart it once settings are saved.
-            _saveTimer->setInterval(SAVE_INTERVAL_MSEC); // 5s, Qt::CoarseTimer acceptable
-            connect(_saveTimer, SIGNAL(timeout()), this, SLOT(saveAll()));
-        }
-        _saveTimer->start();
-    }
-
-    void Manager::stopTimer() {
-        if (_saveTimer) {
-            _saveTimer->stop();
-        }
-    }
-
-    void Manager::saveAll() {
-        withWriteLock([&] {
-            bool forceSync = false;
-            for (auto key : _pendingChanges.keys()) {
-                auto newValue = _pendingChanges[key];
-                auto savedValue = _qSettings.value(key, UNSET_VALUE);
-                if (newValue == savedValue) {
-                    continue;
-                }
-                forceSync = true;
-                if (newValue == UNSET_VALUE || !newValue.isValid()) {
-                    _qSettings.remove(key);
-                } else {
-                    _qSettings.setValue(key, newValue);
-                }
-            }
-            _pendingChanges.clear();
-
-            if (forceSync) {
-                _qSettings.sync();
-            }
-        });
-
-        // Restart timer
-        if (_saveTimer) {
-            _saveTimer->start();
-        }
-    }
 
     /**
      * @brief Forces saving the current configuration
@@ -126,92 +125,46 @@ namespace Setting {
      * @warning This function is for testing only, should only be called from the test suite.
      */
     void Manager::forceSave() {
-        withWriteLock([&] {
-             _qSettings.sync();
-        });
+        emit syncRequested();
     }
 
     QString Manager::fileName() const {
         return resultWithReadLock<QString>([&] {
-            return _qSettings.fileName();
+            return _fileName;
         });
     }
 
     void Manager::remove(const QString &key) {
         withWriteLock([&] {
-            _qSettings.remove(key);
+            _settings.remove(key);
         });
-    }
 
-    QStringList Manager::childGroups() const {
-        return resultWithReadLock<QStringList>([&] {
-            return _qSettings.childGroups();
-        });
-    }
-
-    QStringList Manager::childKeys() const {
-        return resultWithReadLock<QStringList>([&] {
-            return _qSettings.childKeys();
-        });
+        emit keyRemoved(key);
     }
 
     QStringList Manager::allKeys() const {
         return resultWithReadLock<QStringList>([&] {
-            return _qSettings.allKeys();
+            return _settings.keys();
         });
     }
 
     bool Manager::contains(const QString &key) const {
         return resultWithReadLock<bool>([&] {
-            return _qSettings.contains(key);
-        });
-    }
-
-    int Manager::beginReadArray(const QString &prefix) {
-        return resultWithReadLock<int>([&] {
-            return _qSettings.beginReadArray(prefix);
-        });
-    }
-
-    void Manager::beginGroup(const QString &prefix) {
-        withWriteLock([&] {
-            _qSettings.beginGroup(prefix);
-        });
-    }
-
-    void Manager::beginWriteArray(const QString &prefix, int size) {
-        withWriteLock([&] {
-            _qSettings.beginWriteArray(prefix, size);
-        });
-    }
-
-    void Manager::endArray() {
-        withWriteLock([&] {
-            _qSettings.endArray();
-        });
-    }
-
-    void Manager::endGroup() {
-        withWriteLock([&] {
-            _qSettings.endGroup();
-        });
-    }
-
-    void Manager::setArrayIndex(int i) {
-        withWriteLock([&] {
-            _qSettings.setArrayIndex(i);
+            return _settings.contains(key);
         });
     }
 
     void Manager::setValue(const QString &key, const QVariant &value) {
         withWriteLock([&] {
-            _qSettings.setValue(key, value);
+            _settings[key] = value;
         });
+
+        emit valueChanged(key, value);
     }
 
     QVariant Manager::value(const QString &key, const QVariant &defaultValue) const {
         return resultWithReadLock<QVariant>([&] {
-            return _qSettings.value(key, defaultValue);
+            return _settings.value(key, defaultValue);
         });
     }
 }

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -155,12 +155,6 @@ namespace Setting {
 
     }
 
-
-    /**
-     * @brief Forces saving the current configuration
-     *
-     * @warning This function is for testing only, should only be called from the test suite.
-     */
     void Manager::forceSave() {
         emit syncRequested();
     }

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -33,7 +33,10 @@ namespace Setting {
        //qCDebug(settings_writer) << "Setting config " << key << "to" << value;
 
         init();
-        _qSettings->setValue(key, value);
+
+        if (!_qSettings->contains(key) || _qSettings->value(key) != value) {
+            _qSettings->setValue(key, value);
+        }
     }
 
     void WriteWorker::removeKey(const QString key) {

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -17,6 +17,9 @@
 
 #include "SettingInterface.h"
 
+Q_LOGGING_CATEGORY(settings_manager, "settings.manager")
+Q_LOGGING_CATEGORY(settings_writer, "settings.manager.writer")
+
 namespace Setting {
 
 

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -136,14 +136,23 @@ namespace Setting {
 
     void Manager::saveSetting(Interface* handle) {
         const auto& key = handle->getKey();
-        QVariant handleValue = UNSET_VALUE;
+
         if (handle->isSet()) {
-            handleValue = handle->getVariant();
+            QVariant handleValue = handle->getVariant();
+
+            withWriteLock([&] {
+                _settings[key] = handleValue;
+            });
+
+            emit valueChanged(key, handleValue);
+        } else {
+            withWriteLock([&] {
+                _settings.remove(key);
+            });
+
+            emit keyRemoved(key);
         }
 
-        withWriteLock([&] {
-            _settings[key] = handleValue;
-        });
     }
 
 

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -29,13 +29,14 @@ namespace Setting {
         init();
     }
 
-    void WriteWorker::setValue(const QString &key, const QVariant &value) {
-        //qDebug() << "Setting config " << key << "to" << value;
+    void WriteWorker::setValue(const QString key, const QVariant value) {
+       //qCDebug(settings_writer) << "Setting config " << key << "to" << value;
+
         init();
         _qSettings->setValue(key, value);
     }
 
-    void WriteWorker::removeKey(const QString &key) {
+    void WriteWorker::removeKey(const QString key) {
         init();
         _qSettings->remove(key);
     }

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -127,7 +127,7 @@ namespace Setting {
      */
     void Manager::forceSave() {
         withWriteLock([&] {
-             _qSettings->sync();
+             _qSettings.sync();
         });
     }
 

--- a/libraries/shared/src/SettingManager.cpp
+++ b/libraries/shared/src/SettingManager.cpp
@@ -65,7 +65,7 @@ namespace Setting {
         _fileName = settings.fileName();
 
         for(QString key : settings.allKeys()) {
-            qDebug() << "Loaded key" << key << "with value" << settings.value(key);
+            //qCDebug(settings_manager) << "Loaded key" << key << "with value" << settings.value(key);
             _settings[key] = settings.value(key);
         }
     }
@@ -82,7 +82,7 @@ namespace Setting {
         const QString& key = handle->getKey();
         withWriteLock([&] {
             if (_handles.contains(key)) {
-                qWarning() << "Setting::Manager::registerHandle(): Key registered more than once, overriding: " << key;
+                qCWarning(settings_manager) << "Setting::Manager::registerHandle(): Key registered more than once, overriding: " << key;
             }
             _handles.insert(key, handle);
         });
@@ -96,6 +96,7 @@ namespace Setting {
 
     void Manager::loadSetting(Interface* handle) {
         const auto& key = handle->getKey();
+
         withWriteLock([&] {
             QVariant loadedValue = _settings[key];
 

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -4,6 +4,7 @@
 //
 //  Created by Clement on 2/2/15.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -19,10 +19,13 @@
 
 #include <QSettings>
 #include <QThread>
+#include <QLoggingCategory>
 
 #include "DependencyManager.h"
 #include "shared/ReadWriteLockable.h"
 
+Q_DECLARE_LOGGING_CATEGORY(settings_manager)
+Q_DECLARE_LOGGING_CATEGORY(settings_writer)
 
 // This is for the testing system.
 class SettingsTests;

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -80,6 +80,18 @@ namespace Setting {
          */
         void sync();
 
+        /**
+         * @brief Called when the thread is terminating
+         *
+         */
+        void threadFinished();
+
+        /**
+         * @brief Thread is being asked to finish work and quit
+         *
+         */
+        void terminate();
+
         private:
 
         void init() {
@@ -194,6 +206,7 @@ namespace Setting {
         void valueChanged(const QString key, QVariant value);
         void keyRemoved(const QString key);
         void syncRequested();
+        void terminationRequested();
 
     private:
         QHash<QString, Interface*> _handles;

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -23,6 +23,7 @@
 
 // This is for the testing system.
 class SettingsTests;
+class SettingsTestsWorker;
 
 
 
@@ -50,7 +51,6 @@ namespace Setting {
         void setArrayIndex(int i);
         void setValue(const QString &key, const QVariant &value);
         QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
-        void forceSave();
 
     protected:
         ~Manager();
@@ -59,6 +59,7 @@ namespace Setting {
 
         void loadSetting(Interface* handle);
         void saveSetting(Interface* handle);
+        void forceSave();
 
     private slots:
         void startTimer();
@@ -73,7 +74,8 @@ namespace Setting {
         QHash<QString, QVariant> _pendingChanges;
 
         friend class Interface;
-        friend class SettingsTests;
+        friend class ::SettingsTests;
+        friend class ::SettingsTestsWorker;
 
         friend void cleanupSettingsSaveThread();
         friend void setupSettingsSaveThread();

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -210,8 +210,6 @@ namespace Setting {
 
     private:
         QHash<QString, Interface*> _handles;
-        const QVariant UNSET_VALUE { QUuid::createUuid() };
-
 
         friend class Interface;
         friend class ::SettingsTests;

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -20,6 +20,12 @@
 #include "DependencyManager.h"
 #include "shared/ReadWriteLockable.h"
 
+
+// This is for the testing system.
+class SettingsTests;
+
+
+
 namespace Setting {
     class Interface;
 
@@ -67,6 +73,8 @@ namespace Setting {
         QHash<QString, QVariant> _pendingChanges;
 
         friend class Interface;
+        friend class SettingsTests;
+
         friend void cleanupSettingsSaveThread();
         friend void setupSettingsSaveThread();
 

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -44,6 +44,7 @@ namespace Setting {
         void setArrayIndex(int i);
         void setValue(const QString &key, const QVariant &value);
         QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
+        void forceSave();
 
     protected:
         ~Manager();

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -109,21 +109,83 @@ namespace Setting {
 
         void customDeleter() override;
 
+        /**
+         * @brief Returns the filename where the config file will be written
+         *
+         * @return QString Path to the config file
+         */
         QString fileName() const;
+
+        /**
+         * @brief Remove a configuration key
+         *
+         * @param key Key to remove
+         */
         void remove(const QString &key);
+
+        /**
+         * @brief Lists all keys in the configuration
+         *
+         * @return QStringList List of keys
+         */
         QStringList allKeys() const;
+
+        /**
+         * @brief Returns whether a key is part of the configuration
+         *
+         * @param key Key to look for
+         * @return true Key is in the configuration
+         * @return false Key isn't in the configuration
+         */
         bool contains(const QString &key) const;
+
+        /**
+         * @brief Set a setting to a value
+         *
+         * @param key Setting to set
+         * @param value Value
+         */
         void setValue(const QString &key, const QVariant &value);
+
+        /**
+         * @brief Returns the value of a setting
+         *
+         * @param key Setting to look for
+         * @param defaultValue Default value to return, if the setting has no value
+         * @return QVariant Current value of the setting, of defaultValue.
+         */
         QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
 
     protected:
+        /**
+         * @brief How long to wait for writer thread termination
+         *
+         * We probably want a timeout here since we don't want to block shutdown indefinitely in case of
+         * any weirdness.
+         */
+        const int THREAD_TERMINATION_TIMEOUT = 2000;
+
         ~Manager();
         void registerHandle(Interface* handle);
         void removeHandle(const QString& key);
 
         void loadSetting(Interface* handle);
         void saveSetting(Interface* handle);
+
+
+        /**
+         * @brief Force saving the config to disk.
+         *
+         * Normally unnecessary to use. Asynchronous.
+         */
         void forceSave();
+
+        /**
+         * @brief Write config to disk and terminate the writer thread
+         *
+         * This is part of the shutdown process.
+         */
+        void terminateThread();
 
     signals:
         void valueChanged(const QString &key, const QVariant &value);

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -65,14 +65,14 @@ namespace Setting {
          * @param key Configuration key
          * @param value Configuration value
          */
-        void setValue(const QString &key, const QVariant &value);
+        void setValue(const QString key, const QVariant value);
 
         /**
          * @brief Remove a value from the configuration
          *
          * @param key Key to remove
          */
-        void removeKey(const QString &key);
+        void removeKey(const QString key);
 
         /**
          * @brief Force writing the config to disk
@@ -191,8 +191,8 @@ namespace Setting {
         void terminateThread();
 
     signals:
-        void valueChanged(const QString &key, const QVariant &value);
-        void keyRemoved(const QString &key);
+        void valueChanged(const QString key, QVariant value);
+        void keyRemoved(const QString key);
         void syncRequested();
 
     private:

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -1,6 +1,9 @@
 
 # Declare dependencies
 macro (setup_testcase_dependencies)
+  setup_memory_debugger()
+  setup_thread_debugger()
+
 
   # link in the shared libraries
   link_hifi_libraries(shared test-utils)

--- a/tests/shared/src/SettingsTests.cpp
+++ b/tests/shared/src/SettingsTests.cpp
@@ -20,7 +20,7 @@
 
 QTEST_MAIN(SettingsTests)
 
-void SettingsTestThread::saveSettings() {
+void SettingsTestsWorker::saveSettings() {
     auto sm = DependencyManager::get<Setting::Manager>();
     QThread *thread = QThread::currentThread();
 
@@ -75,7 +75,6 @@ void SettingsTests::benchmarkSetValue() {
         sm->setValue("BenchmarkSetValue", ++i);
     }
 
-    sm->forceSave();
 }
 
 
@@ -84,7 +83,7 @@ void SettingsTests::benchmarkSaveSettings() {
     int i = 0;
 
     QBENCHMARK {
-        sm->setValue("Benchmark", ++i);
+        sm->setValue("BenchmarkSave", ++i);
         sm->forceSave();
     }
 
@@ -96,22 +95,22 @@ void SettingsTests::benchmarkSetValueConcurrent() {
     int i = 0;
 
     _settingsThread = new QThread(qApp);
-    _settingsThreadObj = new SettingsTestThread;
+    _testWorker = new SettingsTestsWorker();
 
     _settingsThread->setObjectName("Save thread");
-    _settingsThreadObj->moveToThread(_settingsThread);
+    _testWorker->moveToThread(_settingsThread);
 
-    QObject::connect(_settingsThread, &QThread::started, _settingsThreadObj, &SettingsTestThread::saveSettings, Qt::QueuedConnection );
+    QObject::connect(_settingsThread, &QThread::started, _testWorker, &SettingsTestsWorker::saveSettings, Qt::QueuedConnection );
 
     _settingsThread->start();
     QBENCHMARK {
-        sm->setValue("BenchmarkSetValue", ++i);
+        sm->setValue("BenchmarkSetValueConcurrent", ++i);
     }
 
     _settingsThread->requestInterruption();
     _settingsThread->wait();
 
-    delete _settingsThreadObj;
+    delete _testWorker;
     delete _settingsThread;
 }
 

--- a/tests/shared/src/SettingsTests.cpp
+++ b/tests/shared/src/SettingsTests.cpp
@@ -1,0 +1,61 @@
+//
+//  Created by Bradley Austin Davis on 2017/11/08
+//  Copyright 2013-2017 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+
+#include "SettingsTests.h"
+
+#include <QtTest/QtTest>
+#include <SettingHandle.h>
+#include <SettingManager.h>
+#include <DependencyManager.h>
+#include <QDebug>
+#include <QCoreApplication>
+#include "SettingInterface.h"
+
+
+QTEST_MAIN(SettingsTests)
+
+void SettingsTests::initTestCase() {
+    QCoreApplication::setOrganizationName("OverteTest");
+
+    DependencyManager::set<Setting::Manager>();
+
+    Setting::init();
+}
+
+void SettingsTests::cleanupTestCase() {
+  //  Setting::cleanupSettingsSaveThread();
+}
+
+void SettingsTests::loadSettings() {
+    Settings s;
+    qDebug() << "Loaded" << s.fileName();
+}
+
+void SettingsTests::saveSettings() {
+    Settings s;
+    s.setValue("TestValue", "Hello");
+
+    auto sm = DependencyManager::get<Setting::Manager>();
+    sm->setValue("TestValueSM", "Hello");
+
+    // There seems to be a bug here, data gets lost without this call here.
+    sm->forceSave();
+    qDebug() << "Wrote" << s.fileName();
+}
+
+void SettingsTests::benchmarkSaveSettings() {
+    auto sm = DependencyManager::get<Setting::Manager>();
+    int i = 0;
+
+    QBENCHMARK {
+        sm->setValue("Benchmark", ++i);
+        sm->forceSave();
+    }
+
+}

--- a/tests/shared/src/SettingsTests.cpp
+++ b/tests/shared/src/SettingsTests.cpp
@@ -1,6 +1,6 @@
 //
-//  Created by Bradley Austin Davis on 2017/11/08
-//  Copyright 2013-2017 High Fidelity, Inc.
+//  Created by Dale Glass on 2022/10/22
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/tests/shared/src/SettingsTests.cpp
+++ b/tests/shared/src/SettingsTests.cpp
@@ -75,6 +75,10 @@ void SettingsTests::testSettings() {
 
     s.setValue("settingsTest", 1);
     QVERIFY(sm->value("settingsTest") == 1);
+
+    QVERIFY(!sm->contains("nonExistingKey"));
+    QVERIFY(sm->value("nonExistingKey") == QVariant());
+
 }
 
 void SettingsTests::testGroups() {
@@ -141,6 +145,37 @@ void SettingsTests::testArrayInGroup() {
     QVERIFY(sm->value("groupWithArray/arrayInGroup/2/X") == 20);
     QVERIFY(sm->value("valueNotInArrayOrGroup") == 8);
 }
+
+void SettingsTests::testHandleUnused() {
+
+    {
+        Setting::Handle<int> testHandle("unused_handle", -1);
+    }
+}
+
+void SettingsTests::testHandle() {
+    auto sm = DependencyManager::get<Setting::Manager>();
+    Setting::Handle<int> testHandle("integer_value", -1);
+
+    QVERIFY(!testHandle.isSet());
+    QVERIFY(testHandle.get() == -1);
+    QVERIFY(testHandle.get(-5) == -5);
+    QVERIFY(testHandle.getDefault() == -1);
+
+    testHandle.set(42);
+    QVERIFY(testHandle.get() == 42);
+    QVERIFY(testHandle.isSet());
+    QVERIFY(sm->value("integer_value") == 42);
+
+    testHandle.reset();
+    QVERIFY(testHandle.get() == -1);
+    QVERIFY(testHandle.isSet());
+    QVERIFY(sm->value("integer_value") == -1);
+
+    testHandle.remove();
+    QVERIFY(!testHandle.isSet());
+}
+
 
 void SettingsTests::benchmarkSetValue() {
     auto sm = DependencyManager::get<Setting::Manager>();

--- a/tests/shared/src/SettingsTests.h
+++ b/tests/shared/src/SettingsTests.h
@@ -11,15 +11,32 @@
 
 #include <QtCore/QObject>
 
+
+class SettingsTestThread : public QObject {
+    Q_OBJECT
+
+public slots:
+    void saveSettings();
+};
+
+
 class SettingsTests : public QObject {
     Q_OBJECT
 private slots:
     void initTestCase();
     void loadSettings();
     void saveSettings();
+
+    void benchmarkSetValue();
     void benchmarkSaveSettings();
+    void benchmarkSetValueConcurrent();
 
     void cleanupTestCase();
+
+private:
+    QThread *_settingsThread = nullptr;
+    SettingsTestThread *_settingsThreadObj = nullptr;
+
 };
 
 #endif // overte_SettingsTests_h

--- a/tests/shared/src/SettingsTests.h
+++ b/tests/shared/src/SettingsTests.h
@@ -29,6 +29,12 @@ private slots:
     void loadSettings();
     void saveSettings();
 
+    void testSettings();
+    void testGroups();
+    void testArray();
+    void testArrayInGroup();
+
+
     void benchmarkSetValue();
     void benchmarkSaveSettings();
     void benchmarkSetValueConcurrent();

--- a/tests/shared/src/SettingsTests.h
+++ b/tests/shared/src/SettingsTests.h
@@ -12,16 +12,18 @@
 #include <QtCore/QObject>
 
 
-class SettingsTestThread : public QObject {
+
+
+class SettingsTestsWorker : public QObject {
     Q_OBJECT
 
 public slots:
     void saveSettings();
 };
 
-
 class SettingsTests : public QObject {
     Q_OBJECT
+
 private slots:
     void initTestCase();
     void loadSettings();
@@ -35,7 +37,7 @@ private slots:
 
 private:
     QThread *_settingsThread = nullptr;
-    SettingsTestThread *_settingsThreadObj = nullptr;
+    SettingsTestsWorker *_testWorker = nullptr;
 
 };
 

--- a/tests/shared/src/SettingsTests.h
+++ b/tests/shared/src/SettingsTests.h
@@ -34,6 +34,9 @@ private slots:
     void testArray();
     void testArrayInGroup();
 
+    void testHandleUnused();
+    void testHandle();
+
 
     void benchmarkSetValue();
     void benchmarkSaveSettings();

--- a/tests/shared/src/SettingsTests.h
+++ b/tests/shared/src/SettingsTests.h
@@ -1,0 +1,25 @@
+//
+//  Created by Dale Glass 2022/10/22
+//  Copyright 2022 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef overte_SettingsTests_h
+#define overte_SettingsTests_h
+
+#include <QtCore/QObject>
+
+class SettingsTests : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase();
+    void loadSettings();
+    void saveSettings();
+    void benchmarkSaveSettings();
+
+    void cleanupTestCase();
+};
+
+#endif // overte_SettingsTests_h


### PR DESCRIPTION
Improve settings system, by moving all writes to a thread. This should solve stutter that may happen on systems with hard disks.
    
This should complete what was started in the HiFi days but didn't quite succeed.
    
Setting::Manager is now thread safe, and delegates all settings writes to a thread     that nothing waits on, which should ensure that settings don't degrade performance even on slow storage devices.
    
Functions that weren't thread safe were removed from Setting::Manager, and it was reduced to a key/value store.
    
Functions that modify state like beginGroup were implemented in the Settings class instead, which should be created only in the context where it's needed. It will forward all changes to the manager.
    
A few QSettings functions were left unimplemented because they're not used in the code. They may be implemented later if there's a need.

This is an alternative to #231 