### PR TITLE
Truncate logs read by FileLogger

### DIFF
--- a/interface/src/ui/LogDialog.cpp
+++ b/interface/src/ui/LogDialog.cpp
@@ -321,7 +321,8 @@ void LogDialog::handleFilterDropdownChanged(int selection) {
 }
 
 QString LogDialog::getCurrentLog() {
-    return _logger->getLogData();
+    // We start 512 KiB from the end of the file.
+    return _logger->getLogData(524288);
 }
 
 void LogDialog::appendLogLine(QString logLine) {

--- a/libraries/shared/src/shared/AbstractLoggerInterface.h
+++ b/libraries/shared/src/shared/AbstractLoggerInterface.h
@@ -43,7 +43,7 @@ public:
     inline void setUnknownPrint(bool unknownPrint) { _unknownPrint = unknownPrint; }
 
     virtual void addMessage(const QString&) = 0;
-    virtual QString getLogData() = 0;
+    virtual QString getLogData(const qint64 maxSize = 0) = 0;
     virtual void locateLog() = 0;
     virtual void sync() {}
 

--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -157,11 +157,22 @@ void FileLogger::locateLog() {
     FileUtils::locateFile(_fileName);
 }
 
-QString FileLogger::getLogData() {
+QString FileLogger::getLogData(const qint64 maxSize) {
     QString result;
     QFile f(_fileName);
     if (f.open(QFile::ReadOnly | QFile::Text)) {
-        result = QTextStream(&f).readAll();
+        if (maxSize != 0) {
+            f.seek(f.size() - maxSize);
+        }
+        QTextStream stream(&f);
+        if (maxSize != 0) {
+            // Continue one line, in case we are in the middle of a line.
+            stream.readLine();
+            result = "Log has been truncated to " + QString::number(maxSize) + " bytes.\n" + stream.readAll();
+        }
+        else {
+            result = stream.readAll();
+        }
     }
     return result;
 }

--- a/libraries/shared/src/shared/FileLogger.h
+++ b/libraries/shared/src/shared/FileLogger.h
@@ -27,7 +27,7 @@ public:
     QString getFilename() const { return _fileName; }
     virtual void addMessage(const QString&) override;
     virtual void setSessionID(const QUuid&);
-    virtual QString getLogData() override;
+    virtual QString getLogData(const qint64 maxSize = 0) override;
     virtual void locateLog() override;
     virtual void sync() override;
 


### PR DESCRIPTION
This PR changes the log viewer in "Developer" -> "Log" to only read the last 512 KiB when initially reading the file.
Fixes #496 