### PR TITLE
Restore the original dimensions of the bubble (for the "Shield" app.)

### DIFF
--- a/scripts/system/bubble.js
+++ b/scripts/system/bubble.js
@@ -25,9 +25,9 @@
         "type": "Model",
         "modelURL": Script.resolvePath("assets/models/Bubble-v14.fbx"), // If you'd like to change the model, modify this line (and the dimensions below)
         "dimensions": { 
-            "x": MyAvatar.sensorToWorldScale * 2,
-            "y": (0.75 * MyAvatar.sensorToWorldScale) * ((MyAvatar.scale * 0.5) + 0.5),
-            "z": MyAvatar.sensorToWorldScale * 2
+            "x": MyAvatar.sensorToWorldScale,
+            "y": (0.75 * MyAvatar.sensorToWorldScale),
+            "z": MyAvatar.sensorToWorldScale
         },
         "position": { "x": MyAvatar.position.x, "y": -MyAvatar.scale * 2 + MyAvatar.position.y + MyAvatar.scale * BUBBLE_HEIGHT_SCALE, "z": MyAvatar.position.z },
         "rotation": Quat.multiply(MyAvatar.orientation, Quat.fromVec3Degrees({"x": 0.0, "y": 180.0, "z": 0.0})),
@@ -90,9 +90,9 @@
 
         Entities.editEntity(bubbleOverlay, {
             "dimensions": { 
-                "x": MyAvatar.sensorToWorldScale * 2, 
-                "y": (0.75 * MyAvatar.sensorToWorldScale) * ((MyAvatar.scale * 0.5)  + 0.5), 
-                "z": MyAvatar.sensorToWorldScale * 2 
+                "x": MyAvatar.sensorToWorldScale,
+                "y": 0.75 * MyAvatar.sensorToWorldScale,
+                "z": MyAvatar.sensorToWorldScale
             },
             "position": { 
                 "x": MyAvatar.position.x, 
@@ -127,9 +127,9 @@
             if (delay < BUBBLE_RAISE_ANIMATION_DURATION_MS) {
                 Entities.editEntity(bubbleOverlay, {
                     "dimensions": { 
-                        "x": MyAvatar.sensorToWorldScale * 2,
-                        "y": (0.75 * MyAvatar.sensorToWorldScale) * ((1 - ((BUBBLE_RAISE_ANIMATION_DURATION_MS - delay) / BUBBLE_RAISE_ANIMATION_DURATION_MS)) * MyAvatar.scale * 0.5 + 0.5),
-                        "z": MyAvatar.sensorToWorldScale * 2
+                        "x": MyAvatar.sensorToWorldScale,
+                        "y": (0.75 * MyAvatar.sensorToWorldScale) * (1 - ((BUBBLE_RAISE_ANIMATION_DURATION_MS - delay) / BUBBLE_RAISE_ANIMATION_DURATION_MS)),
+                        "z": MyAvatar.sensorToWorldScale
                     },
                     // Quickly raise the bubble from the ground up
                     "position": {
@@ -143,9 +143,9 @@
                 // Keep the bubble in place for a couple seconds
                 Entities.editEntity(bubbleOverlay, {
                     "dimensions": { 
-                        "x": MyAvatar.sensorToWorldScale * 2,
-                        "y": (0.75 * MyAvatar.sensorToWorldScale) * ((MyAvatar.scale * 0.5) + 0.5),
-                        "z": MyAvatar.sensorToWorldScale * 2
+                        "x": MyAvatar.sensorToWorldScale,
+                        "y": 0.75 * MyAvatar.sensorToWorldScale,
+                        "z": MyAvatar.sensorToWorldScale
                     },            
                     "position": {
                         "x": MyAvatar.position.x,


### PR DESCRIPTION
There was a "scale" property on the original 3d overlay that was used in the bubble.js script to scale the dimensions. But it seems that the "scale" property was not doing anything.  When I moved this script to Local Entities, I had to multiply the dimensions with their respective scale and the result was badly stretched. (clearly, based on the texture deformation, it was not wished. In addition to the fact that Hifi released it as is, ignoring that the scale was doing nothing.) 

This PR just remove that scaling that I added assuming that it was working.  Now it is it was before V8. The texture is in a correct ratio, and the bubble size as before.