### PR TITLE
Disable libOVR on MSVC 2022 for now

### DIFF
--- a/plugins/oculus/CMakeLists.txt
+++ b/plugins/oculus/CMakeLists.txt
@@ -6,7 +6,7 @@
 #  See the accompanying file LICENSE or http:#www.apache.org/licenses/LICENSE-2.0.html
 #
 
-if (WIN32 AND (NOT USE_GLES))
+if (WIN32 AND (NOT USE_GLES) AND (MSVC_VERSION LESS 1930) )
 
   # if we were passed an Oculus App ID for entitlement checks, send that along
   if (DEFINED ENV{OCULUS_APP_ID})


### PR DESCRIPTION
This allows building Overte with MSVC 2022