### PR TITLE
GitHub Actions Doxygen update

### DIFF
--- a/.github/workflows/master_deploy_doxygen.yml
+++ b/.github/workflows/master_deploy_doxygen.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Overte e.V.
+# Copyright 2022-2023 Overte e.V.
 # SPDX-License-Identifier: MIT
 
 name: Master Doxygen CI Build and Deploy
@@ -10,11 +10,11 @@ on:
 
 jobs:
   build_doxygen:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     name: Build and deploy Doxygen documentation
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |
@@ -29,7 +29,7 @@ jobs:
         doxygen Doxyfile
 
     - name: Deploy Doxygen
-      uses: SamKirkland/FTP-Deploy-Action@4.3.0
+      uses: SamKirkland/FTP-Deploy-Action@4.3.3
       with:
         server: ftp.tuxfamily.org
         username: ${{ secrets.GHA_JSDOC_FTP_USER }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 <p align="center">
     <a href="https://github.com/overte-org/overte/actions/workflows/master_build.yml"><img alt="Master CI Build" src="https://github.com/overte-org/overte/actions/workflows/master_build.yml/badge.svg"></a>
     <a href="https://github.com/overte-org/overte/actions/workflows/master_deploy_apidocs.yml"><img alt="API-docs CI Build & Deploy" src="https://github.com/overte-org/overte/actions/workflows/master_deploy_apidocs.yml/badge.svg"></a>
+    <a href="https://github.com/overte-org/overte/actions/workflows/master_deploy_doxygen.yml"><img alt="Doxygen CI Build & Deploy" src="https://github.com/overte-org/overte/actions/workflows/master_deploy_doxygen.yml/badge.svg"></a>
     <a href="https://api.reuse.software/info/github.com/overte-org/overte"><img alt="REUSE status" src="https://api.reuse.software/badge/github.com/overte-org/overte"></a>
 </p>
 


### PR DESCRIPTION
Updates to Ubuntu 22.04 for newer Doxygen and updates Actions to fix nodejs12 depreciation warning.
This also adds the Doxygen build and deploy status into the README.md

The build log can be viewed here: https://github.com/overte-org/overte/actions/runs/4092176102/jobs/7056729547
The result is currently on https://doxygen.overte.org

Closes #312 