### PR TITLE
Fix "may be used uninitialized" warning for blendtime

### DIFF
--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -123,7 +123,7 @@ public:
     void overrideAnimation(const QString& url, float fps, bool loop, float firstFrame, float lastFrame);
     bool isPlayingOverrideAnimation() const { return _userAnimState.clipNodeEnum != UserAnimState::None; };
     void restoreAnimation();
-    
+
     void overrideHandAnimation(bool isLeft, const QString& url, float fps, bool loop, float firstFrame, float lastFrame);
     void restoreHandAnimation(bool isLeft);
 
@@ -371,7 +371,7 @@ protected:
         };
         NetworkAnimState() : clipNodeEnum(NetworkAnimState::None), fps(30.0f), loop(false), firstFrame(0.0f), lastFrame(0.0f), blendTime(FLT_MAX) {}
         NetworkAnimState(ClipNodeEnum clipNodeEnumIn, const QString& urlIn, float fpsIn, bool loopIn, float firstFrameIn, float lastFrameIn) :
-            clipNodeEnum(clipNodeEnumIn), url(urlIn), fps(fpsIn), loop(loopIn), firstFrame(firstFrameIn), lastFrame(lastFrameIn) {}
+            clipNodeEnum(clipNodeEnumIn), url(urlIn), fps(fpsIn), loop(loopIn), firstFrame(firstFrameIn), lastFrame(lastFrameIn), blendTime(FLT_MAX) {}
 
         ClipNodeEnum clipNodeEnum;
         QString url;


### PR DESCRIPTION
Fixes this warning:

```
In file included from /home/dale/git/vircadia/overte/libraries/animation/src/Rig.cpp:12:
In member function ‘Rig::NetworkAnimState& Rig::NetworkAnimState::operator=(Rig::NetworkAnimState&&)’,
    inlined from ‘Rig::initAnimGraph(const QUrl&)::<lambda(AnimNode::Pointer)>’ at /home/dale/git/vircadia/overte/libraries/animation/src/Rig.cpp:2497:92,
    inlined from ‘static void QtPrivate::FunctorCall<QtPrivate::IndexesList<II ...>, QtPrivate::List<Tail ...>, R, Function>::call(Function&, void**) [with int ...II = {0}; SignalArgs = {std::shared_ptr<AnimNode>}; R = void; Function = Rig::initAnimGraph(const QUrl&)::<lambda(AnimNode::Pointer)>]’ at /usr/include/qt5/QtCore/qobjectdefs_impl.h:146:14,
    inlined from ‘static void QtPrivate::Functor<Function, N>::call(Function&, void*, void**) [with SignalArgs = QtPrivate::List<std::shared_ptr<AnimNode> >; R = void; Function = Rig::initAnimGraph(const QUrl&)::<lambda(AnimNode::Pointer)>; int N = 1]’ at /usr/include/qt5/QtCore/qobjectdefs_impl.h:256:83,
    inlined from ‘static void QtPrivate::QFunctorSlotObject<Func, N, Args, R>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) [with Func = Rig::initAnimGraph(const QUrl&)::<lambda(AnimNode::Pointer)>; int N = 1; Args = QtPrivate::List<std::shared_ptr<AnimNode> >; R = void]’ at /usr/include/qt5/QtCore/qobjectdefs_impl.h:443:49:
/home/dale/git/vircadia/overte/libraries/animation/src/Rig.h:363:12: warning: ‘<anonymous>.Rig::NetworkAnimState::blendTime’ may be used uninitialized [-Wmaybe-uninitialized]
  363 |     struct NetworkAnimState {
      |            ^~~~~~~~~~~~~~~~
/home/dale/git/vircadia/overte/libraries/animation/src/Rig.cpp: In static member function ‘static void QtPrivate::QFunctorSlotObject<Func, N, Args, R>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) [with Func = Rig::initAnimGraph(const QUrl&)::<lambda(AnimNode::Pointer)>; int N = 1; Args = QtPrivate::List<std::shared_ptr<AnimNode> >; R = void]’:
/home/dale/git/vircadia/overte/libraries/animation/src/Rig.cpp:2497:92: note: ‘<anonymous>’ declared here
 2497 |                 _networkAnimState = { NetworkAnimState::None, "", 30.0f, false, 0.0f, 0.0f };
      |                       
```