### PR TITLE
Remove some .gitignore entries for in-source builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,18 +7,12 @@
 VideoDecodeStats
 
 # CMake
-CMakeCache.txt
-CMakeFiles/
-CMakeScripts/
-cmake_install.cmake
 build*/
 cmake-build-relwithdebinfo-visual-studio/
 release*/
 debug*/
 gprof*/
 valgrind*/
-ext/
-Makefile
 *.user
 
 # Android Studio


### PR DESCRIPTION
This PR removes some gitignore entries that only hit when you build in source.

It took me a while to figure out why CMake kept building in source, even though I had deleted all untracked files.

I tested that a build in `build/` wouldn't create any untracked files that aren't ignored with this.