### PR TITLE
Fix the link on the place name to use the right hifiurl

### DIFF
--- a/scripts/system/places/places.html
+++ b/scripts/system/places/places.html
@@ -432,7 +432,7 @@
                                         formatedList = formatedList + "<table class='placeTable'>";
                                         formatedList = formatedList + "    <tr valign = 'top'>";
                                         formatedList = formatedList + "        <td width='2%'></td>";                                
-                                        formatedList = formatedList + "        <td align='left' width='75%' onclick='teleport(" + '"' + placeRecords[i].id + '"' + ", " + '"' + placeUrl + '"' + "); return false;'><a class= 'placeTitle' href='javascript:void(0)' onclick='teleport(" + '"' + placeRecords[i].id + '"' + ", " + '"' + placeRecords[i].address + '"' + "); return false;'>" + placeRecords[i].name + "</a></td>";
+                                        formatedList = formatedList + "        <td align='left' width='75%' onclick='teleport(" + '"' + placeRecords[i].id + '"' + ", " + '"' + placeUrl + '"' + "); return false;'><a class= 'placeTitle' href='javascript:void(0)' onclick='teleport(" + '"' + placeRecords[i].id + '"' + ", " + '"' + placeUrl + '"' + "); return false;'>" + placeRecords[i].name + "</a></td>";
                                         if (placeRecords[i].category !== "Z") {
                                             formatedList = formatedList + "        <td align='right' ><span style='padding: 0%; cursor: pointer;' onclick='openDetail(" + '"' + placeRecords[i].id + '"' + ")'><img src='icons/info.png' width='26' height='26' draggable='false'></span></td>";
                                         }


### PR DESCRIPTION
On the place list, the link to a place should use: 

- the placename for "local" places 
- the address for a "federated" or "external" places 

The link on the name was still using directly the address while the other parts (cell background and description) were using the placeurl variable correctly.

With this PR, all the link are now using the placeurl variable

This solves the issue #514 

To test:
For a local place (connected to you Directory Server). In the place list, click on the 3 following part:
- Cells background: (this use the placename)
- Place Name:  (this use the placename) [before it was using the address ip:port]
- Description: (this use the placename)

Do the same text for a Federated place and for an External place ...
the 3 link should use the address ip:port