### PR TITLE
Clear directory of aarch64 runner

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -89,6 +89,11 @@ jobs:
     container: ${{matrix.image}}
 
     steps:
+    - name: Clear Working Directory
+      if: contains(matrix.runner, 'linux_aarch64')
+      shell: bash
+      run: rm -rf ./*
+
     - name: Configure Build Environment 1
       shell: bash
       run: |
@@ -267,3 +272,8 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.s3_access_key_id }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.s3_secret_access_key }}
       run: python3 $GITHUB_WORKSPACE/tools/ci-scripts/upload.py
+
+    - name: Clear Working Directory
+      if: contains(matrix.runner, 'linux_aarch64')
+      shell: bash
+      run: rm -rf ./*

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -155,6 +155,12 @@ jobs:
           echo "INSTALLER=Overte-Interface-$RELEASE_NUMBER-${GIT_COMMIT_SHORT}.$INSTALLER_EXT" >> $GITHUB_ENV
         fi
 
+    - name: Clear Working Directory
+      if: startsWith(matrix.os, 'windows') || contains(matrix.os, 'self-hosted')
+      shell: bash
+      working-directory: ${{runner.workspace}}
+      run: rm -rf ./*
+
     - uses: actions/checkout@v3
       with:
         submodules: false

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -156,9 +156,8 @@ jobs:
         fi
 
     - name: Clear Working Directory
-      if: startsWith(matrix.os, 'windows') || contains(matrix.os, 'self-hosted')
+      if: contains(matrix.runner, 'linux_aarch64')
       shell: bash
-      working-directory: ${{runner.workspace}}
       run: rm -rf ./*
 
     - uses: actions/checkout@v3
@@ -336,3 +335,8 @@ jobs:
         name: ${{ env.ARTIFACT_PATTERN }}
         path: ./build/${{ env.ARTIFACT_PATTERN }}
         if-no-files-found: error
+
+    - name: Clear Working Directory
+      if: contains(matrix.runner, 'linux_aarch64')
+      shell: bash
+      run: rm -rf ./*


### PR DESCRIPTION
Apparently the GitHub Runner software just keeps the build context even when using containers.

Should fix https://github.com/overte-org/overte/issues/423