### PR TITLE
Fix override warnings

### DIFF
--- a/libraries/script-engine/src/ScriptValue.cpp
+++ b/libraries/script-engine/src/ScriptValue.cpp
@@ -55,7 +55,7 @@ public:
                              const ScriptValue::PropertyFlags& flags = ScriptValue::KeepExistingFlags) override;
     virtual void setPrototype(const ScriptValue& prototype) override;
     virtual bool strictlyEquals(const ScriptValue& other) const override;
-    virtual inline QList<QString> getPropertyNames() const;
+    virtual inline QList<QString> getPropertyNames() const override;
 
     virtual bool toBool() const override;
     virtual qint32 toInt32() const override;

--- a/libraries/script-engine/src/v8/ScriptValueV8Wrapper.h
+++ b/libraries/script-engine/src/v8/ScriptValueV8Wrapper.h
@@ -69,7 +69,7 @@ public:  // ScriptValue implementation
                              const ScriptValue::PropertyFlags& flags = ScriptValue::KeepExistingFlags) override;
     virtual void setPrototype(const ScriptValue& prototype) override;
     virtual bool strictlyEquals(const ScriptValue& other) const override;
-    virtual QList<QString> getPropertyNames() const;
+    virtual QList<QString> getPropertyNames() const override;
 
     virtual bool equals(const ScriptValue& other) const override;
     virtual bool isArray() const override;


### PR DESCRIPTION
Fixes minor build warnings. Makes for a cleaner build, should have no effect.