### PR TITLE
Fix most of the crash causes on script engine reload/shutdown

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7556,8 +7556,9 @@ void Application::registerScriptEngineWithApplicationServices(ScriptManagerPoint
         *connection = scriptManager->connect(scriptManager.get(), &ScriptManager::scriptEnding, [scriptManager, connection]() {
             // Request removal of controller routes with callbacks to a given script engine
             auto userInputMapper = DependencyManager::get<UserInputMapper>();
-            userInputMapper->scheduleScriptEndpointCleanup(scriptManager->engine().get());
-            // V8TODO: Maybe we should wait until endpoint cleanup is finished before deleting the script engine if there are still crashes
+            // scheduleScriptEndpointCleanup will have the last instance of shared pointer to script manager
+            // so script manager will get deleted as soon as cleanup is done
+            userInputMapper->scheduleScriptEndpointCleanup(scriptManager);
             QObject::disconnect(*connection);
         });
     }

--- a/libraries/controllers/src/controllers/Actions.cpp
+++ b/libraries/controllers/src/controllers/Actions.cpp
@@ -30,7 +30,7 @@ namespace controller {
     }
 
     EndpointPointer ActionsDevice::createEndpoint(const Input& input) const {
-        return std::make_shared<ActionEndpoint>(input);
+        return ActionEndpoint::newEndpoint(input);
     }
 
     /*@jsdoc

--- a/libraries/controllers/src/controllers/InputDevice.cpp
+++ b/libraries/controllers/src/controllers/InputDevice.cpp
@@ -91,7 +91,7 @@ namespace controller {
     }
 
     EndpointPointer InputDevice::createEndpoint(const Input& input) const {
-        return std::make_shared<InputEndpoint>(input);
+        return InputEndpoint::newEndpoint(input);
     }
 
 }

--- a/libraries/controllers/src/controllers/StateController.cpp
+++ b/libraries/controllers/src/controllers/StateController.cpp
@@ -51,7 +51,7 @@ Input::NamedVector StateController::getAvailableInputs() const {
 EndpointPointer StateController::createEndpoint(const Input& input) const {
     auto name = stateVariables[input.getChannel()];
     ReadLambda& readLambda = const_cast<QHash<QString, ReadLambda>&>(_namedReadLambdas)[name];
-    return std::make_shared<LambdaRefEndpoint>(readLambda);
+    return LambdaRefEndpoint::newEndpoint(readLambda);
 }
 
 }

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -35,6 +35,7 @@
 #include "StateController.h"
 
 class ScriptEngine;
+class ScriptManager;
 class ScriptValue;
 
 namespace controller {
@@ -136,7 +137,7 @@ namespace controller {
          *
          * @param engine Pointer to the script engine that will be shut down
          */
-        void scheduleScriptEndpointCleanup(ScriptEngine* engine);
+        void scheduleScriptEndpointCleanup(std::shared_ptr<ScriptManager> manager);
 
         AxisValue getValue(const Input& input) const;
         Pose getPose(const Input& input) const;
@@ -223,7 +224,7 @@ namespace controller {
         InputCalibrationData inputCalibrationData;
 
         // Contains pointers to script engines that are requesting callback cleanup during their shutdown process
-        QQueue<ScriptEngine*> scriptEnginesRequestingCleanup;
+        QQueue<std::shared_ptr<ScriptManager>> scriptManagersRequestingCleanup;
 
         mutable std::recursive_mutex _lock;
     };

--- a/libraries/controllers/src/controllers/impl/endpoints/ActionEndpoint.h
+++ b/libraries/controllers/src/controllers/impl/endpoints/ActionEndpoint.h
@@ -21,7 +21,9 @@ namespace controller {
 
 class ActionEndpoint : public Endpoint {
 public:
-    ActionEndpoint(const Input& id = Input::INVALID_INPUT) : Endpoint(id) { }
+    static std::shared_ptr<Endpoint> newEndpoint(const Input& id = Input::INVALID_INPUT) {
+        return std::shared_ptr<Endpoint>(new ActionEndpoint(id));
+    };
 
     virtual AxisValue peek() const override { return _currentValue; }
     virtual void apply(AxisValue newValue, const Pointer& source) override;
@@ -32,6 +34,8 @@ public:
     virtual void reset() override;
 
 private:
+    ActionEndpoint(const Input& id = Input::INVALID_INPUT) : Endpoint(id) { }
+
     AxisValue _currentValue { 0.0f, 0, false };
     Pose _currentPose{};
 };

--- a/libraries/controllers/src/controllers/impl/endpoints/AnyEndpoint.h
+++ b/libraries/controllers/src/controllers/impl/endpoints/AnyEndpoint.h
@@ -17,8 +17,11 @@ namespace controller {
 class AnyEndpoint : public Endpoint {
     friend class UserInputMapper;
 public:
+    static std::shared_ptr<Endpoint> newEndpoint(Endpoint::List children) {
+        return std::shared_ptr<Endpoint>(new AnyEndpoint(children));
+    };
+
     using Endpoint::apply;
-    AnyEndpoint(Endpoint::List children);
     virtual AxisValue peek() const override;
     virtual AxisValue value() override;
     virtual void apply(AxisValue newValue, const Endpoint::Pointer& source) override;
@@ -26,6 +29,8 @@ public:
     virtual bool readable() const override;
 
 private:
+    AnyEndpoint(Endpoint::List children);
+
     Endpoint::List _children;
 };
 

--- a/libraries/controllers/src/controllers/impl/endpoints/ArrayEndpoint.h
+++ b/libraries/controllers/src/controllers/impl/endpoints/ArrayEndpoint.h
@@ -17,9 +17,12 @@ namespace controller {
 class ArrayEndpoint : public Endpoint {
     friend class UserInputMapper;
 public:
+    static std::shared_ptr<Endpoint> newEndpoint() {
+        return std::shared_ptr<Endpoint>(new ArrayEndpoint());
+    };
+
     using Endpoint::apply;
     using Pointer = std::shared_ptr<ArrayEndpoint>;
-    ArrayEndpoint() : Endpoint(Input::INVALID_INPUT) { }
 
     virtual AxisValue peek() const override { return AxisValue(); }
 
@@ -34,6 +37,7 @@ public:
     virtual bool readable() const override { return false; }
 
 private:
+    ArrayEndpoint() : Endpoint(Input::INVALID_INPUT) { }
     Endpoint::List _children;
 };
 

--- a/libraries/controllers/src/controllers/impl/endpoints/CompositeEndpoint.h
+++ b/libraries/controllers/src/controllers/impl/endpoints/CompositeEndpoint.h
@@ -15,14 +15,19 @@
 namespace controller {
     class CompositeEndpoint : public Endpoint, Endpoint::Pair {
     public:
+        static std::shared_ptr<Endpoint> newEndpoint(Endpoint::Pointer first, Endpoint::Pointer second) {
+            return std::shared_ptr<Endpoint>(new CompositeEndpoint(first, second));
+        };
+
         using Endpoint::apply;
-        CompositeEndpoint(Endpoint::Pointer first, Endpoint::Pointer second);
 
         virtual AxisValue peek() const override;
         virtual AxisValue value() override;
         virtual void apply(AxisValue newValue, const Pointer& source) override;
         virtual bool readable() const override;
 
+    private:
+        CompositeEndpoint(Endpoint::Pointer first, Endpoint::Pointer second);
     };
 
 }

--- a/libraries/controllers/src/controllers/impl/endpoints/InputEndpoint.h
+++ b/libraries/controllers/src/controllers/impl/endpoints/InputEndpoint.h
@@ -16,9 +16,9 @@ namespace controller {
 
 class InputEndpoint : public Endpoint {
 public:
-    InputEndpoint(const Input& id = Input::INVALID_INPUT)
-        : Endpoint(id) {
-    }
+    static std::shared_ptr<Endpoint> newEndpoint(const Input& id = Input::INVALID_INPUT) {
+        return std::shared_ptr<Endpoint>(new InputEndpoint(id));
+    };
 
     virtual AxisValue peek() const override;
     virtual AxisValue value() override;
@@ -34,6 +34,10 @@ public:
     virtual void reset() override { _read = false; }
 
 private:
+    InputEndpoint(const Input& id = Input::INVALID_INPUT)
+        : Endpoint(id) {
+    }
+
     bool _read { false };
 };
 

--- a/libraries/controllers/src/controllers/impl/endpoints/JSEndpoint.h
+++ b/libraries/controllers/src/controllers/impl/endpoints/JSEndpoint.h
@@ -19,15 +19,19 @@ namespace controller {
 
 class JSEndpoint : public Endpoint {
 public:
-    using Endpoint::apply;
-    JSEndpoint(const QJSValue& callable)
-        : Endpoint(Input::INVALID_INPUT), _callable(callable) {
-    }
+    static std::shared_ptr<Endpoint> newEndpoint(const QJSValue& callable) {
+        return std::shared_ptr<Endpoint>(new JSEndpoint(callable));
+    };
 
+    using Endpoint::apply;
     virtual AxisValue peek() const override;
     virtual void apply(AxisValue newValue, const Pointer& source) override;
 
 private:
+    JSEndpoint(const QJSValue& callable)
+        : Endpoint(Input::INVALID_INPUT), _callable(callable) {
+    }
+
     mutable QJSValue _callable;
 };
 

--- a/libraries/controllers/src/controllers/impl/endpoints/ScriptEndpoint.cpp
+++ b/libraries/controllers/src/controllers/impl/endpoints/ScriptEndpoint.cpp
@@ -45,7 +45,10 @@ AxisValue ScriptEndpoint::peek() const {
 
 void ScriptEndpoint::updateValue() {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "updateValue", Qt::QueuedConnection);
+        auto pointer = shared_from_this();
+        QMetaObject::invokeMethod(this, [pointer]{
+            std::dynamic_pointer_cast<ScriptEndpoint>(pointer)->updateValue();
+        });
         return;
     }
 

--- a/libraries/controllers/src/controllers/impl/endpoints/ScriptEndpoint.h
+++ b/libraries/controllers/src/controllers/impl/endpoints/ScriptEndpoint.h
@@ -22,9 +22,9 @@ class ScriptEndpoint : public Endpoint {
     Q_OBJECT;
 public:
     using Endpoint::apply;
-    ScriptEndpoint(const ScriptValue& callable)
-        : Endpoint(Input::INVALID_INPUT), _callable(callable) {
-    }
+    static std::shared_ptr<Endpoint> newEndpoint(const ScriptValue& callable) {
+        return std::shared_ptr<Endpoint>(new ScriptEndpoint(callable));
+    };
 
     virtual AxisValue peek() const override;
     virtual void apply(AxisValue newValue, const Pointer& source) override;
@@ -42,6 +42,9 @@ protected:
     Q_INVOKABLE void updatePose();
     Q_INVOKABLE virtual void internalApply(const Pose& newValue, int sourceID);
 private:
+    ScriptEndpoint(const ScriptValue& callable)
+        : Endpoint(Input::INVALID_INPUT), _callable(callable) {
+    }
     ScriptValue _callable;
     float _lastValueRead { 0.0f };
     AxisValue _lastValueWritten { 0.0f, 0, false };

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -226,10 +226,7 @@ void EntityTreeRenderer::resetPersistentEntitiesScriptEngine() {
             manager->stop();
             manager->waitTillDoneRunning();
             manager->disconnectNonEssentialSignals();
-            // TODO: script manager pointer is still in use somewhere after the cleanup in lambda.
-            //  To prevent memory leaks on multiple reloads we would need to find all the usages and remove them.
-            //  Script engines are correctly deleted later during shutdown currently.
-            qDebug() << "_nonPersistentEntitiesScriptManager lambda finished, script manager pointer use count: " << manager.use_count();
+            manager->removeFromScriptEngines();
         });
     }
     _persistentEntitiesScriptManager = scriptManagerFactory(ScriptManager::ENTITY_CLIENT_SCRIPT, NO_SCRIPT,
@@ -252,10 +249,7 @@ void EntityTreeRenderer::resetNonPersistentEntitiesScriptEngine() {
             manager->stop();
             manager->waitTillDoneRunning();
             manager->disconnectNonEssentialSignals();
-            // TODO: script manager pointer is still in use somewhere after the cleanup in lambda.
-            //  To prevent memory leaks on multiple reloads we would need to find all the usages and remove them.
-            //  Script engines are correctly deleted later during shutdown currently.
-            qDebug() << "_nonPersistentEntitiesScriptManager lambda finished, script manager pointer use count: " << manager.use_count();
+            manager->removeFromScriptEngines();
         });
     }
     _nonPersistentEntitiesScriptManager = scriptManagerFactory(ScriptManager::ENTITY_CLIENT_SCRIPT, NO_SCRIPT,

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -226,6 +226,10 @@ void EntityTreeRenderer::resetPersistentEntitiesScriptEngine() {
             manager->stop();
             manager->waitTillDoneRunning();
             manager->disconnectNonEssentialSignals();
+            // TODO: script manager pointer is still in use somewhere after the cleanup in lambda.
+            //  To prevent memory leaks on multiple reloads we would need to find all the usages and remove them.
+            //  Script engines are correctly deleted later during shutdown currently.
+            qDebug() << "_nonPersistentEntitiesScriptManager lambda finished, script manager pointer use count: " << manager.use_count();
         });
     }
     _persistentEntitiesScriptManager = scriptManagerFactory(ScriptManager::ENTITY_CLIENT_SCRIPT, NO_SCRIPT,
@@ -248,6 +252,10 @@ void EntityTreeRenderer::resetNonPersistentEntitiesScriptEngine() {
             manager->stop();
             manager->waitTillDoneRunning();
             manager->disconnectNonEssentialSignals();
+            // TODO: script manager pointer is still in use somewhere after the cleanup in lambda.
+            //  To prevent memory leaks on multiple reloads we would need to find all the usages and remove them.
+            //  Script engines are correctly deleted later during shutdown currently.
+            qDebug() << "_nonPersistentEntitiesScriptManager lambda finished, script manager pointer use count: " << manager.use_count();
         });
     }
     _nonPersistentEntitiesScriptManager = scriptManagerFactory(ScriptManager::ENTITY_CLIENT_SCRIPT, NO_SCRIPT,

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -423,6 +423,11 @@ public:
      */
     virtual void stopProfilingAndSave() = 0;
 
+    /**
+     * @brief Cleanup function that disconnects signals connected to script proxies to avoid use-after-delete crash when shutting down script engine.
+     */
+    virtual void disconnectSignalProxies() = 0;
+
 public:
     // helper to detect and log warnings when other code invokes QScriptEngine/BaseScriptEngine in thread-unsafe ways
     bool IS_THREADSAFE_INVOCATION(const QString& method);

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -184,6 +184,8 @@ public:
 
     void addScriptEngine(ScriptManagerPointer);
 
+    void removeScriptEngine(ScriptManagerPointer);
+
     ScriptGatekeeper scriptGatekeeper;
 
 signals:
@@ -336,7 +338,6 @@ protected slots:
 
 protected:
     ScriptManagerPointer reloadScript(const QString& scriptName, bool isUserLoaded = true) { return loadScript(scriptName, isUserLoaded, false, false, true); }
-    void removeScriptEngine(ScriptManagerPointer);
     void onScriptEngineLoaded(const QString& scriptFilename);
     void quitWhenFinished();
     void onScriptEngineError(const QString& scriptFilename);

--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -519,6 +519,11 @@ void ScriptManager::waitTillDoneRunning(bool shutdown) {
     }
 }
 
+void ScriptManager::removeFromScriptEngines() {
+    Q_ASSERT(_scriptEngines);
+    _scriptEngines.toStrongRef()->removeScriptEngine(shared_from_this());
+}
+
 QString ScriptManager::getFilename() const {
     QStringList fileNameParts = _fileNameString.split("/");
     QString lastPart;

--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -67,6 +67,7 @@
 #include <AddressManager.h>
 #include <NetworkingConstants.h>
 #include <ThreadHelpers.h>
+#include <iostream>
 
 const QString ScriptManager::_SETTINGS_ENABLE_EXTENDED_EXCEPTIONS {
     "com.highfidelity.experimental.enableExtendedJSExceptions"
@@ -366,7 +367,12 @@ bool ScriptManager::isDebugMode() const {
 #endif
 }
 
-ScriptManager::~ScriptManager() {}
+ScriptManager::~ScriptManager() {
+    qDebug() << "ScriptManager::~ScriptManager() : Script manager deleted, type: " << _type << " name: " << _fileNameString;
+    if (_type == ScriptManager::Type::ENTITY_CLIENT) {
+        printf("ScriptManager::~ScriptManager");
+    }
+}
 
 void ScriptManager::disconnectNonEssentialSignals() {
     disconnect();
@@ -464,11 +470,14 @@ void ScriptManager::waitTillDoneRunning(bool shutdown) {
         }
 #else
         auto startedWaiting = usecTimestampNow();
-        while (workerThread->isRunning()) {
+        while (!_isDoneRunning) {
             // If the final evaluation takes too long, then tell the script engine to stop running
             auto elapsedUsecs = usecTimestampNow() - startedWaiting;
+            // TODO: This part was very unsafe and was causing crashes all the time.
+            //  I disabled it for now until we find a safer solution.
+            //  With it disabled now we get clean shutdowns and restarts.
             // V8TODO: temporarily increased script timeout. Maybe use different timeouts for release and unoptimized debug?
-            static const auto MAX_SCRIPT_EVALUATION_TIME = USECS_PER_SECOND;
+            /*static const auto MAX_SCRIPT_EVALUATION_TIME = 10 * USECS_PER_SECOND;
             if (elapsedUsecs > MAX_SCRIPT_EVALUATION_TIME) {
                 workerThread->quit();
 
@@ -485,12 +494,12 @@ void ScriptManager::waitTillDoneRunning(bool shutdown) {
 
                 // Wait for the scripting thread to stop running, as
                 // flooding it with aborts/exceptions will persist it longer
-                static const auto MAX_SCRIPT_QUITTING_TIME = 0.5 * MSECS_PER_SECOND;
+                static const auto MAX_SCRIPT_QUITTING_TIME = 50 * MSECS_PER_SECOND;
                 if (!workerThread->wait(MAX_SCRIPT_QUITTING_TIME)) {
                     Q_ASSERT(false);
                     workerThread->terminate();
                 }
-            }
+            }*/
 
             if (shutdown) {
                 // NOTE: This will be called on the main application thread (among other threads) from stopAllScripts.
@@ -502,7 +511,7 @@ void ScriptManager::waitTillDoneRunning(bool shutdown) {
             }
 
             // Avoid a pure busy wait
-            QThread::yieldCurrentThread();
+            QThread::msleep(1);
         }
 #endif
 
@@ -985,6 +994,7 @@ void ScriptManager::run() {
 
         PROFILE_RANGE(script, "ScriptMainLoop");
 
+//#define SCRIPT_DELAY_DEBUG
 #ifdef SCRIPT_DELAY_DEBUG
         {
             auto actuallySleptUntil = clock::now();
@@ -1064,6 +1074,13 @@ void ScriptManager::run() {
     _isRunning = false;
     emit runningStateChanged();
     emit doneRunning();
+    _engine->disconnectSignalProxies();
+    // Process all remaining events
+    {
+        QEventLoop loop;
+        loop.processEvents();
+    }
+    _isDoneRunning = true;
 }
 
 // NOTE: This is private because it must be called on the same thread that created the timers, which is why
@@ -1121,6 +1138,7 @@ void ScriptManager::timerFired() {
         return; // bail early
     }
 
+//#define SCRIPT_TIMER_PERFORMANCE_STATISTICS
 #ifdef SCRIPT_TIMER_PERFORMANCE_STATISTICS
     _timerCallCounter++;
     if (_timerCallCounter % 100 == 0) {

--- a/libraries/script-engine/src/ScriptManager.h
+++ b/libraries/script-engine/src/ScriptManager.h
@@ -472,6 +472,15 @@ public:
     void waitTillDoneRunning(bool shutdown = false);
 
     /**
+     * @brief Removes shared pointer to script engine from the list of all script engines.
+     *
+     * This allows deletion of the script engine once all shared pointer instances are gone.
+     * This function is called for entity script engines when they are  being destroyed.
+     *
+     */
+    void removeFromScriptEngines();
+
+    /**
      * @brief Load a script from a given URL
      *
      * If the script engine is not already running, this will download the URL and start the process of seting it up

--- a/libraries/script-engine/src/ScriptManager.h
+++ b/libraries/script-engine/src/ScriptManager.h
@@ -1197,6 +1197,14 @@ public:
      */
     void setAbortOnUncaughtException(bool value) { _abortOnUncaughtException = value; }
 
+    /**
+     * @brief Returns true after script finished running and doneRunning signal was called
+     *
+     * @return true If the script and doneRunning signal was called
+     * @return false If the script has not finished running yet
+     */
+    bool isDoneRunning() { return _isDoneRunning; };
+
 public slots:
 
     /**
@@ -1527,6 +1535,7 @@ protected:
     std::atomic<bool> _isFinished { false };
     std::atomic<bool> _isRunning { false };
     std::atomic<bool> _isStopping { false };
+    std::atomic<bool> _isDoneRunning { false };
     bool _areMetaTypesInitialized { false };
     bool _isInitialized { false };
     QHash<QTimer*, CallbackData> _timerFunctionMap;

--- a/libraries/script-engine/src/v8/ScriptObjectV8Proxy.h
+++ b/libraries/script-engine/src/v8/ScriptObjectV8Proxy.h
@@ -270,6 +270,9 @@ public:  // API
     //Moved to public temporarily for debugging:
     QString fullName() const;
 
+    // Disconnects all signals from the proxy
+    void disconnectAll() { QObject::disconnect(this, nullptr, nullptr, nullptr); };
+
 private:  // storage
 
     ScriptEngineV8* _engine;

--- a/libraries/script-engine/src/v8/ScriptValueV8Wrapper.cpp
+++ b/libraries/script-engine/src/v8/ScriptValueV8Wrapper.cpp
@@ -248,6 +248,9 @@ ScriptEnginePointer ScriptValueV8Wrapper::engine() const {
     if (!_engine) {
         return ScriptEnginePointer();
     }
+#ifdef OVERTE_SCRIPT_USE_AFTER_DELETE_GUARD
+    Q_ASSERT(!_engine->_wasDestroyed);
+#endif
     return _engine->shared_from_this();
 }
 


### PR DESCRIPTION
Script reload works pretty well now.
I also temporarily disabled forced termination of script threads because it was completely unsafe and would always cause crashes. We need to do it in a better way in later PR.