### PR TITLE
Hide private methods and QObject signals from script engine

### DIFF
--- a/libraries/script-engine/src/v8/ScriptObjectV8Proxy.cpp
+++ b/libraries/script-engine/src/v8/ScriptObjectV8Proxy.cpp
@@ -280,6 +280,12 @@ void ScriptObjectV8Proxy::investigate() {
             case QMetaMethod::Constructor:
                 continue;
             case QMetaMethod::Signal:
+                if (szName == "destroyed") {
+                    continue;
+                }
+                if (szName == "objectNameChanged") {
+                    continue;
+                }
                 isSignal = true;
                 break;
             case QMetaMethod::Slot:

--- a/libraries/script-engine/src/v8/ScriptObjectV8Proxy.cpp
+++ b/libraries/script-engine/src/v8/ScriptObjectV8Proxy.cpp
@@ -271,7 +271,7 @@ void ScriptObjectV8Proxy::investigate() {
         QMetaMethod method = metaObject->method(idx);
 
         // perhaps keep this comment?  Calls (like AudioScriptingInterface::playSound) seem to expect non-public methods to be script-accessible
-        /* if (method.access() != QMetaMethod::Public) continue;*/
+        if (method.access() == QMetaMethod::Private) continue;
 
         bool isSignal = false;
         QByteArray szName = method.name();
@@ -389,6 +389,7 @@ ScriptObjectV8Proxy::QueryFlags ScriptObjectV8Proxy::queryProperty(const V8Scrip
     v8::Local<v8::Context> context = _engine->getContext();
     v8::Context::Scope contextScope(context);
     QString nameStr(*v8::String::Utf8Value(isolate, name.constGet()));
+    // V8TODO: registering methods on V8 side would make API calls a lot faster
 
     // check for methods
     MethodNameMap::const_iterator method = _methodNameMap.find(nameStr);

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -39,8 +39,8 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/onEscape.js",
     "system/onFirstRun.js",
     "system/appreciate/appreciate_app.js",
-    "system/places/places.js",
-    "developer/debugging/scriptMemoryReport.js"
+    "system/places/places.js"
+    //"developer/debugging/scriptMemoryReport.js"
 ];
 var DEFAULT_SCRIPTS_SEPARATE = [
     "system/controllers/controllerScripts.js",

--- a/scripts/system/controllers/controllerScripts.js
+++ b/scripts/system/controllers/controllerScripts.js
@@ -41,8 +41,7 @@ var CONTOLLER_SCRIPTS = [
     "controllerModules/trackedHandTablet.js"
 ];
 
-Script.include("../../developer/debugging/scriptMemoryReport.js");
-//Script.include("developer/debugging/scriptMemoryReport.js");
+//Script.include("../../developer/debugging/scriptMemoryReport.js");
 
 var DEBUG_MENU_ITEM = "Debug defaultScripts.js";
 


### PR DESCRIPTION
Fixes https://github.com/overte-org/overte/issues/367