### PR TITLE
Remove Vircadia, add metax.zone from the federation.json

### DIFF
--- a/scripts/system/places/federation.json
+++ b/scripts/system/places/federation.json
@@ -1,4 +1,4 @@
 [
-    {"node": "https://metaverse.vircadia.com/live"},
-    {"node": "https://mv.overte.org/server"}
+    {"node": "https://mv.overte.org/server"},
+    {"node": "https://api.mv.metax.zone"}
 ]


### PR DESCRIPTION
This PR remove Vircadia from the Federation (Since it is not really part of a federation when it is one way and not even working with us) This PR also add "https://api.mv.metax.zone" as part of the federation (minimally for testing/development) 

**To merge only if everyone agree about this.**

Note: Vircadia should remain in the place app as an "external" region for those who lock it in the create app. It will be up to them to keep it or let it go.

![image](https://user-images.githubusercontent.com/60075796/219829435-ba5b325c-019b-45f2-936d-70eec7b93f42.png)
