### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -29,57 +29,57 @@ jobs:
       matrix:
         include:
           - os: debian-11
-            image: docker.io/overte/overte-server-build:0.1.2-debian-11-amd64
+            image: docker.io/overte/overte-server-build:0.1.3-debian-11-amd64
             arch: amd64
             runner: ubuntu-latest
 
           - os: debian-11
-            image: docker.io/overte/overte-server-build:0.1.2-debian-11-aarch64
+            image: docker.io/overte/overte-server-build:0.1.3-debian-11-aarch64
             arch: aarch64
             runner: linux_aarch64
 
           - os: ubuntu-18.04
-            image: docker.io/overte/overte-server-build:0.1.1-ubuntu-18.04-amd64
+            image: docker.io/overte/overte-server-build:0.1.3-ubuntu-18.04-amd64
             arch: amd64
             runner: ubuntu-latest
 
           - os: ubuntu-20.04
-            image: docker.io/overte/overte-server-build:0.1.1-ubuntu-20.04-amd64
+            image: docker.io/overte/overte-server-build:0.1.3-ubuntu-20.04-amd64
             arch: amd64
             runner: ubuntu-latest
 
           - os: ubuntu-22.04
-            image: docker.io/overte/overte-server-build:0.1.1-ubuntu-22.04-amd64
+            image: docker.io/overte/overte-server-build:0.1.3-ubuntu-22.04-amd64
             arch: amd64
             runner: ubuntu-latest
 
           - os: ubuntu-22.04
-            image: docker.io/overte/overte-server-build:0.1.1-ubuntu-22.04-aarch64
+            image: docker.io/overte/overte-server-build:0.1.3-ubuntu-22.04-aarch64
             arch: aarch64
             runner: linux_aarch64
 
           - os: fedora-36
-            image: docker.io/overte/overte-server-build:0.1.2-fedora-36-amd64
+            image: docker.io/overte/overte-server-build:0.1.3-fedora-36-amd64
             arch: amd64
             runner: ubuntu-latest
 
           - os: fedora-36
-            image: docker.io/overte/overte-server-build:0.1.2-fedora-36-aarch64
+            image: docker.io/overte/overte-server-build:0.1.3-fedora-36-aarch64
             arch: aarch64
             runner: linux_aarch64
 
           - os: fedora-37
-            image: docker.io/overte/overte-server-build:0.1.2-fedora-37-amd64
+            image: docker.io/overte/overte-server-build:0.1.3-fedora-37-amd64
             arch: amd64
             runner: ubuntu-latest
 
           - os: fedora-37
-            image: docker.io/overte/overte-server-build:0.1.2-fedora-37-aarch64
+            image: docker.io/overte/overte-server-build:0.1.3-fedora-37-aarch64
             arch: aarch64
             runner: linux_aarch64
 
           - os: rockylinux-9
-            image: docker.io/overte/overte-server-build:0.1.2-rockylinux-9-amd64
+            image: docker.io/overte/overte-server-build:0.1.3-rockylinux-9-amd64
             arch: amd64
             runner: ubuntu-latest
 

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -41,8 +41,8 @@ jobs:
         include:
           - os: windows-2019
             build_type: full
-          - os: macOS-10.15
-            build_type: full
+          #- os: macOS-10.15
+          #  build_type: full
           - os: ubuntu-20.04
             build_type: full
             apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion3 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-github python3-distro

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -259,7 +259,7 @@ jobs:
         cmake --build . --config $BUILD_TYPE --target packaged-server-console $CMAKE_BUILD_EXTRA
 
     - name: Build Installer
-      if: matrix.build_type != 'android'
+      if: matrix.build_type != 'android' && matrix.arch != 'aarch64'
       working-directory: build
       shell: bash
       run: |

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -48,9 +48,9 @@ jobs:
           include:
             - os: windows-2019
               build_type: full
-            - os: macOS-10.15
-              build_type: full
             - os: ubuntu-20.04
+            #- os: macOS-10.15
+            #  build_type: full
               build_type: full
               apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion3 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-distro
             # Android builds are currently failing

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   build_pr:
-    name: "${{matrix.os}}, ${{matrix.build_type}}"
+    name: "${{matrix.os}}, ${{matrix.arch}}"
     strategy:
         matrix:
           include:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -155,12 +155,6 @@ jobs:
           echo "INSTALLER=Overte-Interface-$RELEASE_NUMBER-${GIT_COMMIT_SHORT}.$INSTALLER_EXT" >> $GITHUB_ENV
         fi
 
-    - name: Clear Working Directory
-      if: startsWith(matrix.os, 'windows') || contains(matrix.os, 'self-hosted')
-      shell: bash
-      working-directory: ${{runner.workspace}}
-      run: rm -rf ./*
-
     - uses: actions/checkout@v3
       with:
         submodules: false

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -46,11 +46,15 @@ jobs:
     strategy:
         matrix:
           include:
-            - os: windows-2019
+            - os: Windows 2019
+              runner: windows-2019
+              arch: x86_64
               build_type: full
-            - os: ubuntu-20.04
             #- os: macOS-10.15
             #  build_type: full
+            - os: Ubuntu 20.04
+              runner: ubuntu-20.04
+              arch: amd64
               build_type: full
               apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion3 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-distro
             # Android builds are currently failing
@@ -58,11 +62,14 @@ jobs:
             #  build_type: android
             #  apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 python3-github python3-distro
             # Do not change the names of self-hosted runners without knowing what you are doing, as they correspond to labels that have to be set on the runner.
-            - os: self-hosted_debian-11_aarch64
+            - os: Ubuntu 22.04
+              runner: linux_aarch64
+              arch: aarch64
               build_type: full
-              apt-dependencies: qtbase5-dev qtbase5-private-dev qtwebengine5-dev qtwebengine5-dev-tools qtmultimedia5-dev libqt5opengl5-dev qtscript5-dev libqt5scripttools5 libqt5webchannel5-dev libqt5websockets5-dev qtxmlpatterns5-dev-tools qttools5-dev libqt5xmlpatterns5-dev libqt5svg5-dev qml-module-qtwebchannel build-essential cmake curl freeglut3-dev git libasound2 libasound2-dev libdouble-conversion-dev libdrm-dev libfontconfig1 libgl1-mesa-dev libglvnd-dev libharfbuzz-dev libjack-dev libjack0 libnspr4 libnss3 libpcre2-16-0 libpulse0 libsdl2-dev libssl-dev libudev-dev libxcb-xinerama0-dev libxcb-xinput0 libxcomposite1 libxcursor1 libxi-dev libxmu-dev libxrandr-dev libxslt1.1 libxtst6 make mesa-common-dev mesa-utils nodejs npm patchelf python2 python3 python3-distro xdg-user-dirs zlib1g-dev ninja-build zip python3-distro
+              image: docker.io/overte/overte-full-build:0.1.1-ubuntu-22.04-aarch64
         fail-fast: false
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.runner}}
+    container: ${{matrix.image}}
     steps:
     - name: Configure Build Environment 1
       shell: bash
@@ -75,19 +82,18 @@ jobs:
         echo "APP_TARGET_NAME=$APP_NAME" >> $GITHUB_ENV
 
         # Linux build variables
-        if [[ "${{ matrix.os }}" = "ubuntu-"* || "${{ matrix.os }}" = *"debian"* ]]; then
+        if [[ "${{ matrix.os }}" = "Ubuntu"* ]]; then
           echo "PYTHON_EXEC=python3" >> $GITHUB_ENV
           echo "INSTALLER_EXT=*" >> $GITHUB_ENV
           echo "CMAKE_BUILD_EXTRA=-- -j$(nproc)" >> $GITHUB_ENV
           # Don't optimize builds to save build time.
           echo "OVERTE_OPTIMIZE=false" >> $GITHUB_ENV
-          # Variables specific to our aarch64 runner
-          if [ "${{ matrix.os }}" = "self-hosted_debian-11_aarch64" ]; then
+          # Starting with Ubuntu 22.04 we can use system Qt
+          if [[ "${{ matrix.image }}" = *"ubuntu-22.04"* ]]; then
             echo "OVERTE_USE_SYSTEM_QT=true" >> $GITHUB_ENV
-            echo "CI_WORKSPACE=${{runner.workspace}}" >> $GITHUB_ENV
           fi
 
-          if [[ "${{ matrix.os }}" = *"aarch64" ]]; then
+          if [[ "${{ matrix.arch }}" = "aarch64" ]]; then
             echo "VCPKG_FORCE_SYSTEM_BINARIES=true" >> $GITHUB_ENV
             if [ "${{ matrix.build_type }}" = "full" ]; then
               echo "CMAKE_EXTRA=-DOVERTE_CPU_ARCHITECTURE= -DBUILD_TOOLS:BOOLEAN=FALSE -DHIFI_PYTHON_EXEC:FILEPATH=$(which python3)" >> $GITHUB_ENV
@@ -97,7 +103,7 @@ jobs:
 
           fi
 
-          if [[ "${{ matrix.os }}" != *"aarch64" ]]; then
+          if [[ "${{ matrix.arch }}" = "amd64" ]]; then
             if [ "${{ matrix.build_type }}" = "full" ]; then
               echo "CMAKE_EXTRA=-DOVERTE_CPU_ARCHITECTURE=-msse3 -DBUILD_TOOLS:BOOLEAN=FALSE -DHIFI_PYTHON_EXEC:FILEPATH=$(which python3)" >> $GITHUB_ENV
             else
@@ -118,7 +124,7 @@ jobs:
           echo "APP_TARGET_NAME=Overte" >> $GITHUB_ENV
         fi
         # Windows build variables
-        if [ "${{ matrix.os }}" = "windows-2019" ]; then
+        if [ "${{ matrix.os }}" = "Windows 2019" ]; then
           echo "PYTHON_EXEC=python" >> $GITHUB_ENV
           echo "INSTALLER_EXT=exe" >> $GITHUB_ENV
           if [ "${{ matrix.build_type }}" = "full" ]; then
@@ -155,16 +161,16 @@ jobs:
       working-directory: ${{runner.workspace}}
       run: rm -rf ./*
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
       with:
         submodules: false
         fetch-depth: 1
 
     - name: Install dependencies
       shell: bash
-      if: startsWith(matrix.os, 'ubuntu') || contains(matrix.os, 'debian') || startsWith(matrix.os, 'macOS')
+      if: startsWith(matrix.os, 'Ubuntu') || contains(matrix.os, 'Debian') || startsWith(matrix.os, 'macOS')
       run: |
-        if [[ "${{ matrix.os }}" =~ "ubuntu" || "${{ matrix.os }}" =~ "debian" ]]; then
+        if [[ "${{ matrix.os }}" =~ "Ubuntu" || "${{ matrix.os }}" =~ "Debian" ]]; then
 
           echo "Updating apt repository index"
           sudo apt update || exit 1
@@ -187,7 +193,7 @@ jobs:
           sudo cp -rp MacOSX10.12.sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ || exit 0
           echo "  done"
         fi
-        if [[ "${{ matrix.os }}" =~ "debian-11" ]]; then
+        if [[ "${{ matrix.os }}" =~ "Debian 11" ]]; then
           echo "Installing CMake from Debian Backports"
           echo deb http://deb.debian.org/debian bullseye-backports main > /etc/apt/sources.list.d/bullseye-backports.list
           sudo apt update
@@ -197,20 +203,20 @@ jobs:
 
     - name: Override NSIS
       shell: pwsh
-      if: startsWith(matrix.os, 'windows')
+      if: startsWith(matrix.os, 'Windows')
       run: choco install nsis --version=3.06.1
 
     - name: Install Python modules
-      if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')
+      if: startsWith(matrix.os, 'Windows') || startsWith(matrix.os, 'macOS')
       shell: bash
       run: $PYTHON_EXEC -m pip install boto3 PyGithub
 
     - name: Create Build Environment
       shell: bash
-      run: cmake -E make_directory "${{runner.workspace}}/build"
+      run: cmake -E make_directory ./build
 
     - name: Configure CMake
-      working-directory: ${{runner.workspace}}/build
+      working-directory: build
       shell: bash
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DVCPKG_BUILD_TYPE=release $CMAKE_EXTRA
 
@@ -223,48 +229,44 @@ jobs:
         else
           TAR=tar
         fi
-
-        if [ ${{ env.CI_WORKSPACE }} ]; then
-          find "$CI_WORKSPACE/overte-files/vcpkg" -name '*log' -type f -print0 | $TAR --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz"
-        else
-          find "$HOME/overte-files/vcpkg" -name '*log' -type f -print0 | $TAR --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz"
-        fi
+          find "$HOME/overte-files/vcpkg" -name '*log' -type f -print0 | $TAR --null --force-local -T - -c --xz -v -f "./cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz"
 
     - name: Archive cmake logs
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz
-        path: ${{ runner.workspace }}/cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz
+        path: ./cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz
         if-no-files-found: error
 
     - name: Build Application
       if: matrix.build_type == 'full' || matrix.build_type == 'client'
-      working-directory: ${{runner.workspace}}/build
+      working-directory: build
       shell: bash
       run: cmake --build . --config $BUILD_TYPE --target $APP_TARGET_NAME $CMAKE_BUILD_EXTRA
 
     - name: Build Domain Server
       if: matrix.build_type == 'full'
-      working-directory: ${{runner.workspace}}/build
+      working-directory: build
       shell: bash
       run: cmake --build . --config $BUILD_TYPE --target domain-server $CMAKE_BUILD_EXTRA
 
     - name: Build Assignment Client
       if: matrix.build_type == 'full'
-      working-directory: ${{runner.workspace}}/build
+      working-directory: build
       shell: bash
       run: cmake --build . --config $BUILD_TYPE --target assignment-client $CMAKE_BUILD_EXTRA
 
     - name: Build Console
-      if: matrix.build_type == 'full' || startsWith(matrix.os, 'windows')
-      working-directory: ${{runner.workspace}}/build
+      if: matrix.build_type == 'full' && matrix.arch != 'aarch64' || startsWith(matrix.os, 'windows')
+      working-directory: build
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE --target packaged-server-console $CMAKE_BUILD_EXTRA
+      run: |
+        cmake --build . --config $BUILD_TYPE --target packaged-server-console $CMAKE_BUILD_EXTRA
 
     - name: Build Installer
       if: matrix.build_type != 'android'
-      working-directory: ${{runner.workspace}}/build
+      working-directory: build
       shell: bash
       run: |
         echo "Retry code from https://unix.stackexchange.com/a/137639"
@@ -315,22 +317,22 @@ jobs:
 
     - name: Output system stats
       if: ${{ always() }}
-      working-directory: ${{runner.workspace}}/build
+      working-directory: build
       shell: bash
       run: |
         echo "Disk usage:"
         df -h
 
     - name: Output Installer Logs
-      if: failure() && startsWith(matrix.os, 'windows')
+      if: failure() && startsWith(matrix.os, 'Windows')
       shell: bash
-      working-directory: ${{runner.workspace}}/build
+      working-directory: build
       run: cat ./_CPack_Packages/win64/NSIS/NSISOutput.log
 
     - name: Upload Artifact
-      if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')
+      if: startsWith(matrix.os, 'Windows') || startsWith(matrix.os, 'macOS')
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.ARTIFACT_PATTERN }}
-        path: ${{ runner.workspace }}/build/${{ env.ARTIFACT_PATTERN }}
+        path: ./build/${{ env.ARTIFACT_PATTERN }}
         if-no-files-found: error

--- a/tools/ci-scripts/deb_package/Dockerfile_build_debian-11
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_debian-11
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 # Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte Server
 # Example build: docker build -t overte/overte-server-build:0.1.3-debian-11 -f Dockerfile_build_debian-11 .

--- a/tools/ci-scripts/deb_package/Dockerfile_build_debian-11
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_debian-11
@@ -1,8 +1,8 @@
-# Copyright 2022 Overte e.V.
 # SPDX-License-Identifier: MIT
+# Copyright 2022-2023 Overte e.V.
 
 # Docker file for building Overte Server
-# Example build: docker build -t overte/overte-server-build:0.1.2-debian-11 -f Dockerfile_build_debian-11 .
+# Example build: docker build -t overte/overte-server-build:0.1.3-debian-11 -f Dockerfile_build_debian-11 .
 FROM debian:bullseye
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
@@ -15,7 +15,7 @@ RUN echo UTC >/etc/timezone
 RUN apt-get update && apt-get -y install tzdata
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN apt-get -y install curl ninja-build git g++ libssl-dev libqt5websockets5-dev qtscript5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev
+RUN apt-get -y install curl ninja-build git g++ libssl-dev libqt5websockets5-dev qtscript5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystemd-dev
 
 # Install CMake from Debian Backports
 RUN echo deb http://deb.debian.org/debian bullseye-backports main > /etc/apt/sources.list.d/bullseye-backports.list

--- a/tools/ci-scripts/deb_package/Dockerfile_build_debian-11
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_debian-11
@@ -7,7 +7,7 @@ FROM debian:bullseye
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 
-# Don't use any frontend when installalling packages during the creation of this container
+# Don't use any frontend when installing packages during the creation of this container
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN echo UTC >/etc/timezone

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-18.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-18.04
@@ -7,7 +7,7 @@ FROM ubuntu:18.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 
-# Don't use any frontend when installalling packages during the creation of this container
+# Don't use any frontend when installing packages during the creation of this container
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN echo UTC >/etc/timezone

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-18.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-18.04
@@ -1,8 +1,8 @@
-# Copyright 2022 Overte e.V.
 # SPDX-License-Identifier: MIT
+# Copyright 2022-2023 Overte e.V.
 
 # Docker file for building Overte Server
-# Example build: docker build -t overte/overte-server-build:0.1.1-ubuntu-18.04 -f Dockerfile_build_ubuntu-18.04 .
+# Example build: docker build -t overte/overte-server-build:0.1.3-ubuntu-18.04 -f Dockerfile_build_ubuntu-18.04 .
 FROM ubuntu:18.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
@@ -15,7 +15,7 @@ RUN echo UTC >/etc/timezone
 RUN apt-get update && apt-get -y install tzdata
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN apt-get -y install curl ninja-build git g++ libssl-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libharfbuzz-dev libdouble-conversion1
+RUN apt-get -y install curl ninja-build git g++ libssl-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libharfbuzz-dev libdouble-conversion1 libsystemd-dev
 
 # Install tools for package creation
 RUN apt-get -y install sudo chrpath binutils dh-make

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-18.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-18.04
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 # Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte Server
 # Example build: docker build -t overte/overte-server-build:0.1.3-ubuntu-18.04 -f Dockerfile_build_ubuntu-18.04 .

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-20.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-20.04
@@ -7,7 +7,7 @@ FROM ubuntu:20.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 
-# Don't use any frontend when installalling packages during the creation of this container
+# Don't use any frontend when installing packages during the creation of this container
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN echo UTC >/etc/timezone

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-20.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-20.04
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 # Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte Server
 # Example build: docker build -t overte/overte-server-build:0.1.3-ubuntu-20.04 -f Dockerfile_build_ubuntu-20.04 .

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-20.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-20.04
@@ -1,8 +1,8 @@
-# Copyright 2022 Overte e.V.
 # SPDX-License-Identifier: MIT
+# Copyright 2022-2023 Overte e.V.
 
 # Docker file for building Overte Server
-# Example build: docker build -t overte/overte-server-build:0.1.1-ubuntu-20.04 -f Dockerfile_build_ubuntu-20.04 .
+# Example build: docker build -t overte/overte-server-build:0.1.3-ubuntu-20.04 -f Dockerfile_build_ubuntu-20.04 .
 FROM ubuntu:20.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
@@ -15,7 +15,7 @@ RUN echo UTC >/etc/timezone
 RUN apt-get update && apt-get -y install tzdata
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN apt-get -y install curl ninja-build git cmake g++ libssl-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libharfbuzz-dev libdouble-conversion3 libxext-dev
+RUN apt-get -y install curl ninja-build git cmake g++ libssl-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libharfbuzz-dev libdouble-conversion3 libxext-dev libsystemd-dev
 
 # Install tools for package creation
 RUN apt-get -y install sudo chrpath binutils dh-make

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-22.04
@@ -7,7 +7,7 @@ FROM ubuntu:22.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 
-# Don't use any frontend when installalling packages during the creation of this container
+# Don't use any frontend when installing packages during the creation of this container
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN echo UTC >/etc/timezone

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-22.04
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 # Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte Server
 # Example build: docker build -t overte/overte-server-build:0.1.3-ubuntu-22.04 -f Dockerfile_build_ubuntu-22.04 .

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-22.04
@@ -1,8 +1,8 @@
-# Copyright 2022 Overte e.V.
 # SPDX-License-Identifier: MIT
+# Copyright 2022-2023 Overte e.V.
 
 # Docker file for building Overte Server
-# Example build: docker build -t overte/overte-server-build:0.1.1-ubuntu-22.04 -f Dockerfile_build_ubuntu-22.04 .
+# Example build: docker build -t overte/overte-server-build:0.1.3-ubuntu-22.04 -f Dockerfile_build_ubuntu-22.04 .
 FROM ubuntu:22.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
@@ -15,7 +15,7 @@ RUN echo UTC >/etc/timezone
 RUN apt-get update && apt-get -y install tzdata
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN apt-get -y install curl ninja-build git cmake g++ libssl-dev libqt5websockets5-dev qtscript5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev
+RUN apt-get -y install curl ninja-build git cmake g++ libssl-dev libqt5websockets5-dev qtscript5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystemd-dev
 # Install Overte tools build dependencies
 RUN apt-get -y install libqt5webchannel5-dev qtwebengine5-dev libqt5xmlpatterns5-dev
 

--- a/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
@@ -1,0 +1,42 @@
+# Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
+
+# Docker file for building Overte
+# Example build: docker build -t overte/overte-full-build:0.1.1-ubuntu-22.04 -f Dockerfile_build_ubuntu-22.04 .
+FROM ubuntu:22.04
+LABEL maintainer="Julian Groß (julian.gro@overte.org)"
+LABEL description="Development image for full Overte builds"
+
+# Don't use any frontend when installing packages during the creation of this container
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN echo UTC >/etc/timezone
+# Installing via dependency causes interactive hang:
+RUN apt-get update && apt-get -y install tzdata
+
+# Install Overte domain-server and assignment-client build dependencies
+RUN apt-get -y install curl ninja-build git cmake g++ libssl-dev libqt5websockets5-dev qtscript5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystem-dev
+# Install Overte tools build dependencies
+RUN apt-get -y install libqt5webchannel5-dev qtwebengine5-dev libqt5xmlpatterns5-dev
+# Install Overte Interface build dependencies
+RUN apt-get -y install libqt5svg5-dev qttools5-dev
+# Install server-console build dependencies
+RUN apt-get -y install npm
+
+# Install tools for package creation
+RUN apt-get -y install sudo chrpath binutils dh-make
+
+# Install locales package
+RUN apt-get -y install locales
+# Uncomment en_US.UTF-8 for inclusion in generation
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
+# Generate locale
+RUN locale-gen
+
+# Export env vars
+RUN echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc
+RUN echo "export LANG=en_US.UTF-8" >> ~/.bashrc
+RUN echo "export LANGUAGE=en_US.UTF-8" >> ~/.bashrc
+
+# Install tools needed for our Github Actions Workflow
+Run apt-get -y install python3-boto3 python3-github zip

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-36
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-36
@@ -1,14 +1,14 @@
-# Copyright 2022 Overte e.V.
 # SPDX-License-Identifier: MIT
+# Copyright 2022-2023 Overte e.V.
 
 # Docker file for building Overte Server
-# Example build: docker build -t overte/overte-server-build:0.1.2-fedora-36 -f Dockerfile_build_fedora-36 .
+# Example build: docker build -t overte/overte-server-build:0.1.3-fedora-36 -f Dockerfile_build_fedora-36 .
 FROM fedora:36
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel
+RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
 
 # Install additional build tools
 RUN dnf -y install zip unzip

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-36
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-36
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 # Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte Server
 # Example build: docker build -t overte/overte-server-build:0.1.3-fedora-36 -f Dockerfile_build_fedora-36 .

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-37
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-37
@@ -1,14 +1,14 @@
-# Copyright 2022 Overte e.V.
 # SPDX-License-Identifier: MIT
+# Copyright 2022-2023 Overte e.V.
 
 # Docker file for building Overte Server
-# Example build: docker build -t overte/overte-server-build:0.1.2-fedora-37 -f Dockerfile_build_fedora-37 .
+# Example build: docker build -t overte/overte-server-build:0.1.3-fedora-37 -f Dockerfile_build_fedora-37 .
 FROM fedora:37
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel
+RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
 
 # Install additional build tools
 RUN dnf -y install zip unzip

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-37
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-37
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 # Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte Server
 # Example build: docker build -t overte/overte-server-build:0.1.3-fedora-37 -f Dockerfile_build_fedora-37 .

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_rockylinux-9
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_rockylinux-9
@@ -1,8 +1,8 @@
-# Copyright 2022 Overte e.V.
 # SPDX-License-Identifier: MIT
+# Copyright 2022-2023 Overte e.V.
 
 # Docker file for building Overte Server
-# Example build: docker build -t overte/overte-server-build:0.1.2-rockylinux-9 -f Dockerfile_build_rockylinux-9 .
+# Example build: docker build -t overte/overte-server-build:0.1.3-rockylinux-9 -f Dockerfile_build_rockylinux-9 .
 FROM rockylinux:9
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
@@ -16,7 +16,7 @@ RUN dnf -y install epel-release
 RUN dnf config-manager --enable crb
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel
+RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
 
 # Install additional build tools
 RUN dnf -y install zip unzip

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_rockylinux-9
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_rockylinux-9
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: MIT
 # Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte Server
 # Example build: docker build -t overte/overte-server-build:0.1.3-rockylinux-9 -f Dockerfile_build_rockylinux-9 .


### PR DESCRIPTION
This PR gets rid of the need for two separate GitHub Actions aarch64 runners, by creating a container to build in and using that instead of the root environment.

Of course things escalated, so here a list of all changes:
- Don't try to run macOS-10.15 jobs anymore, since their runners have been shut down. We would need to put work into updating it while knowing that the end result would be a build that doesn't work, so I choose to wait till macOS support can actually be restored.
- The systemd logging dependency was missing from the Linux Domain server build containers, which presumably broke the extended systemd logging features.
- Change the license of the Dockerfiles from MIT to Apache 2.0. (I changed my mind)
- Overhaul pr_build.yml to work around multiple bugs in GitHub Actions. This includes switching to a build container for aarch64.
- Add a Dockerfile for creating said build container.
- Change the job names to include the architecture.
- Fix some typos.