### PR TITLE
remove qtscript from cmake dependencies

### DIFF
--- a/libraries/script-engine/CMakeLists.txt
+++ b/libraries/script-engine/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 set(TARGET_NAME script-engine)
 # FIXME Move undo scripting interface to application and remove Widgets
-setup_hifi_library(Network Script WebSockets)
+setup_hifi_library(Network WebSockets)
 
 target_zlib()
 target_v8()


### PR DESCRIPTION
cmake still treats qtscript as a dependency, and will error out if you don't have it installed.  this pull fixes that.