### PR TITLE
Update Linux server packaging

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -70,16 +70,6 @@ jobs:
             arch: aarch64
             runner: linux_aarch64
 
-          - os: fedora-36
-            image: docker.io/overte/overte-server-build:0.1.3-fedora-36-amd64
-            arch: amd64
-            runner: ubuntu-latest
-
-          - os: fedora-36
-            image: docker.io/overte/overte-server-build:0.1.3-fedora-36-aarch64
-            arch: aarch64
-            runner: linux_aarch64
-
           - os: fedora-37
             image: docker.io/overte/overte-server-build:0.1.3-fedora-37-amd64
             arch: amd64
@@ -87,6 +77,16 @@ jobs:
 
           - os: fedora-37
             image: docker.io/overte/overte-server-build:0.1.3-fedora-37-aarch64
+            arch: aarch64
+            runner: linux_aarch64
+
+          - os: fedora-38
+            image: docker.io/overte/overte-server-build:0.1.3-fedora-38-amd64
+            arch: amd64
+            runner: ubuntu-latest
+
+          - os: fedora-38
+            image: docker.io/overte/overte-server-build:0.1.3-fedora-38-aarch64
             arch: aarch64
             runner: linux_aarch64
 
@@ -197,10 +197,10 @@ jobs:
         else  # RPM
           if [ "${{ matrix.os }}" == "rockylinux-9" ]; then
             echo "ARTIFACT_PATTERN=overte-server-$RPMVERSION-1.el9.$INSTALLER_EXT" >> $GITHUB_ENV
-          elif [ "${{ matrix.os }}" == "fedora-36" ]; then
-            echo "ARTIFACT_PATTERN=overte-server-$RPMVERSION-1.fc36.$INSTALLER_EXT" >> $GITHUB_ENV
           elif [ "${{ matrix.os }}" == "fedora-37" ]; then
             echo "ARTIFACT_PATTERN=overte-server-$RPMVERSION-1.fc37.$INSTALLER_EXT" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" == "fedora-38" ]; then
+            echo "ARTIFACT_PATTERN=overte-server-$RPMVERSION-1.fc38.$INSTALLER_EXT" >> $GITHUB_ENV
           else
             echo "Error! ARTIFACT_PATTERN not set!"
             exit 1  # Fail

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -40,6 +40,16 @@ jobs:
             arch: aarch64
             runner: linux_aarch64
 
+          - os: debian-12
+            image: docker.io/overte/overte-server-build:0.1.3-debian-12-amd64
+            arch: amd64
+            runner: ubuntu-latest
+
+          - os: debian-12
+            image: docker.io/overte/overte-server-build:0.1.3-debian-12-aarch64
+            arch: aarch64
+            runner: linux_aarch64
+
           - os: ubuntu-18.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-18.04-amd64
             arch: amd64

--- a/cmake/macros/AddCrashpad.cmake
+++ b/cmake/macros/AddCrashpad.cmake
@@ -27,6 +27,11 @@ macro(add_crashpad)
     set(CMAKE_BACKTRACE_TOKEN $ENV{CMAKE_BACKTRACE_TOKEN})
   endif()
 
+  if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    message(STATUS "Checking crashpad config - Linux aarch64 is not supported by crashpad, disabled.")
+    set(USE_CRASHPAD FALSE)
+  endif()
+
   if (USE_CRASHPAD)
     message(STATUS "Checking crashpad config - enabled.")
     get_property(CRASHPAD_CHECKED GLOBAL PROPERTY CHECKED_FOR_CRASHPAD_ONCE)

--- a/pkg-scripts/make-deb-server
+++ b/pkg-scripts/make-deb-server
@@ -10,6 +10,7 @@ fi
 if [ ! "$OVERTE_USE_SYSTEM_QT" ]; then
 	QT5_LIBS=`realpath ~/overte-files/qt/qt5-install/lib`
 fi
+# The regex below extracts the path from the VCPKG_INSTALL_ROOT variable. Said variable gets populated during the CMake step.
 VCPKG_INSTALL_ROOT=`grep VCPKG_INSTALL_ROOT $OVERTE/build/vcpkg.cmake | perl -ne 'm/set\(VCPKG_INSTALL_ROOT\s+\"(.*?)\"/; print $1'`
 
 sudo apt-get install chrpath binutils dh-make

--- a/pkg-scripts/make-deb-server
+++ b/pkg-scripts/make-deb-server
@@ -1,15 +1,16 @@
 #!/bin/sh
 
 # Copyright 2020-2021 Vircadia contributors.
-# Copyright 2022 Overte e.V.
+# Copyright 2022-2023 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 if [ "$OVERTE" = "" ]; then
 	OVERTE=`realpath ..`
-	if [ ! "$OVERTE_USE_SYSTEM_QT" ]; then
-		QT5_LIBS=`realpath ~/overte-files/qt/qt5-install/lib`
-	fi
 fi
+if [ ! "$OVERTE_USE_SYSTEM_QT" ]; then
+	QT5_LIBS=`realpath ~/overte-files/qt/qt5-install/lib`
+fi
+VCPKG_INSTALL_ROOT=`grep VCPKG_INSTALL_ROOT $OVERTE/build/vcpkg.cmake | perl -ne 'm/set\(VCPKG_INSTALL_ROOT\s+\"(.*?)\"/; print $1'`
 
 sudo apt-get install chrpath binutils dh-make
 
@@ -31,12 +32,12 @@ if [ ! "$OVERTE_USE_SYSTEM_QT" ]; then
 	cp $QT5_LIBS/libQt5Core.so.*.*.* $DEB_BUILD_ROOT
 	cp $QT5_LIBS/libQt5Widgets.so.*.*.* $DEB_BUILD_ROOT
 	cp $QT5_LIBS/libQt5Gui.so.*.*.* $DEB_BUILD_ROOT
-	cp $QT5_LIBS/libQt5Script.so.*.*.* $DEB_BUILD_ROOT
 	cp $QT5_LIBS/libQt5WebSockets.so.*.*.* $DEB_BUILD_ROOT
 	cp $QT5_LIBS/libQt5Qml.so.*.*.* $DEB_BUILD_ROOT
-	cp $QT5_LIBS/libQt5ScriptTools.so.*.*.* $DEB_BUILD_ROOT
 	chmod +x $DEB_BUILD_ROOT/*.so.*.*.*
 fi
+cp $VCPKG_INSTALL_ROOT/lib/libnode.so* $DEB_BUILD_ROOT
+
 strip --strip-all $DEB_BUILD_ROOT/*
 cp $OVERTE/pkg-scripts/new-server $DEB_BUILD_ROOT
 cp -a $OVERTE/domain-server/resources $DEB_BUILD_ROOT
@@ -77,12 +78,7 @@ echo domain-server opt/overte >> debian/install
 echo oven opt/overte >> debian/install
 #echo ice-server opt/overte >> debian/install
 echo new-server opt/overte >> debian/install
-if [ ! "$OVERTE_USE_SYSTEM_QT" ]; then
-	for so in *.so.*.*.*; do
-		echo $so opt/overte/lib >> debian/install
-	done
-fi
-for so in *.so; do
+for so in *.so*; do
 	echo $so opt/overte/lib >> debian/install
 done
 #for service in *.service; do

--- a/pkg-scripts/make-rpm-server
+++ b/pkg-scripts/make-rpm-server
@@ -10,6 +10,7 @@ fi
 if [ "$OVERTE_USE_SYSTEM_QT" = "" ]; then
 	QT5_LIBS=`realpath ~/overte-files/qt/qt5-install/lib`
 fi
+# The regex below extracts the path from the VCPKG_INSTALL_ROOT variable. Said variable gets populated during the CMake step.
 VCPKG_INSTALL_ROOT=`grep VCPKG_INSTALL_ROOT $OVERTE/build/vcpkg.cmake | perl -ne 'm/set\(VCPKG_INSTALL_ROOT\s+\"(.*?)\"/; print $1'`
 
 VERSION=${RPMVERSION}

--- a/pkg-scripts/make-rpm-server
+++ b/pkg-scripts/make-rpm-server
@@ -1,33 +1,36 @@
 #!/bin/sh
 
 # Copyright 2020-2021 Vircadia contributors.
-# Copyright 2022 Overte e.V.
+# Copyright 2022-2023 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 if [ "$OVERTE" = "" ]; then
-	        OVERTE=`realpath ..`
-	        QT5_LIBS=`realpath ~/overte-files/qt/qt5-install/lib`
+	OVERTE=`realpath ..`
 fi
+if [ "$OVERTE_USE_SYSTEM_QT" = "" ]; then
+	QT5_LIBS=`realpath ~/overte-files/qt/qt5-install/lib`
+fi
+VCPKG_INSTALL_ROOT=`grep VCPKG_INSTALL_ROOT $OVERTE/build/vcpkg.cmake | perl -ne 'm/set\(VCPKG_INSTALL_ROOT\s+\"(.*?)\"/; print $1'`
 
 VERSION=${RPMVERSION}
 
 if [ "$OVERTE_USE_SYSTEM_QT" = "" ]; then
 SOFILES=`ls \
 		$OVERTE/build/libraries/*/*.so \
+		$VCPKG_INSTALL_ROOT/lib/libnode.so* \
 		$OVERTE/qt5-install/lib/libQt5Network.so.*.*.* \
 		$OVERTE/qt5-install/lib/libQt5Core.so.*.*.* \
 		$OVERTE/qt5-install/lib/libQt5Widgets.so.*.*.* \
 		$OVERTE/qt5-install/lib/libQt5Gui.so.*.*.* \
-		$OVERTE/qt5-install/lib/libQt5Script.so.*.*.* \
 		$OVERTE/qt5-install/lib/libQt5WebSockets.so.*.*.* \
 		$OVERTE/qt5-install/lib/libQt5Qml.so.*.*.* \
 		$OVERTE/qt5-install/lib/libQt5Quick.so.*.*.* \
-		$OVERTE/qt5-install/lib/libQt5ScriptTools.so.*.*.* \
 	| sed 's/\./\\\./g' \
 	| paste -d'|' -s`
 else
 SOFILES=`ls \
 		$OVERTE/build/libraries/*/*.so \
+		$VCPKG_INSTALL_ROOT/lib/libnode.so* \
 	| sed 's/\./\\\./g' \
 	| paste -d'|' -s`
 fi
@@ -38,15 +41,14 @@ DEPENDS=mesa-libGL,`ls \
 		$OVERTE/build/domain-server/domain-server \
 		$OVERTE/build/tools/oven/oven \
 		$OVERTE/build/libraries/*/*.so \
+		$VCPKG_INSTALL_ROOT/lib/libnode.so* \
 		$QT5_LIBS/libQt5Network.so.*.*.* \
 		$QT5_LIBS/libQt5Core.so.*.*.* \
 		$QT5_LIBS/libQt5Widgets.so.*.*.* \
 		$QT5_LIBS/libQt5Gui.so.*.*.* \
-		$QT5_LIBS/libQt5Script.so.*.*.* \
 		$QT5_LIBS/libQt5WebSockets.so.*.*.* \
 		$QT5_LIBS/libQt5Qml.so.*.*.* \
 		$QT5_LIBS/libQt5Quick.so.*.*.* \
-		$QT5_LIBS/libQt5ScriptTools.so.*.*.* \
 		$OVERTE/build/assignment-client/plugins/*.so \
 		$OVERTE/build/assignment-client/plugins/*/*.so \
 	| xargs -I {} sh -c 'objdump -p {} | grep NEEDED' \
@@ -64,6 +66,7 @@ DEPENDS=mesa-libGL,`ls \
 		$OVERTE/build/domain-server/domain-server \
 		$OVERTE/build/tools/oven/oven \
 		$OVERTE/build/libraries/*/*.so \
+		$VCPKG_INSTALL_ROOT/lib/libnode.so* \
 		$OVERTE/build/assignment-client/plugins/*.so \
 		$OVERTE/build/assignment-client/plugins/*/*.so \
 	| xargs -I {} sh -c 'objdump -p {} | grep NEEDED' \
@@ -79,6 +82,6 @@ fi
 
 sudo yum install chrpath
 
-export VERSION DEPENDS OVERTE
+export VERSION DEPENDS OVERTE QT5_LIBS VCPKG_INSTALL_ROOT
 rpmbuild --target $(uname -m) -bb ./overte-server.spec
 mv ~/rpmbuild/RPMS/$(uname -m)/*.rpm .

--- a/pkg-scripts/overte-server.spec
+++ b/pkg-scripts/overte-server.spec
@@ -50,16 +50,15 @@ install -d $RPM_BUILD_ROOT/opt/overte/lib
 install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $OVERTE/build/libraries/*/*.so
 strip --strip-all $RPM_BUILD_ROOT/opt/overte/lib/*
 chrpath -d $RPM_BUILD_ROOT/opt/overte/lib/*
+install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $VCPKG_INSTALL_ROOT/lib/libnode.so*
 %if "$OVERTE_USE_SYSTEM_QT" == ""
 install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5Network.so.*.*.*
 install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5Core.so.*.*.*
 install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5Widgets.so.*.*.*
 install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5Gui.so.*.*.*
-install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5Script.so.*.*.*
 install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5WebSockets.so.*.*.*
 install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5Qml.so.*.*.*
 install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5Quick.so.*.*.*
-install -m 0644 -t $RPM_BUILD_ROOT/opt/overte/lib $QT5_LIBS/libQt5ScriptTools.so.*.*.*
 %endif
 install -d $RPM_BUILD_ROOT/usr/lib/systemd/system
 install -m 0644 -t $RPM_BUILD_ROOT/usr/lib/systemd/system $OVERTE/pkg-scripts/overte-assignment-client.service

--- a/tools/ci-scripts/deb_package/Dockerfile_build_debian-11
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_debian-11
@@ -15,7 +15,7 @@ RUN echo UTC >/etc/timezone
 RUN apt-get update && apt-get -y install tzdata
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN apt-get -y install curl ninja-build git g++ libssl-dev libqt5websockets5-dev qtscript5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystemd-dev
+RUN apt-get -y install curl ninja-build git g++ libssl-dev libqt5websockets5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystemd-dev
 
 # Install CMake from Debian Backports
 RUN echo deb http://deb.debian.org/debian bullseye-backports main > /etc/apt/sources.list.d/bullseye-backports.list

--- a/tools/ci-scripts/deb_package/Dockerfile_build_debian-12
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_debian-12
@@ -1,0 +1,39 @@
+# Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
+
+# Docker file for building Overte Server
+# Example build: docker build -t overte/overte-server-build:0.1.3-debian-12 -f Dockerfile_build_debian-12 .
+FROM debian:bookworm
+LABEL maintainer="Julian Groß (julian.gro@overte.org)"
+LABEL description="Development image for Overte Domain server and assignment clients."
+
+# Don't use any frontend when installing packages during the creation of this container
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN echo UTC >/etc/timezone
+# Installing via dependency causes interactive hang:
+RUN apt-get update && apt-get -y install tzdata
+
+# Install Overte domain-server and assignment-client build dependencies
+RUN apt-get -y install cmake curl ninja-build git g++ libssl-dev libqt5websockets5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystemd-dev
+
+# Install Overte tools build dependencies
+RUN apt-get -y install libqt5webchannel5-dev qtwebengine5-dev libqt5xmlpatterns5-dev
+
+# Install tools for package creation
+RUN apt-get -y install sudo chrpath binutils dh-make
+
+# Install locales package
+RUN apt-get -y install locales
+# Uncomment en_US.UTF-8 for inclusion in generation
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
+# Generate locale
+RUN locale-gen
+
+# Export env vars
+RUN echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc
+RUN echo "export LANG=en_US.UTF-8" >> ~/.bashrc
+RUN echo "export LANGUAGE=en_US.UTF-8" >> ~/.bashrc
+
+# Install tools needed for our Github Actions Workflow
+Run apt-get -y install python3-boto3 python3-github zip

--- a/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/deb_package/Dockerfile_build_ubuntu-22.04
@@ -15,7 +15,7 @@ RUN echo UTC >/etc/timezone
 RUN apt-get update && apt-get -y install tzdata
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN apt-get -y install curl ninja-build git cmake g++ libssl-dev libqt5websockets5-dev qtscript5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystemd-dev
+RUN apt-get -y install curl ninja-build git cmake g++ libssl-dev libqt5websockets5-dev qtdeclarative5-dev qtmultimedia5-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystemd-dev
 # Install Overte tools build dependencies
 RUN apt-get -y install libqt5webchannel5-dev qtwebengine5-dev libqt5xmlpatterns5-dev
 

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-36
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-36
@@ -8,7 +8,7 @@ LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
+RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
 
 # Install additional build tools
 RUN dnf -y install zip unzip

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-37
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-37
@@ -8,7 +8,7 @@ LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
+RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
 
 # Install additional build tools
 RUN dnf -y install zip unzip

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-38
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_fedora-38
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte Server
-# Example build: docker build -t overte/overte-server-build:0.1.3-fedora-36 -f Dockerfile_build_fedora-36 .
-FROM fedora:36
+# Example build: docker build -t overte/overte-server-build:0.1.3-fedora-38 -f Dockerfile_build_fedora-38 .
+FROM fedora:38
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for Overte Domain server and assignment clients."
 

--- a/tools/ci-scripts/rpm_package/Dockerfile_build_rockylinux-9
+++ b/tools/ci-scripts/rpm_package/Dockerfile_build_rockylinux-9
@@ -16,7 +16,7 @@ RUN dnf -y install epel-release
 RUN dnf config-manager --enable crb
 
 # Install Overte domain-server and assignment-client build dependencies
-RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtscript-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
+RUN dnf -y install curl ninja-build git cmake gcc-c++ openssl-devel qt5-qtwebsockets-devel qt5-qtmultimedia-devel unzip libXext-devel qt5-qtwebchannel-devel qt5-qtwebengine-devel qt5-qtxmlpatterns-devel systemd-devel
 
 # Install additional build tools
 RUN dnf -y install zip unzip


### PR DESCRIPTION
This PR updates Linux server packaging for all the changes that happened in the last couple of weeks.
Namely it:
- adds Debian 12 package building
- adds libnode to Debian and RPM packages
- removes Qt Script from future Docker build environments
- disables crashpad on aarch64 Linux, as crashpad doesn't support the platform (and an initial try at making it support the platform turned out to be too involved for now).
- adds Fedora 38 support
- removes Fedora 36 support



Fixes https://github.com/overte-org/overte/issues/429