### PR TITLE
Home button fallbacking to Tutorial

### DIFF
--- a/scripts/system/places/places.html
+++ b/scripts/system/places/places.html
@@ -425,6 +425,9 @@
                                         if (placeRecords[i].metaverseRegion !== "local") {
                                             placeUrl = "hifi://" + placeRecords[i].address;
                                         }
+                                        if (placeRecords[i].name === "tutorial") {
+                                            placeUrl = "file:///~/serverless/tutorial.json";
+                                        }
 
                                         //Add the place to the list
 

--- a/scripts/system/places/places.js
+++ b/scripts/system/places/places.js
@@ -94,7 +94,7 @@
                 if (LocationBookmarks.getHomeLocationAddress()) {
                     location.handleLookupString(LocationBookmarks.getHomeLocationAddress());
                 } else {
-                    location.goToLocalSandbox();
+                    Window.location = "file:///~/serverless/tutorial.json";
                 }                
             } else if (messageObj.action === "GO_BACK" && (n - timestamp) > INTERCALL_DELAY) {
                 location.goBack();
@@ -442,7 +442,7 @@
             "domain": "",
             "domainOrder": "ZZZZZZZZZZZZZZZ",
             "metaverseServer": "",
-            "metaverseRegion": "local"            
+            "metaverseRegion": "local"
         };
         portalList.push(tutorialPortal);
         


### PR DESCRIPTION
Previously, in the case where there is no home bookmark defined, the Places app Home button was redirecting to localhost. But some people might not have a localhost domain server running. This PR change the fallback to the tutorial instead of localhost, which is safer.

In addition, the tutorial place card wasn't working correctly. (it was trying to use the name instead of the address.) I added an exception case for this.