### PR TITLE
Add QML_IMPORT_PATH for KDevelop and Qt Creator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,3 +512,6 @@ if (BUILD_INSTALLER)
   endif()
   generate_installers()
 endif()
+
+# QML import paths for Qt Creator and KDevelop code completion
+set(QML_IMPORT_PATH ${CMAKE_SOURCE_DIR}/interface/resources/qml;${CMAKE_SOURCE_DIR}/launchers/qt/resources/qml CACHE PATH "Extra QML import paths for KDevelop and Qt Creator")


### PR DESCRIPTION
This PR adds an QML_IMPORT_PATH to CMake, which tells KDevelop and Qt Creator where to find our custom QML modules.