### PR TITLE
Made ExtractionMode::SphereCollapse fail more gracefully in case of incorrect data

### DIFF
--- a/libraries/physics/src/MultiSphereShape.cpp
+++ b/libraries/physics/src/MultiSphereShape.cpp
@@ -243,8 +243,12 @@ MultiSphereShape::CollapsingMode MultiSphereShape::computeSpheres(ExtractionMode
         break;
     case ExtractionMode::SphereCollapse:
         sphere._radius = 0.5f * glm::min(glm::min(dimensions.x, dimensions.y), dimensions.z);
-        sphere._position = glm::vec3(0.0f);
-        _spheres.push_back(sphere);
+        if (sphere._radius > 0.0f) {
+            sphere._position = glm::vec3(0.0f);
+            _spheres.push_back(sphere);
+        } else {
+            qDebug() << "MultiSphereShape::computeSpheres in mode ExtractionMode::SphereCollapse generated sphere with zero radius";
+        }
         break;
     case ExtractionMode::SpheresX:
         axis = 0.5f* dimensions.x * Vectors::UNIT_NEG_X;


### PR DESCRIPTION
This fixes https://github.com/overte-org/overte/issues/277