### PR TITLE
Improve audio settings

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -337,6 +337,9 @@ void Agent::selectAudioFormat(const QString& selectedCodecName) {
             _codec = plugin;
             _receivedAudioStream.setupCodec(plugin, _selectedCodecName, AudioConstants::STEREO);
             _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, AudioConstants::MONO);
+
+            //TODO: _codecSettings is not being set by anything -- where do we receive the settings here?
+            _encoder->configure(_codecSettings);
             qDebug() << "Selected Codec Plugin:" << _codec.get();
             break;
         }
@@ -730,7 +733,7 @@ void Agent::processAgentAvatarAudio() {
             if (isPlayingRecording && !_shouldMuteRecordingAudio) {
                 _shouldMuteRecordingAudio = true;
             }
-            
+
             auto audioData = _avatarSound->getAudioData();
             nextSoundOutput = reinterpret_cast<const int16_t*>(audioData->rawData()
                     + _numAvatarSoundSentBytes);
@@ -891,7 +894,7 @@ void Agent::aboutToFinish() {
     {
         DependencyManager::get<ScriptEngines>()->shutdownScripting();
     }
-    
+
     DependencyManager::destroy<ScriptEngines>();
 
     DependencyManager::destroy<AssignmentDynamicFactory>();

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -129,6 +129,7 @@ private:
     Encoder* _encoder { nullptr };
     QTimer _avatarAudioTimer;
     bool _flushEncoder { false };
+    std::vector<Encoder::CodecSettings> _codecSettings;
 };
 
 #endif // hifi_Agent_h

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -59,7 +59,10 @@ float AudioMixer::_noiseMutingThreshold{ DEFAULT_NOISE_MUTING_THRESHOLD };
 float AudioMixer::_attenuationPerDoublingInDistance{ DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE };
 map<QString, shared_ptr<CodecPlugin>> AudioMixer::_availableCodecs{ };
 QStringList AudioMixer::_codecPreferenceOrder{};
+
 unordered_map<QString, AudioMixer::ZoneSettings> AudioMixer::_audioZones;
+vector<Encoder::CodecSettings> AudioMixer::_codecSettings;
+
 
 AudioMixer::AudioMixer(ReceivedMessage& message) :
     ThreadedAssignment(message)
@@ -227,6 +230,7 @@ void AudioMixer::handleNodeMuteRequestPacket(QSharedPointer<ReceivedMessage> pac
             // we need to set a flag so we send them the appropriate packet to mute them
             AudioMixerClientData* nodeData = (AudioMixerClientData*)node->getLinkedData();
             nodeData->setShouldMuteClient(true);
+            nodeData->setCodecSettings(_codecSettings);
         } else {
             qWarning() << "Node mute packet received for unknown node " << uuidStringWithoutCurlyBraces(nodeUUID);
         }
@@ -401,6 +405,7 @@ AudioMixerClientData* AudioMixer::getOrCreateClientData(Node* node) {
         node->setLinkedData(unique_ptr<NodeData> { new AudioMixerClientData(node->getUUID(), node->getLocalID()) });
         clientData = dynamic_cast<AudioMixerClientData*>(node->getLinkedData());
         connect(clientData, &AudioMixerClientData::injectorStreamFinished, this, &AudioMixer::removeHRTFsForFinishedInjector);
+        clientData->setCodecSettings(_codecSettings);
     }
 
     return clientData;
@@ -810,6 +815,8 @@ void AudioMixer::parseSettingsObject(const QJsonObject& settingsObject) {
                 }
             }
         }
+
+        _codecSettings = Encoder::parseSettings(audioEnvGroupObject);
     }
 }
 

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -26,6 +26,7 @@
 #include "AudioMixerWorkerPool.h"
 
 #include "../entities/EntityTreeHeadlessViewer.h"
+#include "plugins/CodecPlugin.h"
 
 class PositionalAudioStream;
 class AvatarAudioStream;
@@ -50,11 +51,25 @@ public:
         std::vector<float> coefficients;
     };
 
+/*
+    struct CodecSettings {
+        QString codec;
+        Encoder::Bandpass bandpass = Encoder::Bandpass::Fullband;
+        Encoder::ApplicationType applicationType = Encoder::ApplicationType::Audio;
+        Encoder::SignalType signalType = Encoder::SignalType::Auto;
+        int bitrate = 128000;
+        int complexity = 100;
+        bool enableFEC = 0;
+        int packetLossPercent = 0;
+        bool enableVBR = 1;
+    };
+*/
     static int getStaticJitterFrames() { return _numStaticJitterFrames; }
     static bool shouldMute(float quietestFrame) { return quietestFrame > _noiseMutingThreshold; }
     static float getAttenuationPerDoublingInDistance() { return _attenuationPerDoublingInDistance; }
     static const std::unordered_map<QString, ZoneSettings>& getAudioZones() { return _audioZones; }
     static const std::pair<QString, CodecPluginPointer> negotiateCodec(std::vector<QString> codecs);
+    static const std::vector<Encoder::CodecSettings> getCodecSettings() { return _codecSettings; }
 
     static bool shouldReplicateTo(const Node& from, const Node& to) {
         return to.getType() == NodeType::DownstreamAudioMixer &&
@@ -63,7 +78,7 @@ public:
     }
 
     virtual void aboutToFinish() override;
-    
+
 public slots:
     void run() override;
     void sendStatsPacket() override;
@@ -148,6 +163,7 @@ private:
     static QStringList _codecPreferenceOrder;
 
     static std::unordered_map<QString, ZoneSettings> _audioZones;
+    static std::vector<Encoder::CodecSettings> _codecSettings;
 
     float _throttleStartTarget = 0.9f;
     float _throttleBackoffTarget = 0.44f;

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -165,7 +165,7 @@ void AudioMixerClientData::optionallyReplicatePacket(ReceivedMessage& message, c
 
                     packet->write(message.getMessage());
                 }
-                
+
                 nodeList->sendUnreliablePacket(*packet, *downstreamNode);
             }
         });
@@ -385,7 +385,7 @@ int AudioMixerClientData::parseData(ReceivedMessage& message) {
             qWarning() << "Received AudioStreamStats of wrong size" << message.getBytesLeftToRead()
                 << "instead of" << sizeof(AudioStreamStats) << "from"
                 << message.getSourceID() << "at" << message.getSenderSockAddr();
-            
+
             return message.getPosition();
         }
 
@@ -793,6 +793,8 @@ void AudioMixerClientData::setupCodec(CodecPluginPointer codec, const QString& c
     if (codec) {
         _encoder = codec->createEncoder(AudioConstants::SAMPLE_RATE, AudioConstants::STEREO);
         _decoder = codec->createDecoder(AudioConstants::SAMPLE_RATE, AudioConstants::MONO);
+
+        _encoder->configure(_codecSettings);
     }
 
     auto avatarAudioStream = getAvatarAudioStream();

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -104,6 +104,7 @@ public:
     bool shouldFlushEncoder() { return _shouldFlushEncoder; }
 
     QString getCodecName() { return _selectedCodecName; }
+    void setCodecSettings(const std::vector<Encoder::CodecSettings> &settings) { _codecSettings = settings; }
 
     bool shouldMuteClient() { return _shouldMuteClient; }
     void setShouldMuteClient(bool shouldMuteClient) { _shouldMuteClient = shouldMuteClient; }
@@ -197,6 +198,7 @@ private:
     QString _selectedCodecName;
     Encoder* _encoder{ nullptr }; // for outbound mixed stream
     Decoder* _decoder{ nullptr }; // for mic stream
+    std::vector<Encoder::CodecSettings> _codecSettings;
 
     bool _shouldFlushEncoder { false };
 

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -179,6 +179,13 @@ void EntityScriptServer::handleSettings() {
     _maxEntityPPS = std::max(0, entityScriptServerSettings[MAX_ENTITY_PPS_OPTION].toInt());
     _entityPPSPerScript = std::max(0, entityScriptServerSettings[ENTITY_PPS_PER_SCRIPT].toInt());
 
+    static const QString AUDIO_ENV_GROUP_KEY = "audio_env";
+    if ( settingsObject.contains(AUDIO_ENV_GROUP_KEY)) {
+        _codecSettings = Encoder::parseSettings(settingsObject[AUDIO_ENV_GROUP_KEY].toObject());
+    } else {
+        qWarning() << "Failed to find" << AUDIO_ENV_GROUP_KEY << "key in settings. Dump: " << settingsObject;
+    }
+
     qDebug() << QString("Received entity script server settings, Max Entity PPS: %1, Entity PPS Per Entity Script: %2")
                 .arg(_maxEntityPPS).arg(_entityPPSPerScript);
 }
@@ -459,6 +466,7 @@ void EntityScriptServer::selectAudioFormat(const QString& selectedCodecName) {
         if (_selectedCodecName == plugin->getName()) {
             _codec = plugin;
             _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, AudioConstants::MONO);
+            _encoder->configure(_codecSettings);
             qCDebug(entity_script_server) << "Selected Codec Plugin:" << _codec.get();
             break;
         }

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -31,6 +31,7 @@
 #include <QJsonArray>
 
 #include "../entities/EntityTreeHeadlessViewer.h"
+#include "plugins/CodecPlugin.h"
 
 class EntityScriptServer : public ThreadedAssignment {
     Q_OBJECT
@@ -121,6 +122,7 @@ private:
     QString _selectedCodecName;
     CodecPluginPointer _codec;
     Encoder* _encoder { nullptr };
+    std::vector<Encoder::CodecSettings> _codecSettings;
 };
 
 #endif // hifi_EntityScriptServer_h

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1414,43 +1414,89 @@
             {
               "name": "codec",
               "label": "Codec",
-              "can_set": false,
-              "placeholder": "(codec)"
+              "can_set": true,
+              "placeholder": "(codec)",
+              "editable": false
             },
             {
               "name": "complexity",
               "label": "Complexity",
               "can_set": true,
               "type": "int",
-              "placeholder": "(percentage)"
+              "placeholder": "(percentage)",
+              "default": 0,
+              "editable": true
             },
             {
               "name": "bitrate",
               "label": "Bitrate",
               "can_set": true,
-              "placeholder": "(bps)"
+              "placeholder": "(bps)",
+              "default" : 0,
+              "editable": true
             },
             {
               "name": "vbr",
               "label": "Variable Bitrate",
               "can_set": true,
-              "type": "checkbox"
+              "type": "checkbox",
+              "default": false,
+              "editable": true
             },
             {
               "name": "fec",
               "label": "Error correction",
               "can_set": true,
               "type": "checkbox",
-              "placeholder": "(percentage)"
+              "default" : false,
+              "editable": true
             },
             {
               "name": "packet_loss",
               "label": "Expected loss %",
               "can_set": true,
               "type": "int",
-              "placeholder": "(percentage)"
+              "placeholder": "(percentage)",
+              "default": 0,
+              "editable": true
             }
 
+          ],
+          "non-deletable-row-key": "codec",
+          "non-deletable-row-values": [ "pcm", "zlib", "hifiAC", "opus" ],
+          "default": [
+            {
+                "codec": "pcm",
+                "complexity": 0,
+                "bitrate": 0,
+                "vbr": false,
+                "fec": false,
+                "packet_loss": 0
+            },
+            {
+              "codec": "zlib",
+              "complexity": 6,
+              "bitrate": 0,
+              "vbr": false,
+              "fec": false,
+              "packet_loss": 0
+            },
+            {
+              "codec": "hifiAC",
+              "complexity": 0,
+              "bitrate": 0,
+              "vbr": false,
+              "fec": false,
+              "packet_loss": 0
+            },
+            {
+              "codec": "opus",
+              "complexity": 10,
+              "bitrate": 128000,
+              "vbr": true,
+              "fec": false,
+              "packet_loss": 0
+            }
           ]
         }
       ]

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1256,7 +1256,7 @@
     {
       "name": "audio_env",
       "label": "Audio Environment",
-      "assignment-types": [ 0 ],
+      "assignment-types": [ 0, 5 ],
       "settings": [
         {
           "name": "attenuation_per_doubling_in_distance",
@@ -1400,6 +1400,58 @@
           "placeholder": "opus, zlib, pcm",
           "default": "opus,zlib,pcm",
           "advanced": true
+        },
+        {
+          "name": "codec_settings",
+          "label": "Audio Codec Settings",
+          "help": "Advanced settings for audio codecs",
+          "advanced": true,
+          "type": "table",
+          "numbered": false,
+          "content_setting": false,
+          "can_add_new_rows": true,
+          "columns" : [
+            {
+              "name": "codec",
+              "label": "Codec",
+              "can_set": false,
+              "placeholder": "(codec)"
+            },
+            {
+              "name": "complexity",
+              "label": "Complexity",
+              "can_set": true,
+              "type": "int",
+              "placeholder": "(percentage)"
+            },
+            {
+              "name": "bitrate",
+              "label": "Bitrate",
+              "can_set": true,
+              "placeholder": "(bps)"
+            },
+            {
+              "name": "vbr",
+              "label": "Variable Bitrate",
+              "can_set": true,
+              "type": "checkbox"
+            },
+            {
+              "name": "fec",
+              "label": "Error correction",
+              "can_set": true,
+              "type": "checkbox",
+              "placeholder": "(percentage)"
+            },
+            {
+              "name": "packet_loss",
+              "label": "Expected loss %",
+              "can_set": true,
+              "type": "int",
+              "placeholder": "(percentage)"
+            }
+
+          ]
         }
       ]
     },

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1431,6 +1431,7 @@
               "name": "bitrate",
               "label": "Bitrate",
               "can_set": true,
+              "type": "int",
               "placeholder": "(bps)",
               "default" : 0,
               "editable": true

--- a/domain-server/resources/web/js/base-settings.js
+++ b/domain-server/resources/web/js/base-settings.js
@@ -138,7 +138,7 @@ function reloadSettings(callback) {
     Settings.pendingChanges = 0;
 
     // call the callback now that settings are loaded
-    if (callback) { 
+    if (callback) {
       callback(true);
     }
   }).fail(function() {
@@ -590,6 +590,12 @@ function makeTable(setting, keypath, setting_value) {
             "<td class='" + Settings.DATA_COL_CLASS + "'name='" + col.name + "'>" +
               "<input type='time' class='form-control table-time' name='" + colName + "' " +
                      "value='" + (colValue || col.default || "00:00") + "'/>" +
+            "</td>";
+        } else if (isArray && col.type === "int" && col.editable) {
+          html +=
+            "<td class='" + Settings.DATA_COL_CLASS + "'name='" + col.name + "'>" +
+              "<input type='int' class='form-control table-time' name='" + colName + "' " +
+                      "value='" + (colValue || col.default || "0") + "'/>" +
             "</td>";
         } else {
           // Use a hidden input so that the values are posted.

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -503,6 +503,95 @@ void AudioClient::setAllowedCodecs(const QStringList &userCodecs) {
     negotiateAudioFormat();
 }
 
+QMap<QString,bool> AudioClient::getEncoderFeatures() {
+    QMap<QString,bool> features;
+
+    if (_encoder) {
+        features.insert("isLossless", _encoder->isLossless());
+        features.insert("hasApplication", _encoder->hasApplication());
+        features.insert("hasComplexity", _encoder->hasComplexity());
+        features.insert("hasBitrate", _encoder->hasBitrate());
+        features.insert("hasFEC", _encoder->hasFEC());
+        features.insert("hasPacketLossPercent", _encoder->hasPacketLossPercent());
+        features.insert("hasBandpass", _encoder->hasBandpass());
+        features.insert("hasSignalType", _encoder->hasSignalType());
+        features.insert("hasVBR", _encoder->hasVBR());
+    }
+
+    return features;
+}
+
+bool AudioClient::getEncoderVBR() {
+    if (_encoder) {
+        return _encoder->getVBR();
+    }
+
+    return false;
+}
+
+void AudioClient::setEncoderVBR(bool enabled) {
+    if (_encoder) {
+        _encoder->setVBR(enabled);
+    }
+}
+
+int AudioClient::getEncoderBitrate() {
+    if (_encoder) {
+        return _encoder->getBitrate();
+    }
+
+    return 0;
+}
+
+void AudioClient::setEncoderBitrate(int bitrate) {
+    if (_encoder) {
+        _encoder->setBitrate(bitrate);
+    }
+}
+
+int AudioClient::getEncoderComplexity() {
+    if (_encoder) {
+        return _encoder->getComplexity();
+    }
+
+    return 0;
+}
+
+void AudioClient::setEncoderComplexity(int complexity) {
+    if (_encoder) {
+        _encoder->setComplexity(complexity);
+    }
+}
+
+bool AudioClient::getEncoderFEC() {
+    if (_encoder) {
+        return _encoder->getFEC();
+    }
+
+    return false;
+}
+
+void AudioClient::setEncoderFEC(bool enabled) {
+    if (_encoder) {
+        _encoder->setFEC(enabled);
+    }
+}
+
+int AudioClient::getEncoderPacketLossPercent() {
+    if (_encoder) {
+        return _encoder->getPacketLossPercent();
+    }
+
+    return 0;
+}
+
+void AudioClient::setEncoderPacketLossPercent(int percent) {
+    if (_encoder) {
+        _encoder->setPacketLossPercent(percent);
+    }
+}
+
+
 HifiAudioDeviceInfo getNamedAudioDeviceForMode(QAudio::Mode mode, const QString& deviceName, const QString& hmdName, bool isHmd=false) {
     HifiAudioDeviceInfo result;
     foreach (HifiAudioDeviceInfo audioDevice, getAvailableDevices(mode,hmdName)) {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -99,7 +99,7 @@ void AudioClient::setHmdAudioName(QAudio::Mode mode, const QString& name) {
 // thread-safe
 QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString& hmdName) {
     //get hmd device name prior to locking device mutex. in case of shutdown, this thread will be locked and audio client
-    //cannot properly shut down. 
+    //cannot properly shut down.
     QString defDeviceName = defaultAudioDeviceName(mode);
 
     // NOTE: availableDevices() clobbers the Qt internal device list
@@ -136,7 +136,7 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString&
                 break;
             }
         }
-        
+
         if (!hmdDevice.getDevice().isNull()) {
             newDevices.push_front(hmdDevice);
         }
@@ -163,7 +163,7 @@ void AudioClient::checkDevices() {
 
     auto inputDevices = getAvailableDevices(QAudio::AudioInput, hmdInputName);
     auto outputDevices = getAvailableDevices(QAudio::AudioOutput, hmdOutputName);
-   
+
     static const QMetaMethod devicesChangedSig= QMetaMethod::fromSignal(&AudioClient::devicesChanged);
     //only emit once the scripting interface has connected to the signal
     if (isSignalConnected(devicesChangedSig)) {
@@ -177,7 +177,7 @@ void AudioClient::checkDevices() {
             _outputDevices.swap(outputDevices);
             emit devicesChanged(QAudio::AudioOutput, _outputDevices);
         }
-    } 
+    }
 }
 
 HifiAudioDeviceInfo AudioClient::getActiveAudioDevice(QAudio::Mode mode) const {
@@ -284,7 +284,7 @@ static float computeLoudness(int16_t* samples, int numSamples) {
 
 template <int NUM_CHANNELS>
 static void applyGainSmoothing(float* buffer, int numFrames, float gain0, float gain1) {
-    
+
     // fast path for unity gain
     if (gain0 == 1.0f && gain1 == 1.0f) {
         return;
@@ -299,7 +299,7 @@ static void applyGainSmoothing(float* buffer, int numFrames, float gain0, float 
     float tStep = 1.0f / numFrames;
 
     for (int i = 0; i < numFrames; i++) {
-   
+
         // evaluate poly over t=[0,1)
         float gain = (c3 * t + c2) * t * t + c0;
         t += tStep;
@@ -403,7 +403,7 @@ AudioClient::AudioClient() {
         PacketReceiver::makeUnsourcedListenerReference<AudioClient>(this, &AudioClient::handleSelectedAudioFormat));
 
     auto& domainHandler = nodeList->getDomainHandler();
-    connect(&domainHandler, &DomainHandler::disconnectedFromDomain, this, [this] { 
+    connect(&domainHandler, &DomainHandler::disconnectedFromDomain, this, [this] {
         _solo.reset();
     });
     connect(nodeList.data(), &NodeList::nodeActivated, this, [this](SharedNodePointer node) {
@@ -595,7 +595,7 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
             waveInGetDevCaps(WAVE_MAPPER, &wic, sizeof(wic));
             //Use the received manufacturer id to get the device's real name
             waveInGetDevCaps(wic.wMid, &wic, sizeof(wic));
-#if !defined(NDEBUG) 
+#if !defined(NDEBUG)
             qCDebug(audioclient) << "input device:" << wic.szPname;
 #endif
             deviceName = wic.szPname;
@@ -605,7 +605,7 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
             waveOutGetDevCaps(WAVE_MAPPER, &woc, sizeof(woc));
             //Use the received manufacturer id to get the device's real name
             waveOutGetDevCaps(woc.wMid, &woc, sizeof(woc));
-#if !defined(NDEBUG) 
+#if !defined(NDEBUG)
             qCDebug(audioclient) << "output device:" << woc.szPname;
 #endif
             deviceName = woc.szPname;
@@ -630,8 +630,8 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
         CoUninitialize();
     }
 
-#if !defined(NDEBUG) 
-    qCDebug(audioclient) << "defaultAudioDeviceForMode mode: " << (mode == QAudio::AudioOutput ? "Output" : "Input") 
+#if !defined(NDEBUG)
+    qCDebug(audioclient) << "defaultAudioDeviceForMode mode: " << (mode == QAudio::AudioOutput ? "Output" : "Input")
 	<< " [" << deviceName << "] [" << "]";
 #endif
 
@@ -812,7 +812,7 @@ void AudioClient::start() {
 
     _desiredOutputFormat = _desiredInputFormat;
     _desiredOutputFormat.setChannelCount(OUTPUT_CHANNEL_COUNT);
-    
+
     QString inputName;
     QString outputName;
     {
@@ -824,7 +824,8 @@ void AudioClient::start() {
     // Input was originally set to HifiAudioDeviceInfo(), but that was causing trouble.
     //Original comment: initialize input to the dummy device to prevent starves
     switchInputToAudioDevice(defaultAudioDeviceForMode(QAudio::AudioInput, QString()));
-    switchOutputToAudioDevice(defaultAudioDeviceForMode(QAudio::AudioOutput, QString())); 
+    switchOutputToAudioDevice(defaultAudioDeviceForMode(QAudio::AudioOutput, QString()));
+
 
 #if defined(Q_OS_ANDROID)
     connect(&_checkInputTimer, &QTimer::timeout, this, &AudioClient::checkInputTimeout);
@@ -1023,6 +1024,7 @@ void AudioClient::selectAudioFormat(const QString& selectedCodecName) {
             _codec = plugin;
             _receivedAudioStream.setupCodec(plugin, _selectedCodecName, AudioConstants::STEREO);
             _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, _isStereoInput ? AudioConstants::STEREO : AudioConstants::MONO);
+            _encoder->configure(_codecSettings);
             qCDebug(audioclient) << "Selected codec plugin:" << _codec.get();
             break;
         }
@@ -1033,7 +1035,7 @@ void AudioClient::selectAudioFormat(const QString& selectedCodecName) {
 bool AudioClient::switchAudioDevice(QAudio::Mode mode, const HifiAudioDeviceInfo& deviceInfo) {
     auto device = deviceInfo;
     if (deviceInfo.getDevice().isNull()) {
-        qCDebug(audioclient) << __FUNCTION__ << " switching to null device :" 
+        qCDebug(audioclient) << __FUNCTION__ << " switching to null device :"
             << deviceInfo.deviceName() << " : " << deviceInfo.getDevice().deviceName();
     }
 
@@ -1880,7 +1882,7 @@ void AudioClient::outputFormatChanged() {
 bool AudioClient::switchInputToAudioDevice(const HifiAudioDeviceInfo inputDeviceInfo, bool isShutdownRequest) {
     Q_ASSERT_X(QThread::currentThread() == thread(), Q_FUNC_INFO, "Function invoked on wrong thread");
 
-    qCDebug(audioclient) << __FUNCTION__ << "_inputDeviceInfo: [" << _inputDeviceInfo.deviceName() << ":" << _inputDeviceInfo.getDevice().deviceName() 
+    qCDebug(audioclient) << __FUNCTION__ << "_inputDeviceInfo: [" << _inputDeviceInfo.deviceName() << ":" << _inputDeviceInfo.getDevice().deviceName()
         << "-- inputDeviceInfo:" << inputDeviceInfo.deviceName() << ":" << inputDeviceInfo.getDevice().deviceName() << "]";
     bool supportedFormat = false;
 
@@ -1935,7 +1937,7 @@ bool AudioClient::switchInputToAudioDevice(const HifiAudioDeviceInfo inputDevice
 
     if (!inputDeviceInfo.getDevice().isNull()) {
         qCDebug(audioclient) << "The audio input device" << inputDeviceInfo.deviceName() << ":" << inputDeviceInfo.getDevice().deviceName() << "is available.";
-      
+
         //do not update UI that we're changing devices if default or same device
         _inputDeviceInfo = inputDeviceInfo;
         emit deviceChanged(QAudio::AudioInput, _inputDeviceInfo);
@@ -2109,13 +2111,13 @@ void AudioClient::outputNotify() {
 
 void AudioClient::noteAwakening() {
     qCDebug(audioclient) << "Restarting the audio devices.";
-    switchInputToAudioDevice(_inputDeviceInfo); 
+    switchInputToAudioDevice(_inputDeviceInfo);
     switchOutputToAudioDevice(_outputDeviceInfo);
 }
 
 bool AudioClient::switchOutputToAudioDevice(const HifiAudioDeviceInfo outputDeviceInfo, bool isShutdownRequest) {
     Q_ASSERT_X(QThread::currentThread() == thread(), Q_FUNC_INFO, "Function invoked on wrong thread");
-    
+
     qCDebug(audioclient) << __FUNCTION__ << "_outputdeviceInfo: [" << _outputDeviceInfo.deviceName() << ":" << _outputDeviceInfo.getDevice().deviceName()
         << "-- outputDeviceInfo:" << outputDeviceInfo.deviceName() << ":" << outputDeviceInfo.getDevice().deviceName() << "]";
     bool supportedFormat = false;
@@ -2155,7 +2157,7 @@ bool AudioClient::switchOutputToAudioDevice(const HifiAudioDeviceInfo outputDevi
 
         delete[] _localOutputMixBuffer;
         _localOutputMixBuffer = NULL;
-        
+
         _outputDeviceInfo.setDevice(QAudioDeviceInfo());
     }
 
@@ -2182,7 +2184,7 @@ bool AudioClient::switchOutputToAudioDevice(const HifiAudioDeviceInfo outputDevi
 
     if (!outputDeviceInfo.getDevice().isNull()) {
         qCDebug(audioclient) << "The audio output device" << outputDeviceInfo.deviceName() << ":" << outputDeviceInfo.getDevice().deviceName() << "is available.";
-        
+
         //do not update UI that we're changing devices if default or same device
         _outputDeviceInfo = outputDeviceInfo;
         emit deviceChanged(QAudio::AudioOutput, _outputDeviceInfo);
@@ -2416,7 +2418,7 @@ qint64 AudioClient::AudioOutputIODevice::readData(char * data, qint64 maxSize) {
             qCDebug(audiostream, "Read %d samples from injectors (%d available, %d requested)", injectorSamplesPopped, _localInjectorsStream.samplesAvailable(), samplesRequested);
         }
     }
-    
+
     // prepare injectors for the next callback
      _audio->_localPrepInjectorFuture = QtConcurrent::run(QThreadPool::globalInstance(), [this] {
         _audio->prepareLocalAudioInjectors();

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -461,6 +461,48 @@ void AudioClient::setAudioPaused(bool pause) {
     }
 }
 
+
+QStringList AudioClient::getCodecs() {
+    QStringList codecs;
+
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    for (const auto& plugin : codecPlugins) {
+        codecs << plugin->getName();
+    }
+
+    return codecs;
+}
+
+QString AudioClient::getCodec() {
+    if ( _encoder ) {
+        return _encoder->getName();
+    }
+
+    return "";
+}
+
+void AudioClient::setAllowedCodecs(const QStringList &userCodecs) {
+    QStringList list;
+    QSet<QString> knownCodecs;
+
+
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    for (const auto& plugin : codecPlugins) {
+        knownCodecs << plugin->getName();
+    }
+
+    for(const auto &uc : userCodecs) {
+        if ( knownCodecs.contains(uc)) {
+            list << uc;
+        } else {
+            qCWarning(audioclient) << "setAllowedCodecs called with unknown codec name" << uc;
+        }
+    }
+
+    _allowedCodecs = list;
+    negotiateAudioFormat();
+}
+
 HifiAudioDeviceInfo getNamedAudioDeviceForMode(QAudio::Mode mode, const QString& deviceName, const QString& hmdName, bool isHmd=false) {
     HifiAudioDeviceInfo result;
     foreach (HifiAudioDeviceInfo audioDevice, getAvailableDevices(mode,hmdName)) {
@@ -984,12 +1026,19 @@ void AudioClient::negotiateAudioFormat() {
     auto negotiateFormatPacket = NLPacket::create(PacketType::NegotiateAudioFormat);
     const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
     quint8 numberOfCodecs = (quint8)codecPlugins.size();
-    negotiateFormatPacket->writePrimitive(numberOfCodecs);
-    for (const auto& plugin : codecPlugins) {
-        auto codecName = plugin->getName();
-        negotiateFormatPacket->writeString(codecName);
-    }
 
+    if ( _allowedCodecs.length() ) {
+        negotiateFormatPacket->writePrimitive((quint8)_allowedCodecs.length());
+        for (const auto& codecName : _allowedCodecs) {
+            negotiateFormatPacket->writeString(codecName);
+        }
+    } else {
+        negotiateFormatPacket->writePrimitive(numberOfCodecs);
+        for (const auto& plugin : codecPlugins) {
+            auto codecName = plugin->getName();
+            negotiateFormatPacket->writeString(codecName);
+        }
+    }
     // grab our audio mixer from the NodeList, if it exists
     SharedNodePointer audioMixer = nodeList->soloNodeOfType(NodeType::AudioMixer);
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -545,7 +545,7 @@ int AudioClient::getEncoderBitrate() {
 
 void AudioClient::setEncoderBitrate(int bitrate) {
     if (_encoder) {
-        _encoder->setBitrate(bitrate);
+        _encoder->setBitrate(std::clamp(bitrate, 0, std::numeric_limits<int>::max()));
     }
 }
 
@@ -559,7 +559,7 @@ int AudioClient::getEncoderComplexity() {
 
 void AudioClient::setEncoderComplexity(int complexity) {
     if (_encoder) {
-        _encoder->setComplexity(complexity);
+        _encoder->setComplexity(std::clamp(complexity, 0, 100));
     }
 }
 
@@ -587,7 +587,7 @@ int AudioClient::getEncoderPacketLossPercent() {
 
 void AudioClient::setEncoderPacketLossPercent(int percent) {
     if (_encoder) {
-        _encoder->setPacketLossPercent(percent);
+        _encoder->setPacketLossPercent(std::clamp(percent, 0, 100));
     }
 }
 

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -194,6 +194,23 @@ public:
     void setAllowedCodecs(const QStringList &codecs) override;
     void setCodecSettings(const std::vector<Encoder::CodecSettings> &settings ) { _codecSettings = settings; }
 
+    QMap<QString,bool> getEncoderFeatures() override;
+
+    bool getEncoderVBR() override;
+    void setEncoderVBR(bool enabled) override;
+
+    int getEncoderBitrate() override;
+    void setEncoderBitrate(int bitrate) override;
+
+    int getEncoderComplexity() override;
+    void setEncoderComplexity(int complexity) override;
+
+    bool getEncoderFEC() override;
+    void setEncoderFEC(bool enabled) override;
+
+    int getEncoderPacketLossPercent() override;
+    void setEncoderPacketLossPercent(int percent) override;
+
 #ifdef Q_OS_WIN
     static QString getWinDeviceName(wchar_t* guid);
 #endif

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -124,7 +124,7 @@ public:
         AudioClient* _audio;
         int _unfulfilledReads;
     };
-    
+
     void startThread();
     void negotiateAudioFormat();
     void selectAudioFormat(const QString& selectedCodecName);
@@ -170,7 +170,7 @@ public:
 
     HifiAudioDeviceInfo getActiveAudioDevice(QAudio::Mode mode) const;
     QList<HifiAudioDeviceInfo> getAudioDevices(QAudio::Mode mode) const;
-  
+
     void enablePeakValues(bool enable) { _enablePeakValues = enable; }
     bool peakValuesAvailable() const;
 
@@ -186,6 +186,7 @@ public:
     void setAudioPaused(bool pause);
 
     AudioSolo& getAudioSolo() override { return _solo; }
+    void setCodecSettings(const std::vector<Encoder::CodecSettings> &settings ) { _codecSettings = settings; }
 
 #ifdef Q_OS_WIN
     static QString getWinDeviceName(wchar_t* guid);
@@ -225,10 +226,10 @@ public slots:
 
     void setNoiseReduction(bool isNoiseGateEnabled, bool emitSignal = true);
     bool isNoiseReductionEnabled() const { return _isNoiseGateEnabled; }
-    
+
     void setNoiseReductionAutomatic(bool isNoiseGateAutomatic, bool emitSignal = true);
     bool isNoiseReductionAutomatic() const { return _isNoiseReductionAutomatic; }
-    
+
     void setNoiseReductionThreshold(float noiseReductionThreshold, bool emitSignal = true);
     float noiseReductionThreshold() const { return _noiseReductionThreshold; }
 
@@ -338,6 +339,7 @@ private:
     bool mixLocalAudioInjectors(float* mixBuffer);
     float azimuthForSource(const glm::vec3& relativePosition);
     float gainForSource(float distance, float volume);
+    std::vector<Encoder::CodecSettings> _codecSettings;
 
 #ifdef Q_OS_ANDROID
     QTimer _checkInputTimer{ this };
@@ -527,7 +529,7 @@ private:
 #endif
 
     AudioSolo _solo;
-    
+
     QFuture<void> _localPrepInjectorFuture;
     QReadWriteLock _hmdNameLock;
     Mutex _checkDevicesMutex;

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -186,6 +186,12 @@ public:
     void setAudioPaused(bool pause);
 
     AudioSolo& getAudioSolo() override { return _solo; }
+
+    QStringList getCodecs() override;
+    QString getCodec() override;
+
+    QStringList getAllowedCodecs() override { return _allowedCodecs; }
+    void setAllowedCodecs(const QStringList &codecs) override;
     void setCodecSettings(const std::vector<Encoder::CodecSettings> &settings ) { _codecSettings = settings; }
 
 #ifdef Q_OS_WIN
@@ -454,6 +460,9 @@ private:
     float* _localOutputMixBuffer { NULL };
     Mutex _localAudioMutex;
     AudioLimiter _audioLimiter{ AudioConstants::SAMPLE_RATE, OUTPUT_CHANNEL_COUNT };
+
+    // Negotiate only these codecs with the domain
+    QStringList _allowedCodecs;
 
     // Adds Reverb
     void configureReverb();

--- a/libraries/audio/src/AbstractAudioInterface.h
+++ b/libraries/audio/src/AbstractAudioInterface.h
@@ -60,6 +60,26 @@ public slots:
     virtual void setAllowedCodecs(const QStringList &codec) = 0;
     virtual QStringList getAllowedCodecs() = 0;
 
+    virtual QMap<QString,bool> getEncoderFeatures() = 0;
+
+    virtual bool getEncoderVBR() = 0;
+    virtual void setEncoderVBR(bool enabled) = 0;
+
+    virtual int getEncoderBitrate() = 0;
+    virtual void setEncoderBitrate(int bitrate) = 0;
+
+    virtual int getEncoderComplexity() = 0;
+    virtual void setEncoderComplexity(int complexity) = 0;
+
+    virtual bool getEncoderFEC() = 0;
+    virtual void setEncoderFEC(bool enabled) = 0;
+
+    virtual int getEncoderPacketLossPercent() = 0;
+    virtual void setEncoderPacketLossPercent(int percent) = 0;
+
+
+
+
 signals:
     void isStereoInputChanged(bool isStereo);
 };

--- a/libraries/audio/src/AbstractAudioInterface.h
+++ b/libraries/audio/src/AbstractAudioInterface.h
@@ -55,6 +55,11 @@ public slots:
     virtual void setServerEcho(bool serverEcho) = 0;
     virtual void toggleServerEcho() = 0;
 
+    virtual QStringList getCodecs() = 0;
+    virtual QString getCodec() = 0;
+    virtual void setAllowedCodecs(const QStringList &codec) = 0;
+    virtual QStringList getAllowedCodecs() = 0;
+
 signals:
     void isStereoInputChanged(bool isStereo);
 };

--- a/libraries/audio/src/AudioScriptingInterface.cpp
+++ b/libraries/audio/src/AudioScriptingInterface.cpp
@@ -169,3 +169,83 @@ QStringList AudioScriptingInterface::getAllowedCodecs() {
 
     return codecs;
 }
+
+QMap<QString,bool> AudioScriptingInterface::getEncoderFeatures() {
+    QMap<QString, bool> features;
+
+    if (_localAudioInterface) {
+        features = _localAudioInterface->getEncoderFeatures();
+    }
+
+    return features;
+}
+
+int AudioScriptingInterface::getEncoderBitrate() {
+    if (_localAudioInterface) {
+        return _localAudioInterface->getEncoderBitrate();
+    }
+
+    return 0;
+}
+
+void AudioScriptingInterface::setEncoderBitrate(int bitrate) {
+    if (_localAudioInterface) {
+        _localAudioInterface->setEncoderBitrate(bitrate);
+    }
+}
+
+int AudioScriptingInterface::getEncoderComplexity() {
+    if (_localAudioInterface) {
+        return _localAudioInterface->getEncoderComplexity();
+    }
+
+    return 0;
+}
+
+void AudioScriptingInterface::setEncoderComplexity(int complexity) {
+    if (_localAudioInterface) {
+        _localAudioInterface->setEncoderComplexity(complexity);
+    }
+}
+
+bool AudioScriptingInterface::getEncoderVBR() {
+    if (_localAudioInterface) {
+        return _localAudioInterface->getEncoderVBR();
+    }
+
+    return 0;
+}
+
+void AudioScriptingInterface::setEncoderVBR(bool enabled) {
+    if (_localAudioInterface) {
+        _localAudioInterface->setEncoderVBR(enabled);
+    }
+}
+
+bool AudioScriptingInterface::getEncoderFEC() {
+    if (_localAudioInterface) {
+        return _localAudioInterface->getEncoderFEC();
+    }
+
+    return 0;
+}
+
+void AudioScriptingInterface::setEncoderFEC(bool enabled) {
+    if (_localAudioInterface) {
+        _localAudioInterface->setEncoderFEC(enabled);
+    }
+}
+
+int AudioScriptingInterface::getEncoderPacketLossPercent() {
+    if (_localAudioInterface) {
+        return _localAudioInterface->getEncoderPacketLossPercent();
+    }
+
+    return 0;
+}
+
+void AudioScriptingInterface::setEncoderPacketLossPercent(int percent) {
+    if (_localAudioInterface) {
+        _localAudioInterface->setEncoderPacketLossPercent(percent);
+    }
+}

--- a/libraries/audio/src/AudioScriptingInterface.cpp
+++ b/libraries/audio/src/AudioScriptingInterface.cpp
@@ -47,7 +47,7 @@ void AudioScriptingInterface::setLocalAudioInterface(AbstractAudioInterface* aud
         disconnect(_localAudioInterface, &AbstractAudioInterface::isStereoInputChanged,
                    this, &AudioScriptingInterface::isStereoInputChanged);
     }
-    
+
     _localAudioInterface = audioInterface;
 
     if (_localAudioInterface) {
@@ -135,4 +135,37 @@ void AudioScriptingInterface::toggleLocalEcho() {
     if (_localAudioInterface) {
         QMetaObject::invokeMethod(_localAudioInterface, "toggleLocalEcho");
     }
+}
+
+QStringList AudioScriptingInterface::getCodecs() {
+    QStringList codecs;
+    if (_localAudioInterface) {
+        codecs = _localAudioInterface->getCodecs();
+    }
+
+    return codecs;
+}
+
+QString AudioScriptingInterface::getCodec() {
+    QString codec;
+    if (_localAudioInterface) {
+        codec = _localAudioInterface->getCodec();
+    }
+
+    return codec;
+}
+
+void AudioScriptingInterface::setAllowedCodecs(const QStringList &codecs) {
+    if (_localAudioInterface) {
+        _localAudioInterface->setAllowedCodecs(codecs);
+    }
+}
+
+QStringList AudioScriptingInterface::getAllowedCodecs() {
+    QStringList codecs;
+    if (_localAudioInterface) {
+        codecs = _localAudioInterface->getAllowedCodecs();
+    }
+
+    return codecs;
 }

--- a/libraries/audio/src/AudioScriptingInterface.h
+++ b/libraries/audio/src/AudioScriptingInterface.h
@@ -165,6 +165,29 @@ public:
 
     Q_INVOKABLE QStringList getAllowedCodecs();
 
+    Q_INVOKABLE QMap<QString,bool> getEncoderFeatures();
+
+    Q_INVOKABLE int getEncoderBitrate();
+
+    Q_INVOKABLE void setEncoderBitrate(int bitrate);
+
+    Q_INVOKABLE bool getEncoderVBR();
+
+    Q_INVOKABLE void setEncoderVBR(bool enabled);
+
+    Q_INVOKABLE int getEncoderComplexity();
+
+    Q_INVOKABLE void setEncoderComplexity(int complexity);
+
+    Q_INVOKABLE bool getEncoderFEC();
+
+    Q_INVOKABLE void setEncoderFEC(bool enabled);
+
+    Q_INVOKABLE int getEncoderPacketLossPercent();
+
+    Q_INVOKABLE void setEncoderPacketLossPercent(int percent);
+
+
 
 protected:
     AudioScriptingInterface() = default;

--- a/libraries/audio/src/AudioScriptingInterface.h
+++ b/libraries/audio/src/AudioScriptingInterface.h
@@ -157,34 +157,119 @@ public:
      */
     Q_INVOKABLE void toggleLocalEcho();
 
+    /*@jsdoc
+     * Returns the list of codecs known to the system as an array
+     * @function Audio.getCodecs
+     */
     Q_INVOKABLE QStringList getCodecs();
 
+    /*@jsdoc
+     * Returns the currently used codec
+     * @function Audio.getCodec
+     */
     Q_INVOKABLE QString getCodec();
 
+    /*@jsdoc
+     * Sets the list of codecs the client will try to negotiate with the domain.
+     * This is a sub-set of the list returned by getCodecs.
+     * If this list is empty, all system codecs are accepted.
+     * @parm {String[]} list of codecs to accept
+     * @function Audio.setAllowedCodecs
+     */
     Q_INVOKABLE void setAllowedCodecs(const QStringList &codecs);
 
+    /*@jsdoc
+     * Returns the list of currently accepted codecs.
+     * If this list is empty, all system codecs are accepted.
+     * @function Audio.setAllowedCodecs
+     */
     Q_INVOKABLE QStringList getAllowedCodecs();
 
     Q_INVOKABLE QMap<QString,bool> getEncoderFeatures();
 
+    /*@jsdoc
+     * Returns the bitrate of the current encoder
+     * @function Audio.getEncoderBitrate
+     */
     Q_INVOKABLE int getEncoderBitrate();
 
+    /*@jsdoc
+     * Sets the bitrate of the current encoder.
+     *
+     * @parm {int} Bit rate, in bps (eg, 128000 for 128kbps)
+     * @function Audio.setEncoderBitrate
+     */
     Q_INVOKABLE void setEncoderBitrate(int bitrate);
 
+    /*@jsdoc
+     * Returns whether the current encoder has Variable Bit Rate enabled.
+     * @function Audio.getEncoderVBR
+     */
     Q_INVOKABLE bool getEncoderVBR();
+
+    /*@jsdoc
+     * Sets whether the current encoder uses Variable Bit Rate.
+     *
+     * When VBR is enabled, the encoder will use less bandwidth during times of silence and low
+     * audio signal complexity.
+     * @parm {bool} Whether VBR is abled
+     * @function Audio.setEncoderVBR
+     */
 
     Q_INVOKABLE void setEncoderVBR(bool enabled);
 
+    /*@jsdoc
+     * Returns the complexity of the current encoder.
+     * The complexity is a number from 0 to 100 indicating how hard the codec tries to compress the data.
+     * This is expected to have an effect on the amount of CPU time needed to compress the audio.
+     * Higher levels are more CPU intensive but produce better quality or lower bandwidth usage.
+     * @function Audio.getEncoderComplexity
+     */
     Q_INVOKABLE int getEncoderComplexity();
+
+    /*@jsdoc
+     * Sets the complexity of the current encoder.
+     * The complexity is a number from 0 to 100 indicating how hard the codec tries to compress the data.
+     * This is expected to have an effect on the amount of CPU time needed to compress the audio.
+     * Higher levels are more CPU intensive but produce better quality or lower bandwidth usage.
+     * @parm {int} Complexity, from 0 to 100.
+     * @function Audio.setEncoderComplexity
+     */
 
     Q_INVOKABLE void setEncoderComplexity(int complexity);
 
+    /*@jsdoc
+     * Returns whether the current encoder has Forward Error Correction enabled
+     * @function Audio.getEncoderFEC
+     */
     Q_INVOKABLE bool getEncoderFEC();
 
+    /*@jsdoc
+     * Sets whether the current encoder uses Forward Error Correction
+     * FEC compensates for data loss in audio. Enabling this on a codec that supports it should result
+     * in better audio quality with bad network connections.
+     *
+     * Enabling this may cost additional bandwidth, or reduce encoding quality to make room for the redundancy.
+     * @parm {bool} Whether FEC is enabled
+     * @function Audio.setEncoderFEC
+     */
     Q_INVOKABLE void setEncoderFEC(bool enabled);
 
+    /*@jsdoc
+     * Returns the current encoder's expected packet loss percent
+     * @function Audio.getEncoderPacketLossPercent
+     */
     Q_INVOKABLE int getEncoderPacketLossPercent();
 
+    /*@jsdoc
+     * Sets whether the expected packet loss for FEC
+     * FEC compensates for data loss in audio. Enabling this on a codec that supports it should result
+     * in better audio quality with bad network connections.
+     *
+     * Enabling this may cost additional bandwidth, or reduce encoding quality to make room for the redundancy.
+     * @parm {int} Expected packet loss, in percent
+     * @function Audio.setEncoderPacketLossPercent
+     */
     Q_INVOKABLE void setEncoderPacketLossPercent(int percent);
 
 

--- a/libraries/audio/src/AudioScriptingInterface.h
+++ b/libraries/audio/src/AudioScriptingInterface.h
@@ -140,7 +140,7 @@ public:
      * Sets whether your microphone audio is echoed back to you by the client. When enabled, microphone audio is echoed
      * even if you're muted or not using push-to-talk.
      * @function Audio.setLocalEcho
-     * @parm {boolean} localEcho - <code>true</code> to enable echoing microphone audio back to you from the client,
+     * @param {boolean} localEcho - <code>true</code> to enable echoing microphone audio back to you from the client,
      *     <code>false</code> to disable.
      * @example <caption>Echo local audio for a few seconds.</caption>
      * Audio.setLocalEcho(true);
@@ -173,7 +173,7 @@ public:
      * Sets the list of codecs the client will try to negotiate with the domain.
      * This is a sub-set of the list returned by getCodecs.
      * If this list is empty, all system codecs are accepted.
-     * @parm {String[]} list of codecs to accept
+     * @param {String[]} list of codecs to accept
      * @function Audio.setAllowedCodecs
      */
     Q_INVOKABLE void setAllowedCodecs(const QStringList &codecs);
@@ -196,7 +196,7 @@ public:
     /*@jsdoc
      * Sets the bitrate of the current encoder.
      *
-     * @parm {int} Bit rate, in bps (eg, 128000 for 128kbps)
+     * @param {int} Bit rate, in bps (eg, 128000 for 128kbps)
      * @function Audio.setEncoderBitrate
      */
     Q_INVOKABLE void setEncoderBitrate(int bitrate);
@@ -212,7 +212,7 @@ public:
      *
      * When VBR is enabled, the encoder will use less bandwidth during times of silence and low
      * audio signal complexity.
-     * @parm {bool} Whether VBR is abled
+     * @param {bool} Whether VBR is abled
      * @function Audio.setEncoderVBR
      */
 
@@ -232,7 +232,7 @@ public:
      * The complexity is a number from 0 to 100 indicating how hard the codec tries to compress the data.
      * This is expected to have an effect on the amount of CPU time needed to compress the audio.
      * Higher levels are more CPU intensive but produce better quality or lower bandwidth usage.
-     * @parm {int} Complexity, from 0 to 100.
+     * @param {int} Complexity, from 0 to 100.
      * @function Audio.setEncoderComplexity
      */
 
@@ -250,7 +250,7 @@ public:
      * in better audio quality with bad network connections.
      *
      * Enabling this may cost additional bandwidth, or reduce encoding quality to make room for the redundancy.
-     * @parm {bool} Whether FEC is enabled
+     * @param {bool} Whether FEC is enabled
      * @function Audio.setEncoderFEC
      */
     Q_INVOKABLE void setEncoderFEC(bool enabled);
@@ -267,7 +267,7 @@ public:
      * in better audio quality with bad network connections.
      *
      * Enabling this may cost additional bandwidth, or reduce encoding quality to make room for the redundancy.
-     * @parm {int} Expected packet loss, in percent
+     * @param {int} Expected packet loss, in percent
      * @function Audio.setEncoderPacketLossPercent
      */
     Q_INVOKABLE void setEncoderPacketLossPercent(int percent);

--- a/libraries/audio/src/AudioScriptingInterface.h
+++ b/libraries/audio/src/AudioScriptingInterface.h
@@ -157,6 +157,14 @@ public:
      */
     Q_INVOKABLE void toggleLocalEcho();
 
+    Q_INVOKABLE QStringList getCodecs();
+
+    Q_INVOKABLE QString getCodec();
+
+    Q_INVOKABLE void setAllowedCodecs(const QStringList &codecs);
+
+    Q_INVOKABLE QStringList getAllowedCodecs();
+
 
 protected:
     AudioScriptingInterface() = default;

--- a/libraries/plugins/src/plugins/CodecPlugin.cpp
+++ b/libraries/plugins/src/plugins/CodecPlugin.cpp
@@ -1,0 +1,166 @@
+//
+//  CodecPlugin.h
+//  plugins/src/plugins
+//
+//  Created by Brad Hefta-Gaub on 6/9/2016
+//  Copyright 2016 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "CodecPlugin.h"
+#include <QJsonArray>
+
+Q_LOGGING_CATEGORY(codec_plugin, "vircadia.codec_plugin")
+
+std::vector<Encoder::CodecSettings> Encoder::parseSettings(const QJsonObject &root) {
+    const QString CODEC_SETTINGS = "codec_settings";
+
+    std::vector<Encoder::CodecSettings> list;
+
+    if (root[CODEC_SETTINGS].isArray()) {
+        qCWarning(codec_plugin) << "Parsing codec settings";
+
+        const QJsonArray &codecSettings = root[CODEC_SETTINGS].toArray();
+
+        const QString CODEC = "codec";
+        const QString BITRATE = "bitrate";
+        const QString COMPLEXITY = "complexity";
+        const QString FEC = "fec";
+        const QString PACKET_LOSS = "packet_loss";
+        const QString VBR = "vbr";
+
+        for (int i=0;i<codecSettings.count(); ++i) {
+            QJsonObject codecObject = codecSettings[i].toObject();
+
+            qCWarning(codec_plugin) << "Parsing codec" << i;
+
+            if ( codecObject.contains(CODEC)) {
+                Encoder::CodecSettings settings;
+
+                settings.codec = codecObject.value(CODEC).toString();
+
+                if ( codecObject.contains(BITRATE)) {
+                    settings.bitrate = codecObject.value(BITRATE).toString().toInt();
+                }
+
+                if ( codecObject.contains(COMPLEXITY)) {
+                    settings.complexity = codecObject.value(COMPLEXITY).toString().toInt();
+                }
+
+                if ( codecObject.contains(FEC) && codecObject.contains(PACKET_LOSS)) {
+                    settings.enableFEC = codecObject.value(FEC).toBool();
+                    settings.packetLossPercent = codecObject.value(PACKET_LOSS).toString().toInt();
+                }
+
+                if ( codecObject.contains(VBR)) {
+                    settings.enableVBR = codecObject.value(VBR).toBool();
+                }
+
+                qCCritical(codec_plugin) << "Codec settings parsed:" << settings;
+                list.push_back( settings );
+            } else {
+                qCCritical(codec_plugin) << "Failed to find" << CODEC << "element";
+            }
+        }
+    } else {
+        qCWarning(codec_plugin) << "Failed to find a" << CODEC_SETTINGS << "array inside" << root;
+    }
+
+    return list;
+}
+
+void Encoder::configure(const std::vector<Encoder::CodecSettings> &settings) {
+    const QString myName = getName().trimmed().toLower();
+
+    for( const auto &s : settings ) {
+        if ( s.codec.trimmed().toLower() == myName ) {
+
+            qCDebug(codec_plugin) << "Configuring encoder" << getName();
+
+            if (hasApplication()) {
+                setApplication(s.applicationType);
+            }
+
+            if (hasBandpass()) {
+                setBandpass(s.bandpass);
+            }
+
+            if (hasSignalType()) {
+                setSignalType(s.signalType);
+            }
+
+            if (hasBitrate()) {
+                setBitrate(s.bitrate);
+            }
+
+            if (hasComplexity()) {
+                setComplexity(s.complexity);
+            }
+
+            if (hasFEC()) {
+                setFEC(s.enableFEC);
+            }
+
+            if (hasPacketLossPercent()) {
+                setPacketLossPercent(s.packetLossPercent);
+            }
+
+            if (hasVBR()) {
+                setVBR(s.enableVBR);
+            }
+        }
+    }
+}
+
+QDebug operator<<(QDebug &debug, const Encoder::CodecSettings &settings) {
+    debug << "{ Codec =" << settings.codec;
+    debug << "; Complexity =" << settings.complexity;
+    debug << "; Bitrate =" << settings.bitrate;
+    debug << "; FEC =" << settings.enableFEC;
+    debug << "; PacketLoss =" << settings.packetLossPercent;
+    debug << "; Application =" << (int)settings.applicationType;
+    debug << "; Bandpass =" << (int)settings.bandpass;
+    debug << "; Signal =" << (int)settings.signalType;
+    debug << "; VBR =" << settings.enableVBR;
+    debug << "}";
+    return debug;
+}
+
+
+QDebug Encoder::operator<<(QDebug debug) {
+    debug << "{ Codec = " << getName();
+    if ( hasComplexity() ) {
+        debug << "; Complexity = " << getComplexity();
+    }
+
+    if ( hasBitrate() ) {
+        debug << "; Bitrate = " << getBitrate();
+    }
+
+    if ( hasFEC() ) {
+        debug << "; FEC = " << getFEC();
+    }
+
+    if ( hasPacketLossPercent() ) {
+        debug << "; PacketLoss = " << getPacketLossPercent();
+    }
+
+    if ( hasBandpass() ) {
+        debug << "; Bandpass = " << (int)getBandpass();
+    }
+
+    if ( hasSignalType() ) {
+        debug << "; Signal = " << (int)getSignalType();
+    }
+
+    if ( hasVBR() ) {
+        debug << "; VBR = " << getVBR();
+    }
+
+    debug << "}";
+
+    return debug;
+}
+

--- a/libraries/plugins/src/plugins/CodecPlugin.h
+++ b/libraries/plugins/src/plugins/CodecPlugin.h
@@ -10,13 +10,197 @@
 //
 #pragma once
 
+#include <algorithm>
 #include "Plugin.h"
+#include <QDebug>
+
+#ifndef VIRCADIA_CODECPLUGIN_H
+#define VIRCADIA_CODECPLUGIN_H
 
 class Encoder {
 public:
+    enum class EncoderBandpass {
+        Narrowband, Mediumband, Wideband, Superwideband, Fullband
+    };
+
+    enum class EncoderSignal {
+        Auto, Voice, Music
+    };
+
+    enum class EncoderApplication {
+        VOIP, Audio, LowDelay
+    };
+
+/*
+    enum class Capabilities : int {
+        None = 0x00,
+        Lossless = 0x01,
+        Complexity = 0x02,
+        Bitrate = 0x04,
+        FEC = 0x08,
+        Bandpass = 0x10,
+        SignalType = 0x20,
+        VBR = 0x40
+    };
+*/
+
+
     virtual ~Encoder() { }
     virtual void encode(const QByteArray& decodedBuffer, QByteArray& encodedBuffer) = 0;
+
+    /**
+     * @brief Get the codec's name
+     *
+     * Returns the name of the codec, for usage in debug output and UI.
+     *
+     * @return QString Codec's name
+     */
+    virtual const QString getName() const { return "Encoder"; }
+
+    virtual bool isLossless() const { return false; }
+
+    /**
+     * @brief Get the codec's capabilities
+     *
+     * This is a bit field of which of the possible settings have effect on this codec.
+     *
+     * For example, a codec capable of adding redundancy to compensate for packet loss will have the FEC flag set.
+     *
+     * @return Capabilities
+     */
+    //virtual Capabilities getCapabilities() { return Capabilities::None; }
+
+    virtual void setApplication(EncoderApplication app) { _application = app; }
+    virtual bool hasApplication() const { return false; }
+    EncoderApplication getApplication() const { return _application; }
+
+    /**
+     * @brief Set the codec's complexity (CPU usage)
+     *
+     * This defines how much CPU time is spent on encoding. Lower values are expected to have
+     * lower quality or higher bandwidth usage, depending on the codec.
+     *
+     * @param complexity A value from 0 to 100.
+     */
+    virtual void setComplexity(int complexity) { _complexity = qBound(complexity, 0, 100); }
+    virtual bool hasComplexity() const { return false; }
+    int getComplexity() const { return _complexity; }
+
+    /**
+     * @brief Set the bitrate
+     *
+     * How many bits per second the codec is going to use. This only applies to lossy codecs.
+     *
+     * @param bitrate A rate in bits per second from 500 to 512000
+     */
+    virtual void setBitrate(int bitrate) { _bitrate = qBound(bitrate, 500, 512000); }
+    virtual bool hasBitrate() const { return false; }
+    int getBitrate() const { return _bitrate; }
+
+    /**
+     * @brief Sets whether to use Forward Error Correction
+     *
+     * When enabled, redundant data is included in the codec's output to compensate for packet loss
+     * @param enabled
+     */
+    virtual void setFEC(bool enabled) { _useFEC = enabled; }
+    virtual bool hasFEC() const { return false; }
+    bool getFEC() const { return _useFEC; }
+
+    /**
+     * @brief Set how much packet loss to tolerate
+     *
+     * This is how much loss we expect to have. Higher values may consume bandwidth or lower quality to compensate.
+     *
+     * @param percent 0 to 100
+     */
+    virtual void setPacketLossPercent(int percent) { _packetLossPercent = qBound(percent, 0, 100); }
+    virtual bool hasPacketLossPercent() const { return false; }
+    int getPacketLossPercent() const { return _packetLossPercent; }
+
+    /**
+     * @brief Set the bandpass
+     *
+     * @param bandpass
+     */
+    virtual void setBandpass(EncoderBandpass bandpass) { _bandpass = bandpass;}
+    virtual bool hasBandpass() const { return false; }
+    EncoderBandpass getBandpass() const { return _bandpass; }
+
+    /**
+     * @brief Set the type of audio signal
+     *
+     * @param signal
+     */
+    virtual void setSignalType(EncoderSignal signal) { _signal = signal;}
+    virtual bool hasSignalType() const { return false; }
+    EncoderSignal getSignalType() const { return _signal; }
+
+    /**
+     * @brief Whether to use variable bitrate
+     *
+     * @param use_vbr
+     */
+    virtual void setVBR(bool use_vbr) { _useVBR = use_vbr; }
+    virtual bool hasVBR() const { return false; }
+    bool getVBR() const { return _useVBR; }
+
+    QDebug operator<<(QDebug debug) {
+        debug << "{ Codec = " << getName();
+        if ( hasComplexity() ) {
+            debug << "; Complexity = " << getComplexity();
+        }
+
+        if ( hasBitrate() ) {
+            debug << "; Bitrate = " << getBitrate();
+        }
+
+        if ( hasFEC() ) {
+            debug << "; FEC = " << getFEC();
+        }
+
+        if ( hasPacketLossPercent() ) {
+            debug << "; PacketLoss = " << getPacketLossPercent();
+        }
+
+        if ( hasBandpass() ) {
+            debug << "; Bandpass = " << (int)getBandpass();
+        }
+
+        if ( hasSignalType() ) {
+            debug << "; Signal = " << (int)getSignalType();
+        }
+
+        if ( hasVBR() ) {
+            debug << "; VBR = " << getVBR();
+        }
+
+        debug << "}";
+
+        return debug;
+    }
+
+/*
+    Encoder::Capabilities operator|(Encoder::Capabilities lhs, Encoder::Capabilities rhs) {
+    return static_cast<Encoder::Capabilities>(
+        static_cast<std::underlying_type<Encoder::Capabilities>::type>(lhs) |
+        static_cast<std::underlying_type<Encoder::Capabilities>::type>(rhs)
+    );
+
+}
+   */
+protected:
+    int _complexity;
+    int _bitrate;
+    bool _useFEC;
+    bool _useVBR;
+    int _packetLossPercent;
+    EncoderBandpass _bandpass;
+    EncoderSignal _signal;
+    EncoderApplication _application;
 };
+
+
 
 class Decoder {
 public:
@@ -26,6 +210,9 @@ public:
     virtual void lostFrame(QByteArray& decodedBuffer) = 0;
 };
 
+
+
+
 class CodecPlugin : public Plugin {
 public:
     virtual Encoder* createEncoder(int sampleRate, int numChannels) = 0;
@@ -33,3 +220,5 @@ public:
     virtual void releaseEncoder(Encoder* encoder) = 0;
     virtual void releaseDecoder(Decoder* decoder) = 0;
 };
+
+#endif

--- a/plugins/opusCodec/src/OpusEncoder.cpp
+++ b/plugins/opusCodec/src/OpusEncoder.cpp
@@ -93,11 +93,13 @@ int AthenaOpusEncoder::getComplexity() const {
     assert(_encoder);
     int returnValue;
     opus_encoder_ctl(_encoder, OPUS_GET_COMPLEXITY(&returnValue));
-    return returnValue;
+    return returnValue*10;
 }
 
 void AthenaOpusEncoder::setComplexity(int complexity) {
     assert(_encoder);
+    complexity = qBound(0, complexity/10, 10); // The generic interface is 0 to 100, Opus is 0 to 10.
+
     int returnValue = opus_encoder_ctl(_encoder, OPUS_SET_COMPLEXITY(complexity));
 
     if (returnValue != OPUS_OK) {
@@ -114,6 +116,7 @@ int AthenaOpusEncoder::getBitrate() const {
 
 void AthenaOpusEncoder::setBitrate(int bitrate) {
     assert(_encoder);
+    bitrate = qBound(500, bitrate, 512000); // Opus limits
     int errorCode = opus_encoder_ctl(_encoder, OPUS_SET_BITRATE(bitrate));
 
     if (errorCode != OPUS_OK) {

--- a/plugins/opusCodec/src/OpusEncoder.cpp
+++ b/plugins/opusCodec/src/OpusEncoder.cpp
@@ -116,7 +116,7 @@ int AthenaOpusEncoder::getBitrate() const {
 
 void AthenaOpusEncoder::setBitrate(int bitrate) {
     assert(_encoder);
-    bitrate = qBound(500, bitrate, 512000); // Opus limits
+    bitrate = qBound(2400, bitrate, 512000); // Opus limits
     int errorCode = opus_encoder_ctl(_encoder, OPUS_SET_BITRATE(bitrate));
 
     if (errorCode != OPUS_OK) {

--- a/plugins/opusCodec/src/OpusEncoder.h
+++ b/plugins/opusCodec/src/OpusEncoder.h
@@ -22,6 +22,7 @@ public:
 
     virtual void encode(const QByteArray& decodedBuffer, QByteArray& encodedBuffer) override;
 
+    const QString getName() const override { return "opus"; }
 
     int getComplexity() const override;
     void setComplexity(int complexity) override;

--- a/plugins/opusCodec/src/OpusEncoder.h
+++ b/plugins/opusCodec/src/OpusEncoder.h
@@ -23,14 +23,14 @@ public:
     virtual void encode(const QByteArray& decodedBuffer, QByteArray& encodedBuffer) override;
 
 
-    int getComplexity() const;
-    void setComplexity(int complexity);
+    int getComplexity() const override;
+    void setComplexity(int complexity) override;
 
-    int getBitrate() const;
-    void setBitrate(int bitrate);
+    int getBitrate() const override;
+    void setBitrate(int bitrate) override;
 
-    int getVBR() const;
-    void setVBR(int vbr);
+    bool getVBR() const override;
+    void setVBR(bool vbr) override;
 
     int getVBRConstraint() const;
     void setVBRConstraint(int vbrConstraint);
@@ -41,19 +41,19 @@ public:
     int getBandwidth() const;
     void setBandwidth(int bandwidth);
 
-    int getSignal() const;
-    void setSignal(int signal);
+    Encoder::SignalType getSignalType() const override;
+    void setSignalType(Encoder::SignalType signal) override;
 
-    int getApplication() const;
-    void setApplication(int application);
+    ApplicationType getApplication() const override;
+    void setApplication(ApplicationType application) override;
 
     int getLookahead() const;
 
-    int getInbandFEC() const;
-    void setInbandFEC(int inBandFEC);
+    bool getFEC() const override;
+    void setFEC(bool inBandFEC) override;
 
-    int getExpectedPacketLossPercentage() const;
-    void setExpectedPacketLossPercentage(int percentage);
+    int getPacketLossPercent() const override;
+    void setPacketLossPercent(int percentage) override;
 
     int getDTX() const;
     void setDTX(int dtx);

--- a/plugins/pcmCodec/src/PCMCodecManager.h
+++ b/plugins/pcmCodec/src/PCMCodecManager.h
@@ -31,6 +31,8 @@ public:
     /// Called when a plugin is no longer being used.  May be called multiple times.
     void deactivate() override;
 
+    bool isLossless() const override { return true; }
+
     virtual Encoder* createEncoder(int sampleRate, int numChannels) override;
     virtual Decoder* createDecoder(int sampleRate, int numChannels) override;
     virtual void releaseEncoder(Encoder* encoder) override;
@@ -61,6 +63,12 @@ public:
     bool isSupported() const override;
     const QString getName() const override { return NAME; }
 
+    bool isLossless() const override { return true; }
+
+    bool hasComplexity() const override { return true; }
+
+    void setComplexity(int complexity) override { _compressionLevel = qBound(0, complexity/11, 9); }
+
     void init() override;
     void deinit() override;
 
@@ -75,7 +83,7 @@ public:
     virtual void releaseDecoder(Decoder* decoder) override;
 
     virtual void encode(const QByteArray& decodedBuffer, QByteArray& encodedBuffer) override {
-        encodedBuffer = qCompress(decodedBuffer);
+        encodedBuffer = qCompress(decodedBuffer, _compressionLevel);
     }
 
     virtual void decode(const QByteArray& encodedBuffer, QByteArray& decodedBuffer) override {
@@ -89,6 +97,7 @@ public:
 
 private:
     static const char* NAME;
+    int _compressionLevel = 6; // Default compression level for zLib
 };
 
 #endif // hifi__PCMCodecManager_h


### PR DESCRIPTION
This implements configurable config settings for audio codecs. It's still at an early stage, and only being submitted for feedback and collaboration. Rebased from Vircadia.

TODO list:

* Cleanup code
* API Documentation
* Figure out the final list of audio parameters
* Implement settings in interface
* Fix `Audio.getEncoderFeatures()`


Initial API for audio codecs, client side:

`Audio.getCodec()` -- returns current codec
`Audio.getCodecs()` -- list of known codecs
`Audio.getAllowedCodecs()` -- list of codecs the interface is willing to use. All codecs are accepted if the list is empty. Will check that the names correspond with something in `getCodecs()`, and filter out any unknown entries.
`Audio.setAllowedCodecs()` -- set list of allowed codecs for the interface.
`Audio.getEncoderVBR()` -- is VBR enabled
`Audio.setEncoderVBR(bool)` -- enable/disable Variable Bit Rate
`Audio.getEncoderBitrate()`
`Audio.getEncoderBitrate(int bitrate)` -- Bit rate, in bits/s. 2400 to 512000. Default is 128000 (128kbps)
`Audio.getEncoderComplexity()`
`Audio.getEncoderComplexity(int complexity)` -- How CPU intensive compression is, 0 to 100.
`Audio.getEncoderFEC()` -- is VBR enabled
`Audio.setEncoderFEC(bool)` -- enable/disable Forward Error Correction
`Audio.getEncoderPacketLossPercent()` 
`Audio.setEncoderPacketLossPercent(int percent)` -- how much data loss to allow for

Not working:
`Audio.getEncoderFeatures()`  -- returns a feature list for the current encoder


Testing:

* You can test with yourself by using this console command: `Audio.setServerEcho(true)`. This will bounce audio off the domain at yourself. Microphone has to be on for it to work.

* Use for instance `Audio.setAllowedCodecs(["zlib"])` in the console, and observe the rise in bandwidth usage. 
* Use `Audio.setEncoderBitrate(5000)` to see the effect of 5 kbps audio
* Use `Audio.setEncoderComplexity(1)` to see the effect of less CPU intensive encoding
* Use `Audio.setEncoderFEC(true)` and `Audio.setEncoderPacketLossPercent(10)` to try error correction. Needs a connection with some packet loss.


Feedback would be very welcome -- especially regarding whether the API makes sense, and if there are threading issues anywhere in this.



