### PR TITLE
Use GitHub Actions artifact storage

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -64,7 +64,7 @@ jobs:
       id: buildenv1
       run: |
 
-        echo ::set-output name=github_sha_short::`echo $GIT_COMMIT | cut -c1-7`
+        echo "{github_sha_short}={`echo $GIT_COMMIT | cut -c1-7`}" >> $GITHUB_OUTPUT
         echo "JOB_NAME=${{matrix.os}}, ${{matrix.build_type}}" >> $GITHUB_ENV
         echo "APP_TARGET_NAME=$APP_NAME" >> $GITHUB_ENV
 
@@ -228,7 +228,7 @@ jobs:
 
     - name: Archive cmake logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz
         path: ${{ runner.workspace }}/cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -64,7 +64,6 @@ jobs:
       id: buildenv1
       run: |
 
-        echo "UPLOAD_PREFIX=build/overte/PR" >> $GITHUB_ENV
         echo ::set-output name=github_sha_short::`echo $GIT_COMMIT | cut -c1-7`
         echo "JOB_NAME=${{matrix.os}}, ${{matrix.build_type}}" >> $GITHUB_ENV
         echo "APP_TARGET_NAME=$APP_NAME" >> $GITHUB_ENV
@@ -329,13 +328,9 @@ jobs:
       run: cat ./_CPack_Packages/win64/NSIS/NSISOutput.log
 
     - name: Upload Artifact
-      if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS') || matrix.build_type == 'android'  # Automatic Linux packaging is not implemented
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: |
-        if [[ "${{ matrix.build_type }}" == "android" ]]; then
-          cd $GITHUB_WORKSPACE/android
-        fi
-        $PYTHON_EXEC "$GITHUB_WORKSPACE/tools/ci-scripts/upload_to_publish_server.py"
+      if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.ARTIFACT_PATTERN }}
+        path: ${{ runner.workspace }}/build/${{ env.ARTIFACT_PATTERN }}
+        if-no-files-found: error

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -137,16 +137,12 @@ jobs:
         echo "${{ steps.buildenv1.outputs.symbols_archive }}"
         # Setting short commit SHA for use as RELEASE_NAME in generated installers.
         echo "GIT_COMMIT_SHORT=${{ steps.buildenv1.outputs.github_sha_short }}" >> $GITHUB_ENV
-        if [[ "${{ matrix.build_type }}" != "android" ]]; then
-          if [ "${{ matrix.build_type }}" = "full" ]; then
-            echo "ARTIFACT_PATTERN=Overte-PR${{ github.event.number }}-${{ steps.buildenv1.outputs.github_sha_short }}.$INSTALLER_EXT" >> $GITHUB_ENV
-            echo "INSTALLER=Overte-$RELEASE_NUMBER-${{ steps.buildenv1.outputs.github_sha_short }}.$INSTALLER_EXT" >> $GITHUB_ENV
-          else
-            echo "ARTIFACT_PATTERN=Overte-Interface-PR${{ github.event.number }}-${{ steps.buildenv1.outputs.github_sha_short }}.$INSTALLER_EXT" >> $GITHUB_ENV
-            echo "INSTALLER=Overte-Interface-$RELEASE_NUMBER-${{ steps.buildenv1.outputs.github_sha_short }}.$INSTALLER_EXT" >> $GITHUB_ENV
-          fi
+        if [ "${{ matrix.build_type }}" = "full" ]; then
+          echo "ARTIFACT_PATTERN=Overte-PR${{ github.event.number }}-${{ steps.buildenv1.outputs.github_sha_short }}.$INSTALLER_EXT" >> $GITHUB_ENV
+          echo "INSTALLER=Overte-$RELEASE_NUMBER-${{ steps.buildenv1.outputs.github_sha_short }}.$INSTALLER_EXT" >> $GITHUB_ENV
         else
-          echo "ARTIFACT_PATTERN=*.$INSTALLER_EXT" >> $GITHUB_ENV
+          echo "ARTIFACT_PATTERN=Overte-Interface-PR${{ github.event.number }}-${{ steps.buildenv1.outputs.github_sha_short }}.$INSTALLER_EXT" >> $GITHUB_ENV
+          echo "INSTALLER=Overte-Interface-$RELEASE_NUMBER-${{ steps.buildenv1.outputs.github_sha_short }}.$INSTALLER_EXT" >> $GITHUB_ENV
         fi
 
     - name: Clear Working Directory


### PR DESCRIPTION
This replaced the unmaintained GitHub Actions -> S3 uploader with GitHub Actions artifact storage.

Drawbacks are that they are only retained for 90 days, they are less obvious to find, and the already compressed files get compressed again.

Keep in mind that master build don't require the S3 uploader server to upload to S3, so they aren't touched.

For Linux builds (and probably Android), I plan to switch to Woodpecker CI once it is stable enough, which can easily upload to S3.