### PR TITLE
:green_heart: Fixed GH actions running out diskspace 

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -128,6 +128,16 @@ jobs:
       with:
         tool-cache: true
 
+    - name: Add Swap space
+      shell: bash
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+
     - uses: actions/checkout@v1
       with:
         submodules: false

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -120,6 +120,14 @@ jobs:
         rm -rf ~/overte-files
         rm -rf ~/.cache
 
+
+    # For nodejs we need ~50GB of free disk space
+    - name: Free Disk Space (Ubuntu)
+      if: matrix.os == 'ubuntu-20.04'
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+
     - uses: actions/checkout@v1
       with:
         submodules: false

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -164,6 +164,14 @@ jobs:
         rm -rf ~/overte-files
         rm -rf ~/.cache
 
+    # For nodejs we need ~50GB of free disk space
+    - name: Free Disk Space (Ubuntu)
+      if: matrix.runner == 'ubuntu-20.04'
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+
+
     - uses: actions/checkout@v3
       with:
         submodules: false

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -171,6 +171,15 @@ jobs:
       with:
         tool-cache: true
 
+    - name: Add Swap space
+      shell: bash
+      if: matrix.runner == 'ubuntu-20.04'
+      run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
 
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This should fix the CI build failing to build nodejs

TODO:
- [ ] Add caching to vcpkg to compensate for the slow cleanup step