### PR TITLE
ForceHtmlAudioOutputDeviceUpdate fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ local.properties
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+# Workspace
+*.code-workspace
 
 # Xcode
 *.xcodeproj

--- a/interface/resources/html/createGlobalEventBridge.js
+++ b/interface/resources/html/createGlobalEventBridge.js
@@ -1,11 +1,11 @@
 //
-//  createGlobalEventBridge.js
+// createGlobalEventBridge.js
 //
-//  Created by Anthony J. Thibault on 9/7/2016
-//  Copyright 2016 High Fidelity, Inc.
+// Created by Anthony J. Thibault on 9/7/2016
+// Copyright 2016 High Fidelity, Inc.
 //
-//  Distributed under the Apache License, Version 2.0.
-//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+// Distributed under the Apache License, Version 2.0.
+// See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
 // Stick a EventBridge object in the global namespace.
@@ -25,37 +25,16 @@ var EventBridge;
         this.emitWebEvent = function (message) {
             self._messages.push(message);
         };
-    };
+    }
 
     EventBridge = new TempEventBridge();
 
-    var webChannel = new QWebChannel(qt.webChannelTransport, function (channel) {
+    var webChannel = new QWebChannel(qt.webChannelTransport, (channel) => {
+        //
         // replace the TempEventBridge with the real one.
         var tempEventBridge = EventBridge;
         EventBridge = channel.objects.eventBridge;
-        
-        // To be able to update the state of the output device selection for every element added to the DOM
-        // we need to listen to events that might precede the addition of this elements.
-        // A more robust hack will be to add a setInterval that look for DOM changes every 100-300 ms (low performance?)
-        
-        window.addEventListener("load",function(event) {
-            setTimeout(function() { 
-                // EventBridge.forceHtmlAudioOutputDeviceUpdate();
-            }, 1200);
-        }, false);
-        
-        document.addEventListener("click",function(){
-            setTimeout(function() { 
-                // EventBridge.forceHtmlAudioOutputDeviceUpdate();
-            }, 1200);
-        }, false);
-        
-        document.addEventListener("change",function(){
-            setTimeout(function() { 
-                // EventBridge.forceHtmlAudioOutputDeviceUpdate();
-            }, 1200);
-        }, false);
-        
+
         tempEventBridge._callbacks.forEach(function (callback) {
             EventBridge.scriptEventReceived.connect(callback);
         });

--- a/interface/resources/html/createGlobalEventBridge.js
+++ b/interface/resources/html/createGlobalEventBridge.js
@@ -1,11 +1,9 @@
+//  Created by Anthony J. Thibault on 9/7/2016
+//  Copyright 2016 High Fidelity, Inc.
+//  Copyright 2023 Overte e.V.
 //
-// createGlobalEventBridge.js
-//
-// Created by Anthony J. Thibault on 9/7/2016
-// Copyright 2016 High Fidelity, Inc.
-//
-// Distributed under the Apache License, Version 2.0.
-// See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
 // Stick a EventBridge object in the global namespace.

--- a/interface/resources/html/createGlobalEventBridge.js
+++ b/interface/resources/html/createGlobalEventBridge.js
@@ -40,19 +40,19 @@ var EventBridge;
         
         window.addEventListener("load",function(event) {
             setTimeout(function() { 
-                EventBridge.forceHtmlAudioOutputDeviceUpdate();
+                // EventBridge.forceHtmlAudioOutputDeviceUpdate();
             }, 1200);
         }, false);
         
         document.addEventListener("click",function(){
             setTimeout(function() { 
-                EventBridge.forceHtmlAudioOutputDeviceUpdate();
+                // EventBridge.forceHtmlAudioOutputDeviceUpdate();
             }, 1200);
         }, false);
         
         document.addEventListener("change",function(){
             setTimeout(function() { 
-                EventBridge.forceHtmlAudioOutputDeviceUpdate();
+                // EventBridge.forceHtmlAudioOutputDeviceUpdate();
             }, 1200);
         }, false);
         

--- a/interface/resources/html/createGlobalEventBridge.js
+++ b/interface/resources/html/createGlobalEventBridge.js
@@ -33,6 +33,30 @@ var EventBridge;
         var tempEventBridge = EventBridge;
         EventBridge = channel.objects.eventBridge;
 
+        // TODO: These event listeners cause issues. Most likely the function is not being exposed to this scope. This may be causing issues!
+        
+        // To be able to update the state of the output device selection for every element added to the DOM
+        // we need to listen to events that might precede the addition of this elements.
+        // A more robust hack will be to add a setInterval that look for DOM changes every 100-300 ms (low performance?)
+
+        // window.addEventListener("load",function(event) {
+        //     setTimeout(function() { 
+        //         EventBridge.forceHtmlAudioOutputDeviceUpdate();
+        //     }, 1200);
+        // }, false);
+
+        // document.addEventListener("click",function(){
+        //     setTimeout(function() { 
+        //         EventBridge.forceHtmlAudioOutputDeviceUpdate();
+        //     }, 1200);
+        // }, false);
+
+        // document.addEventListener("change",function(){
+        //     setTimeout(function() { 
+        //         EventBridge.forceHtmlAudioOutputDeviceUpdate();
+        //     }, 1200);
+        // }, false);
+
         tempEventBridge._callbacks.forEach(function (callback) {
             EventBridge.scriptEventReceived.connect(callback);
         });


### PR DESCRIPTION
This fixes the issue of Overte trying to call the `.forceHtmlAudioOutputDeviceUpdate();` function which does not seem to exist in scope and does not appear to be needed otherwise. 

I have built and tested this on Arch Linux, Desktop mode.
Other overlay elements did not seem to be effected negatively. Audio still works fine when playing video from FloofChat or though the in-game web browser. 