### PR TITLE
Build with crash reporting against Sentry

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -19,7 +19,7 @@ env:
   UPLOAD_BUCKET: overte-public
   UPLOAD_REGION: fra1
   UPLOAD_ENDPOINT: "https://fra1.digitaloceanspaces.com"
-  CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT || vars.SENTRY_PR_MINIDUMP_ENDPOINT }}
+  CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT }}
   CMAKE_BACKTRACE_TOKEN: server_${{ github.event.number }}_${{ github.sha }}
 
 jobs:
@@ -210,7 +210,14 @@ jobs:
     - name: Configure CMake
       working-directory: build
       shell: bash
-      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DVCPKG_BUILD_TYPE=release $CMAKE_EXTRA
+      run: |
+        if [ -z "$CMAKE_BACKTRACE_URL" ] ; then
+          # We're building a PR, default to the PR endpoint
+          export CMAKE_BACKTRACE_URL="https://o4504831972343808.ingest.sentry.io/api/4504832427950080/minidump/?sentry_key=f511de295975461b8f92a36f4a4a4f32"
+          export CMAKE_BACKTRACE_TOKEN="server_pr_${{ github.event.number }}_${{ github.sha }}"
+        fi
+
+        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DVCPKG_BUILD_TYPE=release $CMAKE_EXTRA
 
     - name: Compress cmake logs
       if: always()

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -19,6 +19,8 @@ env:
   UPLOAD_BUCKET: overte-public
   UPLOAD_REGION: fra1
   UPLOAD_ENDPOINT: "https://fra1.digitaloceanspaces.com"
+  CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT }}
+  CMAKE_BACKTRACE_TOKEN: server_${{ github.event.number }}_${{ github.sha }}
 
 jobs:
   build:

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -19,7 +19,7 @@ env:
   UPLOAD_BUCKET: overte-public
   UPLOAD_REGION: fra1
   UPLOAD_ENDPOINT: "https://fra1.digitaloceanspaces.com"
-  CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT }}
+  CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT || vars.SENTRY_PR_MINIDUMP_ENDPOINT }}
   CMAKE_BACKTRACE_TOKEN: server_${{ github.event.number }}_${{ github.sha }}
 
 jobs:

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -24,6 +24,8 @@ env:
   UPLOAD_BUCKET: overte-public
   UPLOAD_REGION: fra1
   UPLOAD_ENDPOINT: "https://fra1.digitaloceanspaces.com"
+  CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT }}
+  CMAKE_BACKTRACE_TOKEN: master_${{ github.event.number }}_${{ github.sha }}
 
   # OSX-specific variables
   DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -21,9 +21,8 @@ env:
   RELEASE_NUMBER: ${{ github.event.number }}
   VERSION_CODE: ${{ github.event.number }}
   # Sentry Crash Reporting
-  # We use a variable rather than a secret here -- this makes the URL more exposed, so there's some risk of somebody
-  # using it for no good. But then the secret can also be extracted from a binary.
-  CMAKE_BACKTRACE_URL: ${{ vars.SENTRY_PR_MINIDUMP_ENDPOINT }}
+  # We can't use secrets or actions here, so the actual value has to be hardcoded.
+  CMAKE_BACKTRACE_URL: "https://o4504831972343808.ingest.sentry.io/api/4504832427950080/minidump/?sentry_key=f511de295975461b8f92a36f4a4a4f32"
   CMAKE_BACKTRACE_TOKEN: PR_${{ github.event.number }}_${{ github.sha }}
 
   UPLOAD_BUCKET: overte-public

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -21,7 +21,7 @@ env:
   RELEASE_NUMBER: ${{ github.event.number }}
   VERSION_CODE: ${{ github.event.number }}
   # Sentry Crash Reporting
-  CMAKE_BACKTRACE_URL:
+  CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT }}
   CMAKE_BACKTRACE_TOKEN: PR_${{ github.event.number }}_${{ github.sha }}
 
   UPLOAD_BUCKET: overte-public

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -21,7 +21,9 @@ env:
   RELEASE_NUMBER: ${{ github.event.number }}
   VERSION_CODE: ${{ github.event.number }}
   # Sentry Crash Reporting
-  CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT }}
+  # We use a variable rather than a secret here -- this makes the URL more exposed, so there's some risk of somebody
+  # using it for no good. But then the secret can also be extracted from a binary.
+  CMAKE_BACKTRACE_URL: ${{ vars.SENTRY_PR_MINIDUMP_ENDPOINT }}
   CMAKE_BACKTRACE_TOKEN: PR_${{ github.event.number }}_${{ github.sha }}
 
   UPLOAD_BUCKET: overte-public


### PR DESCRIPTION
Add the Sentry token so that we can report crashes.

This should be handy for the new release which includes large code changes.
