### PR TITLE
Improve V8 logging

### DIFF
--- a/libraries/script-engine/src/ScriptEngineCast.h
+++ b/libraries/script-engine/src/ScriptEngineCast.h
@@ -70,7 +70,7 @@ inline QVariant scriptvalue_cast<QVariant>(const ScriptValue& value) {
     return value.toVariant();
 }
 
-//#define MARSHAL_MACRO(FUNCTION, TYPE) +[FUNCTION](ScriptEngine* engine, const void* p) -> ScriptValue { FUNCTION(engine, *(static_cast<const TYPE*>(p)) ); } 
+//#define MARSHAL_MACRO(FUNCTION, TYPE) +[FUNCTION](ScriptEngine* engine, const void* p) -> ScriptValue { FUNCTION(engine, *(static_cast<const TYPE*>(p)) ); }
 
 template <typename T, ScriptValue (*f)(ScriptEngine*, const T&)>
 ScriptValue toScriptValueWrapper(ScriptEngine* engine, const void *p) {
@@ -153,12 +153,12 @@ ScriptValue scriptValueFromEnumClass(ScriptEngine* eng, const T& enumValue) {
 template <class T>
 bool scriptValueToEnumClass(const ScriptValue& value, T& enumValue) {
     if(!value.isNumber()){
-        qDebug() << "ScriptValue \"" << value.toQObject()->metaObject()->className() << "\" is not a number";
+        qCDebug(scriptengine) << "ScriptValue \"" << value.toQObject()->metaObject()->className() << "\" is not a number";
         return false;
     }
     QMetaEnum metaEnum = QMetaEnum::fromType<T>();
     if (!metaEnum.isValid()) {
-        qDebug() << "Invalid QMetaEnum";
+        qCDebug(scriptengine) << "Invalid QMetaEnum";
         return false;
     }
     bool isValid = false;
@@ -173,7 +173,7 @@ bool scriptValueToEnumClass(const ScriptValue& value, T& enumValue) {
         enumValue = static_cast<T>(enumInteger);
         return true;
     } else {
-        qDebug() << "ScriptValue has invalid value " << value.toInteger() << " for enum" << metaEnum.name();
+        qCDebug(scriptengine) << "ScriptValue has invalid value " << value.toInteger() << " for enum" << metaEnum.name();
         return false;
     }
 }

--- a/libraries/script-engine/src/ScriptEngineLogging.cpp
+++ b/libraries/script-engine/src/ScriptEngineLogging.cpp
@@ -11,6 +11,7 @@
 
 #include "ScriptEngineLogging.h"
 
-Q_LOGGING_CATEGORY(scriptengine, "hifi.scriptengine")
-Q_LOGGING_CATEGORY(scriptengine_module, "hifi.scriptengine.module")
-Q_LOGGING_CATEGORY(scriptengine_script, "hifi.scriptengine.script")
+Q_LOGGING_CATEGORY(scriptengine, "overte.scriptengine")
+Q_LOGGING_CATEGORY(scriptengine_module, "overte.scriptengine.module")
+Q_LOGGING_CATEGORY(scriptengine_script, "overte.scriptengine.script")
+

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -360,7 +360,7 @@ void ScriptEngines::loadScripts() {
 void ScriptEngines::saveScripts() {
     // Do not save anything if we are in the process of shutting down
     if (qApp->closingDown()) {
-        qWarning() << "Trying to save scripts during shutdown.";
+        qCWarning(scriptengine) << "Trying to save scripts during shutdown.";
         return;
     }
 

--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -1118,7 +1118,7 @@ void ScriptManager::timerFired() {
 
     _timerCallCounter++;
     if (_timerCallCounter % 100 == 0) {
-        qDebug() << "Script engine: " << _engine->manager()->getFilename()
+        qCDebug(scriptengine) << "Script engine: " << _engine->manager()->getFilename()
                  << "timer call count: " << _timerCallCounter << " total time: " << _totalTimeInTimerEvents_s;
     }
     QElapsedTimer callTimer;
@@ -1201,7 +1201,7 @@ void ScriptManager::stopTimer(QTimer *timer) {
 }
 
 QUrl ScriptManager::resolvePath(const QString& include) const {
-    //qDebug(scriptengine) << "ScriptManager::resolvePath: getCurrentScriptURLs: " << _engine->getCurrentScriptURLs();
+    //qCDebug(scriptengine) << "ScriptManager::resolvePath: getCurrentScriptURLs: " << _engine->getCurrentScriptURLs();
     QUrl url(include);
     // first lets check to see if it's already a full URL -- or a Windows path like "c:/"
     if (include.startsWith("/") || url.scheme().length() == 1) {
@@ -1219,7 +1219,7 @@ QUrl ScriptManager::resolvePath(const QString& include) const {
     do {
         auto contextInfo = context->functionContext();
         parentURL = QUrl(contextInfo->fileName());
-        //qDebug(scriptengine) << "ScriptManager::resolvePath: URL get: " << parentURL << " backtrace: " << context->backtrace() << " " << _engine->getCurrentScriptURLs();
+        //qCDebug(scriptengine) << "ScriptManager::resolvePath: URL get: " << parentURL << " backtrace: " << context->backtrace() << " " << _engine->getCurrentScriptURLs();
         parentContext = context->parentContext();
         context = parentContext.get();
     } while (parentURL.isRelative() && context);
@@ -1420,7 +1420,7 @@ ScriptValue ScriptManager::newModule(const QString& modulePath, const ScriptValu
     // module.require is a bound version of require that always resolves relative to that module's path
     auto boundRequire = _engine->evaluate("(function(id) { return Script.require(Script.require.resolve(id, this.filename)); })", "(boundRequire)");
     module.setProperty("require", boundRequire, READONLY_PROP_FLAGS);
-    //qDebug() << "Module object contents" << _engine->scriptValueDebugListMembers(module);
+    //qCDebug(scriptengine) << "Module object contents" << _engine->scriptValueDebugListMembers(module);
     return module;
 }
 
@@ -1818,12 +1818,12 @@ QVariant ScriptManager::cloneEntityScriptDetails(const EntityItemID& entityID) {
         map["errorInfo"] = "Error: getEntityScriptDetails -- invalid entityID";
     } else {
 #ifdef DEBUG_ENTITY_STATES
-        qDebug() << "cloneEntityScriptDetails" << entityID << QThread::currentThread();
+        qCDebug(scriptengine) << "cloneEntityScriptDetails" << entityID << QThread::currentThread();
 #endif
         EntityScriptDetails scriptDetails;
         if (getEntityScriptDetails(entityID, scriptDetails)) {
 #ifdef DEBUG_ENTITY_STATES
-            qDebug() << "gotEntityScriptDetails" << scriptDetails.status << QThread::currentThread();
+            qCDebug(scriptengine) << "gotEntityScriptDetails" << scriptDetails.status << QThread::currentThread();
 #endif
             map["isRunning"] = isEntityScriptRunning(entityID);
             map["status"] = EntityScriptStatus_::valueToKey(scriptDetails.status).toLower();
@@ -1841,7 +1841,7 @@ QVariant ScriptManager::cloneEntityScriptDetails(const EntityItemID& entityID) {
 #endif
         } else {
 #ifdef DEBUG_ENTITY_STATES
-            qDebug() << "!gotEntityScriptDetails" <<  QThread::currentThread();
+            qCDebug(scriptengine) << "!gotEntityScriptDetails" <<  QThread::currentThread();
 #endif
             map["isError"] = true;
             map["errorInfo"] = "Entity script details unavailable";
@@ -2130,7 +2130,7 @@ void ScriptManager::entityScriptContentAvailable(const EntityItemID& entityID, c
         }
       // ENTITY SCRIPT WHITELIST ENDS HERE, uncomment below for original full disabling.
 
-      // qDebug() << "(disabled entity script)" << entityID.toString() << scriptOrURL;
+      // qCDebug(scriptengine) << "(disabled entity script)" << entityID.toString() << scriptOrURL;
       // exception = makeError("UNSAFE_ENTITY_SCRIPTS == 0");
     }
 
@@ -2421,7 +2421,7 @@ void ScriptManager::callEntityScriptMethod(const EntityItemID& entityID, const Q
                 }
             }
             if (!callAllowed) {
-                qDebug() << "Method [" << methodName << "] not remotely callable.";
+                qCDebug(scriptengine) << "Method [" << methodName << "] not remotely callable.";
             }
         }
 

--- a/libraries/script-engine/src/ScriptManager.h
+++ b/libraries/script-engine/src/ScriptManager.h
@@ -259,7 +259,7 @@ public:
  *
  * ScriptManagerPointer sm = newScriptManager(ScriptManager::NETWORKLESS_TEST_SCRIPT, scriptSource, scriptFilename);
  * connect(sm.get(), &ScriptManager::printedMessage, [](const QString& message, const QString& engineName){
- *     qDebug() << "Printed message from engine" << engineName << ": " << message;
+ *     qCDebug(scriptengine) << "Printed message from engine" << engineName << ": " << message;
  * });
  *
  * qInfo() << "Running script!";

--- a/libraries/script-engine/src/ScriptValue.h
+++ b/libraries/script-engine/src/ScriptValue.h
@@ -26,6 +26,8 @@
 #include <QtCore/QVariant>
 #include <QtCore/QDebug>
 
+#include "ScriptEngineLogging.h"
+
 class ScriptEngine;
 class ScriptValue;
 class ScriptValueIterator;
@@ -210,7 +212,7 @@ ScriptValue ScriptValue::call(const ScriptValue& thisObject, const ScriptValueLi
     Q_ASSERT(_proxy != nullptr);
     ScriptEnginePointer scriptEngine = _proxy->engine();
     if (scriptEngine == nullptr) {
-        qDebug() << "Call to deleted or non-existing script engine";
+        qCDebug(scriptengine) << "Call to deleted or non-existing script engine";
         return ScriptValue();
     }
     return _proxy->call(thisObject, args);

--- a/libraries/script-engine/src/ScriptValueUtils.cpp
+++ b/libraries/script-engine/src/ScriptValueUtils.cpp
@@ -933,7 +933,7 @@ ScriptValue meshesToScriptValue(ScriptEngine* engine, const MeshProxyList& in) {
 bool meshesFromScriptValue(const ScriptValue& value, MeshProxyList& out) {
     ScriptValueIteratorPointer itr(value.newIterator());
 
-    qDebug(scriptengine) << "in meshesFromScriptValue, value.length =" << value.property("length").toInt32();
+    qCDebug(scriptengine) << "in meshesFromScriptValue, value.length =" << value.property("length").toInt32();
 
     while (itr->hasNext()) {
         itr->next();
@@ -941,7 +941,7 @@ bool meshesFromScriptValue(const ScriptValue& value, MeshProxyList& out) {
         if (meshProxy) {
             out.append(meshProxy);
         } else {
-            qDebug(scriptengine) << "null meshProxy";
+            qCDebug(scriptengine) << "null meshProxy";
         }
     }
     return true;

--- a/libraries/script-engine/src/Vec3.cpp
+++ b/libraries/script-engine/src/Vec3.cpp
@@ -26,7 +26,7 @@
 #include "ScriptManager.h"
 
 Vec3::~Vec3() {
-    qDebug(scriptengine) << "ScriptMethodV8Proxy destroyed";
+    qCDebug(scriptengine) << "ScriptMethodV8Proxy destroyed";
     printf("ScriptMethodV8Proxy destroyed");
 }
 
@@ -55,14 +55,14 @@ glm::vec3 Vec3::toPolar(const glm::vec3& v) {
     if (glm::abs(radius) < EPSILON) {
         return glm::vec3(0.0f, 0.0f, 0.0f);
     }
-    
+
     glm::vec3 u = v / radius;
-    
+
     float elevation, azimuth;
-    
+
     elevation = glm::asin(-u.y);
     azimuth = atan2(v.x, v.z);
-    
+
     // Round off small decimal values
     if (glm::abs(elevation) < EPSILON) {
         elevation = 0.0f;

--- a/libraries/script-engine/src/v8/ScriptContextV8Wrapper.cpp
+++ b/libraries/script-engine/src/v8/ScriptContextV8Wrapper.cpp
@@ -16,6 +16,8 @@
 
 #include "ScriptEngineV8.h"
 #include "ScriptValueV8Wrapper.h"
+#include "ScriptEngineLoggingV8.h"
+
 
 /*ScriptContextV8Wrapper::ScriptContextV8Wrapper(ScriptEngineV8* engine, const v8::Local<v8::Context> context) : _functionCallbackInfo(nullptr), _propertyCallbackInfo(nullptr), _engine(engine) {
     _context.Reset(_engine->getIsolate(), context);
@@ -178,7 +180,7 @@ ScriptValue ScriptContextV8Wrapper::throwError(const QString& text) {
                                  v8::String::NewFromUtf8(_engine->getIsolate(), text.toStdString().c_str()).ToLocalChecked()));
         return ScriptValue(new ScriptValueV8Wrapper(_engine, std::move(result)));
     } else {
-        qWarning() << "throwError on a different thread not implemented yet, error value: " << text;
+        qCWarning(scriptengine_v8) << "throwError on a different thread not implemented yet, error value: " << text;
         //return _engine->undefinedValue();
         return ScriptValue();
     }

--- a/libraries/script-engine/src/v8/ScriptEngineLoggingV8.cpp
+++ b/libraries/script-engine/src/v8/ScriptEngineLoggingV8.cpp
@@ -1,0 +1,17 @@
+//
+//  ScriptEngineLoggingV8.cpp
+//  libraries/script-engine/src/v8
+//
+//  Created by Dale Glass on 06/03/2023
+//  Copyright 2023 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "ScriptEngineLoggingV8.h"
+
+Q_LOGGING_CATEGORY(scriptengine_v8, "overte.scriptengine.v8")
+Q_LOGGING_CATEGORY(scriptengine_module_v8, "overte.scriptengine.module.v8")
+Q_LOGGING_CATEGORY(scriptengine_script_v8, "overte.scriptengine.script.v8")
+

--- a/libraries/script-engine/src/v8/ScriptEngineLoggingV8.h
+++ b/libraries/script-engine/src/v8/ScriptEngineLoggingV8.h
@@ -1,0 +1,25 @@
+//
+//  ScriptEngineLoggingV8.h
+//  libraries/script-engine/src/v8
+//
+//  Created by Dale Glass on 06/03/2023
+//  Copyright 2023 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/// @addtogroup ScriptEngine
+/// @{
+
+#pragma once
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(scriptengine_v8)
+Q_DECLARE_LOGGING_CATEGORY(scriptengine_module_v8)
+Q_DECLARE_LOGGING_CATEGORY(scriptengine_script_v8)
+
+
+
+/// @}

--- a/libraries/script-engine/src/v8/ScriptProgramV8Wrapper.cpp
+++ b/libraries/script-engine/src/v8/ScriptProgramV8Wrapper.cpp
@@ -16,6 +16,7 @@
 
 #include "ScriptEngineV8.h"
 #include "ScriptValueV8Wrapper.h"
+#include "ScriptEngineLoggingV8.h"
 
 ScriptProgramV8Wrapper* ScriptProgramV8Wrapper::unwrap(ScriptProgramPointer val) {
     if (!val) {
@@ -53,13 +54,13 @@ bool ScriptProgramV8Wrapper::compile() {
     v8::ScriptOrigin scriptOrigin(isolate, v8::String::NewFromUtf8(isolate, _url.toStdString().c_str()).ToLocalChecked());
     v8::Local<v8::Script> script;
     if (v8::Script::Compile(context, v8::String::NewFromUtf8(isolate, _source.toStdString().c_str()).ToLocalChecked(), &scriptOrigin).ToLocal(&script)) {
-        qDebug() << "Script compilation successful: " << _url;
+        qCDebug(scriptengine_v8) << "Script compilation successful: " << _url;
         _compileResult = ScriptSyntaxCheckResultV8Wrapper(ScriptSyntaxCheckResult::Valid);
         _value = V8ScriptProgram(_engine, script);
         _isCompiled = true;
         return true;
     }
-    qDebug() << "Script compilation failed: " << _url;
+    qCDebug(scriptengine_v8) << "Script compilation failed: " << _url;
     v8::String::Utf8Value utf8Value(isolate, tryCatch.Exception());
     errorMessage = QString(*utf8Value);
     v8::Local<v8::Message> exceptionMessage = tryCatch.Message();

--- a/libraries/script-engine/src/v8/ScriptValueIteratorV8Wrapper.cpp
+++ b/libraries/script-engine/src/v8/ScriptValueIteratorV8Wrapper.cpp
@@ -13,6 +13,7 @@
 //
 
 #include "ScriptValueIteratorV8Wrapper.h"
+#include "ScriptEngineLoggingV8.h"
 
 V8ScriptValueIterator::V8ScriptValueIterator(ScriptEngineV8* engine, v8::Local<v8::Value> object) : _engine(engine)  {
     auto isolate = _engine->getIsolate();


### PR DESCRIPTION
This adds a V8 specific logging category.

It also renames the logging categories for scripting, and makes logging use categories everywhere in the scripting code.

This should make it easier to see what's going on at what layer in the code, and make for better log filtering.