### PR TITLE
Fix resetting the settings

### DIFF
--- a/interface/src/CrashRecoveryHandler.cpp
+++ b/interface/src/CrashRecoveryHandler.cpp
@@ -25,14 +25,16 @@
 #include "Application.h"
 #include "Menu.h"
 
+
 #include <RunningMarker.h>
 #include <SettingHandle.h>
 #include <SettingHelpers.h>
+#include <SettingManager.h>
+#include <DependencyManager.h>
 
 
 bool CrashRecoveryHandler::checkForResetSettings(bool wasLikelyCrash, bool suppressPrompt) {
-    QSettings::setDefaultFormat(JSON_FORMAT);
-    QSettings settings;
+    Settings settings;
     settings.beginGroup("Developer");
     QVariant displayCrashOptions = settings.value(MenuOption::DisplayCrashOptions);
     settings.endGroup();
@@ -111,7 +113,8 @@ void CrashRecoveryHandler::handleCrash(CrashRecoveryHandler::Action action) {
         return;
     }
 
-    QSettings settings;
+    Settings settings;
+
     const QString ADDRESS_MANAGER_GROUP = "AddressManager";
     const QString ADDRESS_KEY = "address";
     const QString AVATAR_GROUP = "Avatar";
@@ -145,11 +148,8 @@ void CrashRecoveryHandler::handleCrash(CrashRecoveryHandler::Action action) {
         tutorialComplete = settings.value(TUTORIAL_COMPLETE_FLAG_KEY).toBool();
     }
 
-    // Delete Interface.ini
-    QFile settingsFile(settings.fileName());
-    if (settingsFile.exists()) {
-        settingsFile.remove();
-    }
+    // Reset everything
+    settings.clear();
 
     if (action == CrashRecoveryHandler::RETAIN_IMPORTANT_INFO) {
         // Write avatar info

--- a/libraries/shared/src/SettingHandle.cpp
+++ b/libraries/shared/src/SettingHandle.cpp
@@ -200,3 +200,7 @@ QString Settings::getPath(const QString &key) const {
     ret.append(key);
     return ret;
 }
+
+void Settings::clear() {
+    _manager->clearAllSettings();
+}

--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -110,6 +110,8 @@ public:
     void setQuatValue(const QString& name, const glm::quat& quatValue);
     void getQuatValueIfValid(const QString& name, glm::quat& quatValue);
 
+    void clear();
+
 private:
     QString getGroupPrefix() const;
     QString getPath(const QString &value) const;

--- a/libraries/shared/src/SettingManager.h
+++ b/libraries/shared/src/SettingManager.h
@@ -76,6 +76,12 @@ namespace Setting {
         void removeKey(const QString key);
 
         /**
+         * @brief Remove all values from the configuration.
+         *
+         */
+        void clearAllSettings();
+
+        /**
          * @brief Force writing the config to disk
          *
          */
@@ -172,6 +178,13 @@ namespace Setting {
          */
         QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
 
+        /**
+         * @brief Clear all the settings
+         *
+         * Removes the entire configuration, resetting everything to "factory default"
+         *
+         */
+        void clearAllSettings();
     protected:
         /**
          * @brief How long to wait for writer thread termination
@@ -204,9 +217,39 @@ namespace Setting {
         void terminateThread();
 
     signals:
+        /**
+         * @brief The value of a setting was changed
+         *
+         * @param key Setting key
+         * @param value New value
+         */
         void valueChanged(const QString key, QVariant value);
+
+        /**
+         * @brief A setting was removed
+         *
+         * @param key Setting key
+         */
         void keyRemoved(const QString key);
+
+        /**
+         * @brief A request to synchronize the settings to permanent storage was made
+         *
+         */
         void syncRequested();
+
+        /**
+         * @brief A request to clear all the settings was made
+         *
+         */
+        void clearAllSettingsRequested();
+
+        /**
+         * @brief The termination of the settings system was requested
+         *
+         * This happens on shutdown. All pending changes should be serialized to disk.
+         *
+         */
         void terminationRequested();
 
     private:


### PR DESCRIPTION
This fixes the "reset settings" dialog by making it use the improved settings API.

This fixes #277 

So far failed to reproduce #352. Tested on Linux and Windows. 

Closes #352 



