### PR TITLE
Remove unused variable, causes problems if crash reporting is not used.

### DIFF
--- a/interface/src/CrashRecoveryHandler.cpp
+++ b/interface/src/CrashRecoveryHandler.cpp
@@ -36,9 +36,6 @@
 #include <UserActivityLogger.h>
 #include <BuildInfo.h>
 
- static const QString BACKTRACE_URL{ CMAKE_BACKTRACE_URL };
-
-
 bool CrashRecoveryHandler::checkForResetSettings(bool wasLikelyCrash, bool suppressPrompt) {
     Setting::Handle<bool> crashReportingAsked { "CrashReportingAsked", false };
 


### PR DESCRIPTION
Whoops. This was an accidental leftover that can cause a build problem.
