### PR TITLE
Remove redundant policy from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,10 +197,6 @@ else()
         COMMAND ${HIFI_PYTHON_EXEC} ${CMAKE_CURRENT_SOURCE_DIR}/prebuild.py --release-type ${RELEASE_TYPE} --build-root ${CMAKE_BINARY_DIR} ${VCPKG_BUILD_TYPE_PARAM}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} RESULTS_VARIABLE PREBUILD_RET
     )
-    # squelch the Policy CMP0074 warning without requiring an update to cmake 3.12.
-    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
-        cmake_policy(SET CMP0074 NEW)
-    endif()
 endif()
 
 if (PREBUILD_RET GREATER 0)


### PR DESCRIPTION
It is already defined through [cmake/init.cmake](https://github.com/overte-org/overte/blob/012098b7d63f4071d43a1c1e2f6ab5effbee8091/cmake/init.cmake#L14)