### PR TITLE
Create app: PolyVox properties tootips

### DIFF
--- a/scripts/system/create/assets/data/createAppTooltips.json
+++ b/scripts/system/create/assets/data/createAppTooltips.json
@@ -663,5 +663,24 @@
     "importNewEntity": {
         "tooltip": "Import a local or hosted file that can be used across domains.",
         "skipJSProperty": true
+    },
+    "voxelVolumeSize": {
+        "tooltip": "Number of voxels along each axis of the entity."
+    },
+    "polyVoxPreset": {
+        "tooltip": "Apply a predefined set of textures to the PolyVox entity, replacing the url of the properties: X Texture URL, Y Texture URL, Z Texture URL.",
+        "skipJSProperty": true
+    },
+    "voxelSurfaceStyle": {
+        "tooltip": "The style of rendering the voxels' surface and how neighboring PolyVox entities are joined."
+    },
+    "xTextureURL": {
+        "tooltip": "The URL of the texture to map to surfaces perpendicular to the entity's local x-axis. JPG or PNG format."
+    },
+    "yTextureURL": {
+        "tooltip": "The URL of the texture to map to surfaces perpendicular to the entity's local y-axis. JPG or PNG format."
+    },
+    "zTextureURL": {
+        "tooltip": "The URL of the texture to map to surfaces perpendicular to the entity's local z-axis. JPG or PNG format."
     }
 }

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -1343,6 +1343,14 @@ const GROUPS = [
                 propertyID: "voxelVolumeSize",
             },
             {
+                label: "Surface Style",
+                type: "dropdown",
+                options: { 0: "Marching cubes", 1: "Cubic", 
+                           2: "Edged cubic", 3: "Edged marching cubes" },
+                propertyID: "voxelSurfaceStyle",
+                propertyName: "voxelSurfaceStyle",
+            },
+            {
                 label: "Texture preset",
                 type: "dropdown",
                 options: { 0 : "None", 1 : "Grass + ground", 2 : "Bricks", 3 : "Stone", 
@@ -1350,14 +1358,6 @@ const GROUPS = [
                 propertyID: "polyVoxPreset",
                 onDropdownChange: createPolyVoxPresetChangedFunction,
                 skipPropertyUpdate: true,
-            },
-            {
-                label: "Surface Style",
-                type: "dropdown",
-                options: { 0: "Marching cubes", 1: "Cubic", 
-                           2: "Edged cubic", 3: "Edged marching cubes" },
-                propertyID: "voxelSurfaceStyle",
-                propertyName: "voxelSurfaceStyle",
             },
             {
                 label: "X Texture URL",


### PR DESCRIPTION
This PR adds the missing tooltip on the properties of the "PolyVox" entity.

- Volume Size
- Surface Style
- Texture preset
- X Texture URL
- Y Texture URL
- Z Texture URL

The property "Texture preset" has also been moved just over the 3 texture properties that it affects.

![image](https://user-images.githubusercontent.com/60075796/200097798-e724d596-dad9-4ffe-9e39-308f00e3174b.png)


