### PR TITLE
Make NEW MAX ELAPSED AVERAGE trigger less sensitive

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -441,7 +441,7 @@ public:
             auto lastHeartbeatAge = (now > lastHeartbeat) ? now - lastHeartbeat : 0;
             auto elapsedMovingAverage = _movingAverage.getAverage();
 
-            if (elapsedMovingAverage > _maxElapsedAverage) {
+            if (elapsedMovingAverage > _maxElapsedAverage * 1.1f) {
 #if !defined(NDEBUG)
                 qCDebug(interfaceapp_deadlock) << "DEADLOCK WATCHDOG WARNING:"
                     << "lastHeartbeatAge:" << lastHeartbeatAge


### PR DESCRIPTION
In current master branch on Linux it's spamming thousands of such messages in the log:
```
[12/16 07:37:14] [DEBUG] [hifi.interface.deadlock] DEADLOCK WATCHDOG WARNING: lastHeartbeatAge: 41783 elapsedMovingAverage: 2382 maxElapsed: 998484 PREVIOUS maxElapsedAverage: 2381 NEW maxElapsedAverage: 2382 ** NEW MAX ELAPSED AVERAGE ** samples: 5187
[12/16 07:37:15] [DEBUG] [hifi.interface.deadlock] DEADLOCK WATCHDOG WARNING: lastHeartbeatAge: 40046 elapsedMovingAverage: 2385 maxElapsed: 998484 PREVIOUS maxElapsedAverage: 2382 NEW maxElapsedAverage: 2385 ** NEW MAX ELAPSED AVERAGE ** samples: 5197
[12/16 07:37:16] [DEBUG] [hifi.interface.deadlock] DEADLOCK WATCHDOG WARNING: lastHeartbeatAge: 40154 elapsedMovingAverage: 2386 maxElapsed: 998484 PREVIOUS maxElapsedAverage: 2385 NEW maxElapsedAverage: 2386 ** NEW MAX ELAPSED AVERAGE ** samples: 5207
[12/16 07:37:17] [DEBUG] [hifi.interface.deadlock] DEADLOCK WATCHDOG WARNING: lastHeartbeatAge: 40164 elapsedMovingAverage: 2387 maxElapsed: 998484 PREVIOUS maxElapsedAverage: 2386 NEW maxElapsedAverage: 2387 ** NEW MAX ELAPSED AVERAGE ** samples: 5217
```
This PR makes it trigger less often. New trigger level is always set to 110% of the last triggered value instead of last triggered value + 1, which means it's still useful but it doesn't make log unreadable anymore.