### PR TITLE
Put require() in the global scope

### DIFF
--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -736,6 +736,8 @@ void ScriptManager::init() {
         auto require = Script.property("require");
         auto resolve = Script.property("_requireResolve");
         require.setProperty("resolve", resolve, READONLY_PROP_FLAGS);
+
+        scriptEngine->globalObject().setProperty("require", require, READONLY_PROP_FLAGS);
         resetModuleCache();
     }
 


### PR DESCRIPTION
This makes an alias for `Script.require()` as plain `require()`.

