### PR TITLE
Disable Metadata "exporter" by default

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -59,7 +59,7 @@
           "name": "enable_metadata_exporter",
           "label": "Enable Metadata HTTP Availability",
           "help": "Allows your domain's metadata to be accessible on the public internet via direct HTTP connection to the domain server.",
-          "default": true,
+          "default": false,
           "type": "checkbox",
           "advanced":  true
         },


### PR DESCRIPTION
The metadata exporter is very annoying when setting up multiple servers on the same machine, since it always uses the same port by default.
It is also pretty much unused and can be easily enabled if someone wants to use it.