### PR TITLE
Cleanup/remove deprecated jsDocs

### DIFF
--- a/Deprecated JSDocs Removal.md
+++ b/Deprecated JSDocs Removal.md
@@ -1,0 +1,334 @@
+The following is a list of every deprecated API, method, and property that was had its JSDoc removed as a part of commit 4e0bbf4df19cecc9860f4c51b7ec51edfcb9a4a5.
+
+This list includes the removed item as well as the suggested alternative if one was present in the removed JSDoc.
+
+| Name | Replacement |
+|---|---|
+| Account | AccountServices |
+| AddressManager | location and Window.location |
+| AnimationCache.updateTotalSize |
+| Audio.devices |  |
+| Audio.onContextChanged |  |
+| Audio.setInputDevice |  |
+| Audio.setOutputDevice |  |
+| Audio.nop() |  |
+| Avatar.attachmentData | Avatar Entities |
+| Avatar.getAttachmentsVariant | Avatar Entities |
+| Avatar.setAttachmentsVariant | Avatar Entities |
+| Avatar.getAttachmentData | Avatar Entities |
+| Avatar.clearAvatarEntity | Avatar Entities |
+| Avatar.attach | Avatar Entities |
+| Avatar.detachAll | Avatar Entities |
+| Avatar.detachOne | Avatar Entities |
+| Avatar.resetLastSent | |
+| Avatar.sendAvatarDataPacket | |
+| Avatar.sendAvatarDataPacket | |
+| Avatar.sendIdentityPacket | |
+| Avatar.setSessionUUID | |
+| Avatar.setAttachmentData | Avatar Entities |
+| Avatar.setForceFaceTrackerConnected | Avatar.hasScriptedBlendshapes or MyAvatar.hasScriptedBlendshapes |
+| Avatar.setJointMappingsFromNetworkReply | |
+| Avatar.update | |
+| Avatar.updateAvatarEntity |  |
+| AvatarBookmarks.deleteBookmark |  |
+| AvatarBookmarks.updateAvatarEntities | MyAvatar |
+| AvatarBookmarks.deleteBookmark | Avatar Entities |
+| AvatarInputs.cameraEnabled |  |
+| AvatarInputs.cameraMuted |  |
+| AvatarInputs.toggleCameraMute |  |
+| AvatarInputs.avatarLeftIgnoreRadius |  |
+| AvatarInputs.cameraEnabledChanged |  |
+| AvatarInputs.cameraMutedChanged |  |
+| AvatarList.processAvatarDataPacket |  |
+| AvatarList.processAvatarIdentityPacket |  |
+| AvatarList.processBulkAvatarTraits |  |
+| AvatarList.processKillAvatar |  |
+| AvatarList.sessionUUIDChanged |  |
+| AvatarManager.findParabolaIntersectionVector |  |
+| AvatarManager.findRayIntersectionVector |  |
+| AvatarManager.getAvatarSortCoefficient |  |
+| AvatarManager.setAvatarSortCoefficient |  |
+| AvatarManager.updateAvatarRenderStatus |  |
+| AvatarManager.PalData.isReplicated |  |
+| Controller.captureJoystick |  |
+| Controller.releaseJoystick |  |
+| Controller.updateRunningInputDevices |  |
+| Controller.Actions.LeftHandClick |  |
+| Controller.Actions.RightHandClick |  |
+| Controller.Actions.Shift |  |
+| Controller.Actions.PrimaryAction |  |
+| Controller.Actions.SecondaryAction |  |
+| Controller.Actions.LEFT_HAND | LeftHand |
+| Controller.Actions.RIGHT_HAND | RightHand |
+| Controller.Actions.BOOM_IN | BoomIn |
+| Controller.Actions.BOOM_OUT | BoomOut  |
+| Controller.Actions.CONTEXT_MENU | ContextMenu |
+| Controller.Actions.TOGGLE_MUTE | ToggleMute |
+| Controller.Actions.TOGGLE_PUSHTOTALK | TogglePushToTalk |
+| Controller.Actions.SPRINT | Sprint |
+| Controller.Actions.LONGITUDINAL_BACKWARD | Backward |
+| Controller.Actions.LONGITUDINAL_FORWARD | Forward |
+| Controller.Actions.LATERAL_LEFT | StrafeLeft |
+| Controller.Actions.LATERAL_RIGHT | StrafeRight |
+| Controller.Actions.VERTICAL_UP | Up |
+| Controller.Actions.VERTICAL_DOWN | Down |
+| Controller.Actions.PITCH_DOWN | PitchDown |
+| Controller.Actions.PITCH_UP | PitchUp |
+| Controller.Actions.YAW_LEFT | YawLeft |
+| Controller.Actions.YAW_RIGHT | YawRight |
+| Controller.Actions.LEFT_HAND_CLICK | Says to use LeftHandClick which is also deprecated? |
+| Controller.Actions.RIGHT_HAND_CLICK | Says to use RightHandClick which is also deprecated? |
+| Controller.Actions.SHIFT | Says to use Shift which is also deprecated? |
+| Controller.Actions.ACTION1 | Says to use PrimaryAction which is also deprecated? |
+| Controller.Actions.ACTION2 | Says to use SecondaryAction which is also deprecated? |
+| Controller.Actions.TrackedObject00 |  |
+| Controller.Actions.TrackedObject01 |  |
+| Controller.Actions.TrackedObject02 |  |
+| Controller.Actions.TrackedObject03 |  |
+| Controller.Actions.TrackedObject04 |  |
+| Controller.Actions.TrackedObject05 |  |
+| Controller.Actions.TrackedObject06 |  |
+| Controller.Actions.TrackedObject07 |  |
+| Controller.Actions.TrackedObject08 |  |
+| Controller.Actions.TrackedObject09 |  |
+| Controller.Actions.TrackedObject10 |  |
+| Controller.Actions.TrackedObject11 |  |
+| Controller.Actions.TrackedObject12 |  |
+| Controller.Actions.TrackedObject13 |  |
+| Controller.Actions.TrackedObject14 |  |
+| Controller.Actions.TrackedObject15 |  |
+| Entities.mouseMoveEvent | mouseMoveOnEntity  |
+| Entities.appendPoint | PolyLine Entities |
+| Entities.getMeshes | Graphics API |
+| Entities.setAllPoints | PolyLine Entities |
+| Entities.ActionType "spring" |  |
+| Entities.EntityProperties.acceleration |  |
+| Entities.EntityProperties-Grid.pulse |  |
+| Entities.EntityProperties-Grid.alpha |  |
+| Entities.EntityProperties-Image.pulse |  |
+| Entities.EntityProperties-Image.alpha |  |
+| Entities.EntityProperties-Image.faceCamera |  |
+| Entities.EntityProperties-Image.isFacingAvatar |  |
+| Entities.EntityProperties-Line | PolyLine Entities |
+| Entities.EntityProperties-Model.modelScale |  |
+| Entities.EntityProperties-ParticleEffect.pulse |  |
+| Entities.EntityProperties-Shape.pulse |  |
+| Entities.EntityProperties-Text.pulse |  |
+| Entities.EntityProperties-Text.faceCamera |  |
+| Entities.EntityProperties-Text.isFacingAvatar |  |
+| Entities.EntityProperties-Web.pulse |  |
+| Entities.EntityProperties-Web.faceCamera |  |
+| Entities.EntityProperties-Web.isFacingAvatar |  |
+| EntityViewer.getBoundaryLevelAdjust |  |
+| EntityViewer.getVoxelSizeScale |  |
+| EntityViewer.setVoxelSizeScale |  |
+| EntityViewer.setBoundaryLevelAdjust |  |
+| EntityViewer.setKeyholeRadius | setCenterRadius  |
+| GlobalServices | AccountServices |
+| HifiAbout | About |
+| LODManager.lodQualityLevel |  |
+| LODManager.getBoundaryLevelAdjust |  |
+| LODManager.getOctreeSizeScale |  |
+| LODManager.setOctreeSizeScale |  |
+| LODManager.setBoundaryLevelAdjust |  |
+| LODManager.LODDecreased |  |
+| LODManager.LODIncreased |  |
+| LODManager.lodQualityLevelChanged |  |
+| MaterialCache.updateTotalSize |  |
+| Midi.midiNote | midiMessage |
+| ModelCache.updateTotalSize |  |
+| MyAvatar.attachmentData | Avatar Entities |
+| MyAvatar.qmlPosition |  |
+| MyAvatar.energy |  |
+| MyAvatar.characterControllerEnabled | collisionsEnabled |
+| MyAvatar.userRecenterModel |  |
+| MyAvatar.isSitStandStateLocked |  |
+| MyAvatar.addThrust | motorVelocity |
+| MyAvatar.animGraphLoaded |  |
+| MyAvatar.clearScaleRestriction |  |
+| MyAvatar.getCharacterControllerEnabled | getCollisionsEnabled |
+| MyAvatar.getSimulationRate |  |
+| MyAvatar.getThrust | motorVelocity  |
+| MyAvatar.restrictScaleFromDomainSettings |  |
+| MyAvatar.rigReady |  |
+| MyAvatar.rigReset |  |
+| MyAvatar.safeLanding |  |
+| MyAvatar.setCharacterControllerEnabled |  |
+| MyAvatar.setModelScale |  |
+| MyAvatar.setModelURLFinished |  |
+| MyAvatar.setThrust |  |
+| MyAvatar.setToggleHips |  |
+| MyAvatar.attachmentsChanged |  |
+| MyAvatar.energyChanged |  |
+| MyAvatar.transformChanged |  |
+| MyAvatar.IKTargetType.HmdHead |  |
+| MyAvatar.SitStandModelType |  |
+| MyAvatar.analogPlusSprintSpeed |  |
+| Paths | Script.resolvePath and Script.resourcesPath |
+| Picks.PICK_ENTITIES | PICK_DOMAIN_ENTITIES or PICK_AVATAR_ENTITIES property |
+| Picks.PICK_OVERLAYS | PICK_LOCAL_ENTITIES  |
+| Picks.INTERSECTED_OVERLAY | INTERSECTED_LOCAL_ENTITY |
+| Picks.INTERSECTED_AVATAR method | INTERSECTED_AVATAR property |
+| Picks.INTERSECTED_ENTITY method | INTERSECTED_ENTITY property |
+| Picks.INTERSECTED_HUD method | INTERSECTED_HUD property |
+| Picks.INTERSECTED_LOCAL_ENTITY method | INTERSECTED_LOCAL_ENTITY property |
+| Picks.INTERSECTED_NONE method | INTERSECTED_NONE property |
+| Picks.INTERSECTED_OVERLAY method | INTERSECTED_LOCAL_ENTITY property |
+| Picks.PICK_ALL_INTERSECTIONS method | PICK_ALL_INTERSECTIONS property |
+| Picks.PICK_AVATARS method | PICK_AVATARS property |
+| Picks.PICK_AVATAR_ENTITIES method | PICK_DOMAIN_ENTITIES or PICK_AVATAR_ENTITIES property |
+| Picks.PICK_COARSE method | PICK_COARSE property |
+| Picks.PICK_DOMAIN_ENTITIES method | PICK_DOMAIN_ENTITIES property |
+| Picks.PICK_HUD method | PICK_HUD property |
+| Picks.PICK_INCLUDE_COLLIDABLE method | PICK_INCLUDE_COLLIDABLE property |
+| Picks.PICK_INCLUDE_INVISIBLE method | PICK_INCLUDE_INVISIBLE property |
+| Picks.PICK_INCLUDE_NONCOLLIDABLE method | PICK_INCLUDE_NONCOLLIDABLE property |
+| Picks.PICK_INCLUDE_VISIBLE method | PICK_INCLUDE_VISIBLE property |
+| Picks.PICK_LOCAL_ENTITIES method | PICK_LOCAL_ENTITIES property |
+| Picks.PICK_OVERLAYS method | PICK_LOCAL_ENTITIES property |
+| Picks.PICK_PRECISE method | PICK_PRECISE property |
+| Picks.ParabolaPickProperties.scaleWithAvatar |  |
+| PlatformInfo.getCPUBrand | JSON.parse(PlatformInfo.getCPU(0)).model |
+| PlatformInfo.getGraphicsCardType | JSON.parse(PlatformInfo.getGPU( PlatformInfo.getMasterGPU() )).model |
+| PlatformInfo.getNumLogicalCores | JSON.parse(PlatformInfo.getCPU(0)).numCores |
+| PlatformInfo.getOperatingSystemType | JSON.parse({@link PlatformInfo.getComputer|PlatformInfo.getComputer()}).OS |
+| PlatformInfo.getTotalSystemMemoryMB | JSON.parse(PlatformInfo.getMemory()).memTotal |
+| ParabolaPointerProperties.scaleWithAvatar |  |
+| RayPointerProperties.scaleWithAvatar |  |
+| Script._requireResolve |  |
+| Script.callEntityScriptMethod |  |
+| Script.entityScriptContentAvailable |  |
+| Script.executeOnScriptThread |  |
+| Script.formatException |  |
+| Script.generateUUID | Uuid.generate |
+| Script.loadEntityScript |  |
+| Script.resetModuleCache |  |
+| Script.unloadAllEntityScripts |  |
+| Script.unloadEntityScript |  |
+| Script.clearDebugWindow |  |
+| Script.entityScriptDetailsUpdated |  |
+| Script.errorLoadingScript |  |
+| Script.loadScript |  |
+| Script.reloadScript |  |
+| Script.scriptLoaded |  |
+| Script.stop marshal parameter |  |
+| ScriptDiscoveryService.getLocal |  |
+| ScriptDiscoveryService.onClearDebugWindow |  |
+| ScriptDiscoveryService.onErrorLoadingScript |  |
+| ScriptDiscoveryService.onErrorMessage |  |
+| ScriptDiscoveryService.onInfoMessage |  |
+| ScriptDiscoveryService.onPrintedMessage |  |
+| ScriptDiscoveryService.onScriptFinished |  |
+| ScriptDiscoveryService.onWarningMessage |  |
+| ScriptDiscoveryService.errorLoadingScript |  |
+| ScriptDiscoveryService.LocalScript |  |
+| ScriptDiscoveryService.PublicScript.type |  |
+| ScriptDiscoveryService.PublicScript.children |  |
+| SoundCache.updateTotalSize |  |
+| Stats.audioAudioInboundPPS | audioInboundPPS  |
+| Stats.bgColor |  |
+| Stats.activeFocus |  |
+| Stats.activeFocusOnTab |  |
+| Stats.anchors |  |
+| Stats.antialiasing |  |
+| Stats.baselineOffset |  |
+| Stats.children |  |
+| Stats.clip |  |
+| Stats.containmentMask |  |
+| Stats.enabled |  |
+| Stats.focus |  |
+| Stats.height |  |
+| Stats.implicitHeight |  |
+| Stats.implicitWidth |  |
+| Stats.layer |  |
+| Stats.opacity |  |
+| Stats.rotation |  |
+| Stats.scale |  |
+| Stats.smooth |  |
+| Stats.state |  |
+| Stats.transformOrigin |  |
+| Stats.visible |  |
+| Stats.width |  |
+| Stats.x |  |
+| Stats.y |  |
+| Stats.z |  |
+| Stats.childAt |  |
+| Stats.contains |  |
+| Stats.forceActiveFocus |  |
+| Stats.grabToImage |  |
+| Stats.mapFromGlobal |  |
+| Stats.mapFromItem |  |
+| Stats.mapToGlobal |  |
+| Stats.mapToItem |  |
+| Stats.nextItemInFocusChain |  |
+| Stats.update |  |
+| Stats.activeFocusChanged |  |
+| Stats.activeFocusOnTabChanged |  |
+| Stats.antialiasingChanged |  |
+| Stats.baselineOffsetChanged |  |
+| Stats.childrenChanged |  |
+| Stats.childrenRectChanged |  |
+| Stats.clipChanged |  |
+| Stats.containmentMaskChanged |  |
+| Stats.enabledChanged |  |
+| Stats.focusChanged |  |
+| Stats.heightChanged |  |
+| Stats.implicitHeightChanged |  |
+| Stats.implicitWidthChanged |  |
+| Stats.opacityChanged |  |
+| Stats.parentChanged |  |
+| Stats.rotationChanged |  |
+| Stats.scaleChanged |  |
+| Stats.smoothChanged |  |
+| Stats.stateChanged |  |
+| Stats.transformOriginChanged |  |
+| Stats.visibleChanged |  |
+| Stats.visibleChildrenChanged |  |
+| Stats.widthChanged |  |
+| Stats.windowChanged |  |
+| Stats.xChanged |  |
+| Stats.yChanged |  |
+| Stats.zChanged |  |
+| Stats.audioAudioInboundPPSChanged |  |
+| Stats.bgColorChanged |  |
+| TextureCache.updateTotalSize |  |
+| TextureCache.spectatorCameraFramebufferReset |  |
+| Window.domainLoadingProgress |  |
+| location.goToViewpointForPath |  |
+| location.lookupShareableNameForDomainID |  |
+| location.refreshPreviousLookup |  |
+| GraphicsMesh.getMeshPointer |  |
+| GraphicsMesh.getModelBasePointer |  |
+| GraphicsMesh.getModelProviderPointer |  |
+| InteractiveWindow.emitWebEvent |  |
+| InteractiveWindow.qmlToScript |  |
+| InteractiveWindow.scriptEventReceived |  |
+| OverlayWebWindow.clearDebugWindow |  |
+| OverlayWebWindow.emitWebEvent |  |
+| OverlayWebWindow.getEventBridge |  |
+| OverlayWebWindow.hasClosed |  |
+| OverlayWebWindow.hasMoved |  |
+| OverlayWebWindow.initQml |  |
+| OverlayWebWindow.qmlToScript |  |
+| OverlayWebWindow.sendToQML |  |
+| OverlayWebWindow.fromQML |  |
+| OverlayWebWindow.scriptEventReceived |  |
+| ScriptAvatar.isReplicated |  |
+| ScriptAvatar.attachmentData | Avatar Entities |
+| ScriptAvatar.getAttachmentData | Avatar Entitites |
+| ScriptAvatar.getSimulationRate |  |
+| ScriptsModel.downloadFinished |  |
+| ScriptsModel.reloadDefaultFiles |  |
+| ScriptsModel.reloadLocalFiles |  |
+| ScriptsModel.updateScriptsLocation |  |
+| TabletProxy.desktopWindowClosed |  |
+| TabletProxy.emitWebEvent |  |
+| TabletProxy.initialScreen |  |
+| TabletProxy.loadHTMLSourceOnTopImpl |  |
+| TabletProxy.loadQMLOnTopImpl |  |
+| TabletProxy.loadQMLSourceImpl |  |
+| TabletProxy.onTabletShown |  |
+| TabletProxy.returnToPreviousAppImpl |  |
+| TabletProxy.gotoWebScreen loadOtherBase parameter |  |
+| ToolbarProxy.addButton |  |
+| ToolbarProxy.removeButton |  |

--- a/assignment-client/src/avatars/ScriptableAvatar.h
+++ b/assignment-client/src/avatars/ScriptableAvatar.h
@@ -21,7 +21,7 @@
 #include <EntityItem.h>
 
 /*@jsdoc
- * The <code>Avatar</code> API is used to manipulate scriptable avatars on the domain. This API is a subset of the 
+ * The <code>Avatar</code> API is used to manipulate scriptable avatars on the domain. This API is a subset of the
  * {@link MyAvatar} API. To enable this API, set {@link Agent|Agent.isAvatar} to <code>true</code>.
  *
  * <p>For Interface, client entity, and avatar scripts, see {@link MyAvatar}.</p>
@@ -32,7 +32,7 @@
  *
  * @comment IMPORTANT: This group of properties is copied from AvatarData.h; they should NOT be edited here.
  * @property {Vec3} position - The position of the avatar.
- * @property {number} scale=1.0 - The scale of the avatar. The value can be set to anything between <code>0.005</code> and 
+ * @property {number} scale=1.0 - The scale of the avatar. The value can be set to anything between <code>0.005</code> and
  *     <code>1000.0</code>. When the scale value is fetched, it may temporarily be further limited by the domain's settings.
  * @property {number} density - The density of the avatar in kg/m<sup>3</sup>. The density is used to work out its mass in
  *     the application of physics. <em>Read-only.</em>
@@ -59,13 +59,11 @@
  * @property {number} audioAverageLoudness - The rolling average loudness of the audio input that the avatar is injecting
  *     into the domain.
  * @property {string} displayName - The avatar's display name.
- * @property {string} sessionDisplayName - <code>displayName's</code> sanitized and default version defined by the avatar mixer 
+ * @property {string} sessionDisplayName - <code>displayName's</code> sanitized and default version defined by the avatar mixer
  *     rather than Interface clients. The result is unique among all avatars present in the domain at the time.
  * @property {boolean} lookAtSnappingEnabled=true - <code>true</code> if the avatar's eyes snap to look at another avatar's
  *     eyes when the other avatar is in the line of sight and also has <code>lookAtSnappingEnabled == true</code>.
  * @property {string} skeletonModelURL - The avatar's FST file.
- * @property {AttachmentData[]} attachmentData - Information on the avatar's attachments. 
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use avatar entities instead.</p>
  * @property {string[]} jointNames - The list of joints in the current avatar model. <em>Read-only.</em>
  * @property {Uuid} sessionUUID - Unique ID of the avatar in the domain. <em>Read-only.</em>
  * @property {Mat4} sensorToWorldMatrix - The scale, rotation, and translation transform from the user's real world to the
@@ -78,21 +76,21 @@
  *     size in the virtual world. <em>Read-only.</em>
  * @property {boolean} hasPriority - <code>true</code> if the avatar is in a "hero" zone, <code>false</code> if it isn't.
  *     <em>Read-only.</em>
- * @property {boolean} hasScriptedBlendshapes=false - <code>true</code> if blend shapes are controlled by scripted actions, 
- *     otherwise <code>false</code>. Set this to <code>true</code> before using the {@link MyAvatar.setBlendshape} method, 
+ * @property {boolean} hasScriptedBlendshapes=false - <code>true</code> if blend shapes are controlled by scripted actions,
+ *     otherwise <code>false</code>. Set this to <code>true</code> before using the {@link MyAvatar.setBlendshape} method,
  *     and set back to <code>false</code> after you no longer want scripted control over the blend shapes.
- *     <p><strong>Note:</strong> This property will automatically be set to true if the Controller system has valid facial 
+ *     <p><strong>Note:</strong> This property will automatically be set to true if the Controller system has valid facial
  *     blend shape actions.</p>
- * @property {boolean} hasProceduralBlinkFaceMovement=true - <code>true</code> if avatars blink automatically by animating 
- *     facial blend shapes, <code>false</code> if automatic blinking is disabled. Set to <code>false</code> to fully control 
+ * @property {boolean} hasProceduralBlinkFaceMovement=true - <code>true</code> if avatars blink automatically by animating
+ *     facial blend shapes, <code>false</code> if automatic blinking is disabled. Set to <code>false</code> to fully control
  *     the blink facial blend shapes via the {@link MyAvatar.setBlendshape} method.
- * @property {boolean} hasProceduralEyeFaceMovement=true - <code>true</code> if the facial blend shapes for an avatar's eyes 
- *     adjust automatically as the eyes move, <code>false</code> if this automatic movement is disabled. Set this property 
- *     to <code>true</code> to prevent the iris from being obscured by the upper or lower lids. Set to <code>false</code> to 
+ * @property {boolean} hasProceduralEyeFaceMovement=true - <code>true</code> if the facial blend shapes for an avatar's eyes
+ *     adjust automatically as the eyes move, <code>false</code> if this automatic movement is disabled. Set this property
+ *     to <code>true</code> to prevent the iris from being obscured by the upper or lower lids. Set to <code>false</code> to
  *     fully control the eye blend shapes via the {@link MyAvatar.setBlendshape} method.
- * @property {boolean} hasAudioEnabledFaceMovement=true - <code>true</code> if the avatar's mouth blend shapes animate 
- *     automatically based on detected microphone input, <code>false</code> if this automatic movement is disabled. Set 
- *     this property to <code>false</code> to fully control the mouth facial blend shapes via the 
+ * @property {boolean} hasAudioEnabledFaceMovement=true - <code>true</code> if the avatar's mouth blend shapes animate
+ *     automatically based on detected microphone input, <code>false</code> if this automatic movement is disabled. Set
+ *     this property to <code>false</code> to fully control the mouth facial blend shapes via the
  *     {@link MyAvatar.setBlendshape} method.
  *
  * @example <caption>Create a scriptable avatar.</caption>
@@ -115,8 +113,8 @@ public:
     /*@jsdoc
      * Starts playing an animation on the avatar.
      * @function Avatar.startAnimation
-     * @param {string} url - The animation file's URL. Animation files need to be in glTF or FBX format but only need to 
-     *     contain the avatar skeleton and animation data. glTF models may be in JSON or binary format (".gltf" or ".glb" URLs 
+     * @param {string} url - The animation file's URL. Animation files need to be in glTF or FBX format but only need to
+     *     contain the avatar skeleton and animation data. glTF models may be in JSON or binary format (".gltf" or ".glb" URLs
      *     respectively).
      *     <p><strong>Warning:</strong> glTF animations currently do not always animate correctly.</p>
      * @param {number} [fps=30] - The frames per second (FPS) rate for the animation playback. 30 FPS is normal speed.
@@ -129,7 +127,7 @@ public:
      */
     /// Allows scripts to run animations.
     Q_INVOKABLE void startAnimation(const QString& url, float fps = 30.0f, float priority = 1.0f, bool loop = false,
-                                    bool hold = false, float firstFrame = 0.0f, float lastFrame = FLT_MAX, 
+                                    bool hold = false, float firstFrame = 0.0f, float lastFrame = FLT_MAX,
                                     const QStringList& maskedJoints = QStringList());
 
     /*@jsdoc
@@ -200,17 +198,10 @@ public:
     Q_INVOKABLE void updateAvatarEntity(const QUuid& entityID, const QByteArray& entityData) override;
 
 public slots:
-    /*@jsdoc
-     * @function Avatar.update
-     * @param {number} deltaTime - Delta time.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void update(float deltatime);
 
-    /*@jsdoc
-     * @function Avatar.setJointMappingsFromNetworkReply
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void setJointMappingsFromNetworkReply();
 
 private:

--- a/assignment-client/src/octree/OctreeHeadlessViewer.h
+++ b/assignment-client/src/octree/OctreeHeadlessViewer.h
@@ -59,30 +59,16 @@ public slots:
      */
     void setCenterRadius(float radius) { _hasViewFrustum = true; _viewFrustum.setCenterRadius(radius); }
 
-    /*@jsdoc
-     * Sets the radius of the center "keyhole" in the view frustum.
-     * @function EntityViewer.setKeyholeRadius
-     * @param {number} radius - The radius of the center "keyhole" in the view frustum.
-     * @deprecated This function is deprecated and will be removed. Use {@link EntityViewer.setCenterRadius|setCenterRadius} 
-     *     instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void setKeyholeRadius(float radius) { _hasViewFrustum = true; _viewFrustum.setCenterRadius(radius); } // TODO: remove this legacy support
 
 
     // setters for LOD and PPS
 
-    /*@jsdoc
-     * @function EntityViewer.setVoxelSizeScale
-     * @param {number} sizeScale - The voxel size scale.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void setVoxelSizeScale(float sizeScale) { _octreeQuery.setOctreeSizeScale(sizeScale) ; }
 
-    /*@jsdoc
-     * @function EntityViewer.setBoundaryLevelAdjust
-     * @param {number} boundaryLevelAdjust - The boundary level adjust factor.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void setBoundaryLevelAdjust(int boundaryLevelAdjust) { _octreeQuery.setBoundaryLevelAdjust(boundaryLevelAdjust); }
 
     /*@jsdoc
@@ -111,18 +97,10 @@ public slots:
 
     // getters for LOD and PPS
 
-    /*@jsdoc
-     * @function EntityViewer.getVoxelSizeScale
-     * @returns {number} The voxel size scale.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     float getVoxelSizeScale() const { return _octreeQuery.getOctreeSizeScale(); }
 
-    /*@jsdoc
-     * @function EntityViewer.getBoundaryLevelAdjust
-     * @returns {number} The boundary level adjust factor.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     int getBoundaryLevelAdjust() const { return _octreeQuery.getBoundaryLevelAdjust(); }
 
     /*@jsdoc

--- a/interface/src/AboutUtil.h
+++ b/interface/src/AboutUtil.h
@@ -44,27 +44,6 @@
  * print("Qt version: " + About.qtVersion);
  */
 
- /*@jsdoc
- * The <code>HifiAbout</code> API provides information about the version of Interface that is currently running. It also
- * has the functionality to open a web page in an Interface browser window.
- *
- * @namespace HifiAbout
- *
- * @hifi-interface
- * @hifi-client-entity
- * @hifi-avatar
- *
- * @deprecated This API is deprecated and will be removed. Use the {@link About} API instead.
- *
- * @property {string} platform - The name of the Interface platform running, e,g., <code>"Overte"</code> for the Overte.
- *     <em>Read-only.</em>
- * @property {string} buildDate - The build date of Interface that is currently running. <em>Read-only.</em>
- * @property {string} buildVersion - The build version of Interface that is currently running. <em>Read-only.</em>
- * @property {string} qtVersion - The Qt version used in Interface that is currently running. <em>Read-only.</em>
- *
- * @borrows About.openUrl as openUrl
- */
-
 class AboutUtil : public QObject {
     Q_OBJECT
 

--- a/interface/src/AvatarBookmarks.cpp
+++ b/interface/src/AvatarBookmarks.cpp
@@ -187,18 +187,7 @@ void AvatarBookmarks::updateAvatarEntities(const QVariantList &avatarEntities) {
     }
 }
 
-/*@jsdoc
- * Details of an avatar bookmark.
- * @typedef {object} AvatarBookmarks.BookmarkData
- * @property {number} version - The version of the bookmark data format.
- * @property {string} avatarUrl - The URL of the avatar model.
- * @property {number} avatarScale - The target scale of the avatar.
- * @property {Array<Object<"properties",Entities.EntityProperties>>} [avatarEntites] - The avatar entities included with the
- *     bookmark.
- * @property {AttachmentData[]} [attachments] - The attachments included with the bookmark.
- *     <p class="important">Deprecated: Use avatar entities instead.
- */
-
+// TODO: Deprecated by documentation, please review for accuracy
 void AvatarBookmarks::loadBookmark(const QString& bookmarkName) {
     if (QThread::currentThread() != thread()) {
         BLOCKING_INVOKE_METHOD(this, "loadBookmark", Q_ARG(QString, bookmarkName));

--- a/interface/src/AvatarBookmarks.h
+++ b/interface/src/AvatarBookmarks.h
@@ -16,8 +16,8 @@
 #include <DependencyManager.h>
 #include "Bookmarks.h"
 
-/*@jsdoc 
- * The <code>AvatarBookmarks</code> API provides facilities for working with avatar bookmarks ("favorites" in the Avatar app). 
+/*@jsdoc
+ * The <code>AvatarBookmarks</code> API provides facilities for working with avatar bookmarks ("favorites" in the Avatar app).
  * An avatar bookmark associates a name with an avatar model, scale, and avatar entities (wearables).
  *
  * @namespace AvatarBookmarks
@@ -45,7 +45,7 @@ public:
     Q_INVOKABLE QVariantMap getBookmark(const QString& bookmarkName);
 
 public slots:
-    /*@jsdoc 
+    /*@jsdoc
      * Adds a new (or updates an existing) avatar bookmark with your current avatar model, scale, and avatar entities.
      * @function AvatarBookmarks.addBookmark
      * @param {string} bookmarkName - The name of the avatar bookmark (case sensitive).
@@ -58,7 +58,7 @@ public slots:
     void addBookmark(const QString& bookmarkName);
 
     /*@jsdoc
-     * Updates an existing bookmark with your current avatar model, scale, and wearables. No action is taken if the bookmark 
+     * Updates an existing bookmark with your current avatar model, scale, and wearables. No action is taken if the bookmark
      * doesn't exist.
      * @function AvatarBookmarks.saveBookmark
      * @param {string} bookmarkName - The name of the avatar bookmark (case sensitive).
@@ -66,7 +66,7 @@ public slots:
     void saveBookmark(const QString& bookmarkName);
 
     /*@jsdoc
-     * Loads an avatar bookmark, setting your avatar model, scale, and avatar entities (or attachments if an old bookmark) to 
+     * Loads an avatar bookmark, setting your avatar model, scale, and avatar entities (or attachments if an old bookmark) to
      * those in the bookmark.
      * @function AvatarBookmarks.loadBookmark
      * @param {string} bookmarkName - The name of the avatar bookmark to load (case sensitive).
@@ -80,18 +80,13 @@ public slots:
      */
     void removeBookmark(const QString& bookmarkName);
 
-    /*@jsdoc
-     * Updates the avatar entities and their properties. Current avatar entities not included in the list provided are deleted.
-     * @function AvatarBookmarks.updateAvatarEntities
-     * @param {MyAvatar.AvatarEntityData[]} avatarEntities - The avatar entity IDs and properties.
-     * @deprecated This function is deprecated and will be removed. Use the {@link MyAvatar} API instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void updateAvatarEntities(const QVariantList& avatarEntities);
 
     /*@jsdoc
      * Gets the details of all avatar bookmarks.
      * @function AvatarBookmarks.getBookmarks
-     * @returns {Object<string,AvatarBookmarks.BookmarkData>} The current avatar bookmarks in an object where the keys are the 
+     * @returns {Object<string,AvatarBookmarks.BookmarkData>} The current avatar bookmarks in an object where the keys are the
      *     bookmark names and the values are the bookmark details.
      * @example <caption>List the names and URLs of all the avatar bookmarks.</caption>
      * var bookmarks = AvatarBookmarks.getBookmarks();
@@ -104,7 +99,7 @@ public slots:
 
 signals:
     /*@jsdoc
-     * Triggered when an avatar bookmark is loaded, setting your avatar model, scale, and avatar entities (or attachments if an 
+     * Triggered when an avatar bookmark is loaded, setting your avatar model, scale, and avatar entities (or attachments if an
      * old bookmark) to those in the bookmark.
      * @function AvatarBookmarks.bookmarkLoaded
      * @param {string} bookmarkName - The name of the avatar bookmark loaded.
@@ -125,7 +120,7 @@ signals:
     void bookmarkDeleted(const QString& bookmarkName);
 
     /*@jsdoc
-     * Triggered when a new avatar bookmark is added or an existing avatar bookmark is updated, using 
+     * Triggered when a new avatar bookmark is added or an existing avatar bookmark is updated, using
      * {@link AvatarBookmarks.addBookmark|addBookmark}.
      * @function AvatarBookmarks.bookmarkAdded
      * @param {string} bookmarkName - The name of the avatar bookmark added or updated.
@@ -138,12 +133,8 @@ protected:
     void readFromFile() override;
     QVariantMap getAvatarDataToBookmark();
 
-protected slots: 
-    /*@jsdoc
-     * Performs no action.
-     * @function AvatarBookmarks.deleteBookmark
-     * @deprecated This function is deprecated and will be removed.
-     */
+protected slots:
+    // TODO: Deprecated by documentation, please review for accuracy
     void deleteBookmark() override;
 
 private:

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -73,8 +73,8 @@ class AABox;
 
 
 /*@jsdoc
- * The <code>LODManager</code> API manages the Level of Detail displayed in Interface. If the LOD is being automatically 
- * adjusted, the LOD is decreased if the measured frame rate is lower than the target FPS, and increased if the measured frame 
+ * The <code>LODManager</code> API manages the Level of Detail displayed in Interface. If the LOD is being automatically
+ * adjusted, the LOD is decreased if the measured frame rate is lower than the target FPS, and increased if the measured frame
  * rate is greater than the target FPS.
  *
  * @namespace LODManager
@@ -85,40 +85,38 @@ class AABox;
  *
  * @property {LODManager.WorldDetailQuality} worldDetailQuality - The quality of the rendered world detail.
  *     <p>Setting this value updates the current desktop or HMD target LOD FPS.</p>
- * @property {number} lodQualityLevel - <em>Not used.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} automaticLODAdjust - <code>true</code> to automatically adjust the LOD, <code>false</code> to manually 
+ * @property {boolean} automaticLODAdjust - <code>true</code> to automatically adjust the LOD, <code>false</code> to manually
  *     adjust it.
  *
  * @property {number} engineRunTime - The time spent in the "render" thread to produce the most recent frame, in ms.
  *     <em>Read-only.</em>
  * @property {number} batchTime - The time spent in the "present" thread processing the batches of the most recent frame, in ms.
  *     <em>Read-only.</em>
- * @property {number} presentTime - The time spent in the "present" thread between the last buffer swap, i.e., the total time 
+ * @property {number} presentTime - The time spent in the "present" thread between the last buffer swap, i.e., the total time
  *     to submit the most recent frame, in ms.
  *     <em>Read-only.</em>
  * @property {number} gpuTime - The time spent in the GPU executing the most recent frame, in ms.
  *     <em>Read-only.</em>
  *
- * @property {number} nowRenderTime - The current, instantaneous time spend to produce frames, in ms. This is the worst of 
+ * @property {number} nowRenderTime - The current, instantaneous time spend to produce frames, in ms. This is the worst of
  *     <code>engineRunTime</code>, <code>batchTime</code>, <code>presentTime</code>, and <code>gpuTime</code>.
  *     <em>Read-only.</em>
- * @property {number} nowRenderFPS - The current, instantaneous frame rate, in Hz. 
+ * @property {number} nowRenderFPS - The current, instantaneous frame rate, in Hz.
  *     <em>Read-only.</em>
  *
- * @property {number} smoothScale - The amount of smoothing applied to calculate <code>smoothRenderTime</code> and 
+ * @property {number} smoothScale - The amount of smoothing applied to calculate <code>smoothRenderTime</code> and
  *     <code>smoothRenderFPS</code>.
  * @property {number} smoothRenderTime - The average time spend to produce frames, in ms.
  *     <em>Read-only.</em>
- * @property {number} smoothRenderFPS - The average frame rate, in Hz. 
+ * @property {number} smoothRenderFPS - The average frame rate, in Hz.
  *     <em>Read-only.</em>
  *
- * @property {number} lodTargetFPS - The target LOD FPS per the current desktop or HMD display mode, capped by the target 
+ * @property {number} lodTargetFPS - The target LOD FPS per the current desktop or HMD display mode, capped by the target
  *     refresh rate set by the {@link Performance} API.
  *     <em>Read-only.</em>
 
- * @property {number} lodAngleDeg - The minimum angular dimension (relative to the camera position) of an entity in order for 
- *     it to be rendered, in degrees. The angular dimension is calculated as a sphere of radius half the diagonal of the 
+ * @property {number} lodAngleDeg - The minimum angular dimension (relative to the camera position) of an entity in order for
+ *     it to be rendered, in degrees. The angular dimension is calculated as a sphere of radius half the diagonal of the
  *     entity's AA box.
  *
  * @property {number} pidKp - <em>Not used.</em>
@@ -134,7 +132,7 @@ class LODManager : public QObject, public Dependency {
     Q_OBJECT
         SINGLETON_DEPENDENCY
 
-        Q_PROPERTY(WorldDetailQuality worldDetailQuality READ getWorldDetailQuality WRITE setWorldDetailQuality 
+        Q_PROPERTY(WorldDetailQuality worldDetailQuality READ getWorldDetailQuality WRITE setWorldDetailQuality
             NOTIFY worldDetailQualityChanged)
 
         Q_PROPERTY(float lodQualityLevel READ getLODQualityLevel WRITE setLODQualityLevel NOTIFY lodQualityLevelChanged)
@@ -179,7 +177,7 @@ public:
     /*@jsdoc
      * Gets whether the LOD is being automatically adjusted.
      * @function LODManager.getAutomaticLODAdjust
-     * @returns {boolean} <code>true</code> if the LOD is being automatically adjusted, <code>false</code> if it is being 
+     * @returns {boolean} <code>true</code> if the LOD is being automatically adjusted, <code>false</code> if it is being
      *     manually adjusted.
      */
     Q_INVOKABLE bool getAutomaticLODAdjust() const { return _automaticLODAdjust; }
@@ -227,32 +225,16 @@ public:
      */
     Q_INVOKABLE QString getLODFeedbackText();
 
-    /*@jsdoc
-     * @function LODManager.setOctreeSizeScale
-     * @param {number} sizeScale - The octree size scale.
-     * @deprecated This function is deprecated and will be removed. Use the <code>lodAngleDeg</code> property instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void setOctreeSizeScale(float sizeScale);
 
-    /*@jsdoc
-     * @function LODManager.getOctreeSizeScale
-     * @returns {number} The octree size scale.
-     * @deprecated This function is deprecated and will be removed. Use the <code>lodAngleDeg</code> property instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE float getOctreeSizeScale() const;
 
-    /*@jsdoc
-     * @function LODManager.setBoundaryLevelAdjust
-     * @param {number} boundaryLevelAdjust - The boundary level adjust factor.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void setBoundaryLevelAdjust(int boundaryLevelAdjust);
 
-    /*@jsdoc
-     * @function LODManager.getBoundaryLevelAdjust
-     * @returns {number} The boundary level adjust factor.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE int getBoundaryLevelAdjust() const { return _boundaryLevelAdjust; }
 
     /*@jsdoc
@@ -313,35 +295,20 @@ public:
 
 signals:
 
-    /*@jsdoc
-     * <em>Not triggered.</em>
-     * @function LODManager.LODIncreased
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void LODIncreased();
 
-    /*@jsdoc
-     * <em>Not triggered.</em>
-     * @function LODManager.LODDecreased
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void LODDecreased();
 
     /*@jsdoc
-     * Triggered when whether or not the LOD is being automatically adjusted changes. 
+     * Triggered when whether or not the LOD is being automatically adjusted changes.
      * @function LODManager.autoLODChanged
      * @returns {Signal}
      */
     void autoLODChanged();
 
-    /*@jsdoc
-     * Triggered when the <code>lodQualityLevel</code> property value changes.
-     * @function LODManager.lodQualityLevelChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void lodQualityLevelChanged();
 
     /*@jsdoc

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -177,7 +177,7 @@ void AvatarManager::updateMyAvatar(float deltaTime) {
 
     if (dt > MIN_TIME_BETWEEN_MY_AVATAR_DATA_SENDS && !_myAvatarDataPacketsPaused) {
         // send head/hand data to the avatar mixer and voxel server
-        PerformanceTimer perfTimer("send"); 
+        PerformanceTimer perfTimer("send");
         _myAvatar->sendAvatarDataPacket();
         _lastSendAvatarDataTime = now;
         _myAvatarSendRate.increment();
@@ -763,7 +763,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
 
     PROFILE_RANGE(simulation_physics, __FUNCTION__);
 
-    float bulletDistance = (float)INT_MAX;  // with FLT_MAX bullet rayTest does not return results 
+    float bulletDistance = (float)INT_MAX;  // with FLT_MAX bullet rayTest does not return results
     glm::vec3 rayDirection = glm::normalize(ray.direction);
     std::vector<MyCharacterController::RayAvatarResult> physicsResults = _myAvatar->getCharacterController()->rayTest(glmToBullet(ray.origin), glmToBullet(rayDirection), bulletDistance, QVector<uint>());
     if (physicsResults.size() > 0) {
@@ -1001,7 +1001,7 @@ void AvatarManager::setAvatarSortCoefficient(const QString& name, const ScriptVa
         }
     }
     if (somethingChanged) {
-        size_t packetSize = sizeof(AvatarData::_avatarSortCoefficientSize) + 
+        size_t packetSize = sizeof(AvatarData::_avatarSortCoefficientSize) +
                             sizeof(AvatarData::_avatarSortCoefficientCenter) +
                             sizeof(AvatarData::_avatarSortCoefficientAge);
 
@@ -1017,12 +1017,10 @@ void AvatarManager::setAvatarSortCoefficient(const QString& name, const ScriptVa
  * PAL (People Access List) data for an avatar.
  * @typedef {object} AvatarManager.PalData
  * @property {Uuid} sessionUUID - The avatar's session ID. <code>""</code> if the avatar is your own.
- * @property {string} sessionDisplayName - The avatar's display name, sanitized and versioned, as defined by the avatar mixer. 
+ * @property {string} sessionDisplayName - The avatar's display name, sanitized and versioned, as defined by the avatar mixer.
  *     It is unique among all avatars present in the domain at the time.
- * @property {number} audioLoudness - The instantaneous loudness of the audio input that the avatar is injecting into the 
+ * @property {number} audioLoudness - The instantaneous loudness of the audio input that the avatar is injecting into the
  *     domain.
- * @property {boolean} isReplicated - <span class="important">Deprecated: This property is deprecated and will be 
- *     removed.</span>
  * @property {Vec3} position - The position of the avatar.
  * @property {number} palOrbOffset - The vertical offset from the avatar's position that an overlay orb should be displayed at.
  */

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -38,11 +38,11 @@
 class ScriptEngine;
 using SortedAvatar = std::pair<float, std::shared_ptr<Avatar>>;
 
-/*@jsdoc 
- * The <code>AvatarManager</code> API provides information about avatars within the current domain. The avatars available are 
+/*@jsdoc
+ * The <code>AvatarManager</code> API provides information about avatars within the current domain. The avatars available are
  * those that Interface has displayed and therefore knows about.
  *
- * <p><strong>Warning:</strong> This API is also provided to Interface, client entity, and avatar scripts as the synonym, 
+ * <p><strong>Warning:</strong> This API is also provided to Interface, client entity, and avatar scripts as the synonym,
  * "<code>AvatarList</code>". For assignment client scripts, see the separate {@link AvatarList} API.</p>
  *
  * @namespace AvatarManager
@@ -107,7 +107,7 @@ public:
     std::shared_ptr<MyAvatar> getMyAvatar() { return _myAvatar; }
     glm::vec3 getMyAvatarPosition() const { return _myAvatar->getWorldPosition(); }
 
-    /*@jsdoc 
+    /*@jsdoc
      * @comment Uses the base class's JSDoc.
      */
     // Null/Default-constructed QUuids will return MyAvatar
@@ -171,7 +171,7 @@ public:
      * @param {PickRay} ray - The ray to use for finding avatars.
      * @param {Uuid[]} [avatarsToInclude=[]] - If not empty then search is restricted to these avatars.
      * @param {Uuid[]} [avatarsToDiscard=[]] - Avatars to ignore in the search.
-     * @param {boolean} [pickAgainstMesh=true] - If <code>true</code> then the exact intersection with the avatar mesh is 
+     * @param {boolean} [pickAgainstMesh=true] - If <code>true</code> then the exact intersection with the avatar mesh is
      *     calculated, if <code>false</code> then the intersection is approximate.
      * @returns {RayToAvatarIntersectionResult} The result of the search for the first intersected avatar.
      * @example <caption>Find the first avatar directly in front of you.</caption>
@@ -179,7 +179,7 @@ public:
      *     origin: MyAvatar.position,
      *     direction: Quat.getFront(MyAvatar.orientation)
      * };
-     * 
+     *
      * var intersection = AvatarManager.findRayIntersection(pickRay);
      * if (intersection.intersects) {
      *     print("Avatar found: " + JSON.stringify(intersection));
@@ -191,54 +191,30 @@ public:
                                                                   const ScriptValue& avatarIdsToInclude = ScriptValue(),
                                                                   const ScriptValue& avatarIdsToDiscard = ScriptValue(),
                                                                   bool pickAgainstMesh = true);
-    /*@jsdoc
-     * @function AvatarManager.findRayIntersectionVector
-     * @param {PickRay} ray - Ray.
-     * @param {Uuid[]} avatarsToInclude - Avatars to include.
-     * @param {Uuid[]} avatarsToDiscard - Avatars to discard.
-     * @param {boolean} pickAgainstMesh - Pick against mesh.
-     * @returns {RayToAvatarIntersectionResult} Intersection result.
-     * @deprecated This function is deprecated and will be removed.
-     */
+
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE RayToAvatarIntersectionResult findRayIntersectionVector(const PickRay& ray,
                                                                         const QVector<EntityItemID>& avatarsToInclude,
                                                                         const QVector<EntityItemID>& avatarsToDiscard,
                                                                         bool pickAgainstMesh);
 
-    /*@jsdoc
-     * @function AvatarManager.findParabolaIntersectionVector
-     * @param {PickParabola} pick - Pick.
-     * @param {Uuid[]} avatarsToInclude - Avatars to include.
-     * @param {Uuid[]} avatarsToDiscard - Avatars to discard.
-     * @returns {ParabolaToAvatarIntersectionResult} Intersection result.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE ParabolaToAvatarIntersectionResult findParabolaIntersectionVector(const PickParabola& pick,
                                                                                   const QVector<EntityItemID>& avatarsToInclude,
                                                                                   const QVector<EntityItemID>& avatarsToDiscard);
 
-    /*@jsdoc
-     * @function AvatarManager.getAvatarSortCoefficient
-     * @param {string} name - Name.
-     * @returns {number} Value.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // TODO: remove this HACK once we settle on optimal default sort coefficients
     Q_INVOKABLE float getAvatarSortCoefficient(const QString& name);
 
-    /*@jsdoc
-     * @function AvatarManager.setAvatarSortCoefficient
-     * @param {string} name - Name
-     * @param {number} value - Value.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void setAvatarSortCoefficient(const QString& name, const ScriptValue& value);
 
     /*@jsdoc
-     * Gets PAL (People Access List) data for one or more avatars. Using this method is faster than iterating over each avatar 
+     * Gets PAL (People Access List) data for one or more avatars. Using this method is faster than iterating over each avatar
      * and obtaining data about each individually.
      * @function AvatarManager.getPalData
-     * @param {string[]} [avatarIDs=[]] - The IDs of the avatars to get the PAL data for. If empty, then PAL data is obtained 
+     * @param {string[]} [avatarIDs=[]] - The IDs of the avatars to get the PAL data for. If empty, then PAL data is obtained
      *     for all avatars.
      * @returns {Object<"data", AvatarManager.PalData[]>} An array of objects, each object being the PAL data for an avatar.
      * @example <caption>Report the PAL data for an avatar nearby.</caption>
@@ -257,11 +233,7 @@ public:
     void accumulateGrabPositions(std::map<QUuid, GrabLocationAccumulator>& grabAccumulators);
 
 public slots:
-    /*@jsdoc
-     * @function AvatarManager.updateAvatarRenderStatus
-     * @param {boolean} shouldRenderAvatars - Should render avatars.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void updateAvatarRenderStatus(bool shouldRenderAvatars);
 
     /*@jsdoc

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -140,8 +140,6 @@ class MyAvatar : public Avatar {
      * @property {boolean} lookAtSnappingEnabled=true - <code>true</code> if the avatar's eyes snap to look at another avatar's
      *     eyes when the other avatar is in the line of sight and also has <code>lookAtSnappingEnabled == true</code>.
      * @property {string} skeletonModelURL - The avatar's FST file.
-     * @property {AttachmentData[]} attachmentData - Information on the avatar's attachments.
-     *     <p class="important">Deprecated: This property is deprecated and will be removed. Use avatar entities instead.</p>
      * @property {string[]} jointNames - The list of joints in the current avatar model. <em>Read-only.</em>
      * @property {Uuid} sessionUUID - Unique ID of the avatar in the domain. <em>Read-only.</em>
      * @property {Mat4} sensorToWorldMatrix - The scale, rotation, and translation transform from the user's real world to the
@@ -174,9 +172,6 @@ class MyAvatar : public Avatar {
      * @comment IMPORTANT: This group of properties is copied from Avatar.h; they should NOT be edited here.
      * @property {Vec3} skeletonOffset - Can be used to apply a translation offset between the avatar's position and the
      *     registration point of the 3D model.
-     *
-     * @property {Vec3} qmlPosition - A synonym for <code>position</code> for use by QML.
-     *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
      *
      * @property {Vec3} feetPosition - The position of the avatar's feet.
      * @property {boolean} shouldRenderLocally=true - If <code>true</code> then your avatar is rendered for you in Interface,
@@ -238,7 +233,6 @@ class MyAvatar : public Avatar {
      * @property {Pose} rightHandTipPose - The right hand's pose as determined by the hand controllers, relative to the avatar,
      *     with the position adjusted by 0.3m along the direction of the palm. <em>Read-only.</em>
      *
-     * @property {number} energy - <span class="important">Deprecated: This property will be removed.</span>
      * @property {boolean} isAway - <code>true</code> if your avatar is away (i.e., inactive), <code>false</code> if it is
      *     active.
      *
@@ -253,9 +247,6 @@ class MyAvatar : public Avatar {
      *     was set <code>false</code> because the zone may disallow collisionless avatars.
      * @property {boolean} otherAvatarsCollisionsEnabled - Set to <code>true</code> to enable the avatar to collide with other
      *     avatars, <code>false</code> to disable collisions with other avatars.
-     * @property {boolean} characterControllerEnabled - Synonym of <code>collisionsEnabled</code>.
-     *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>collisionsEnabled</code>
-     *     instead.</p>
      * @property {boolean} useAdvancedMovementControls - Returns and sets the value of the Interface setting, Settings >
      *     Controls > Walking. Note: Setting the value has no effect unless Interface is restarted.
      * @property {boolean} showPlayArea - Returns and sets the value of the Interface setting, Settings > Controls > Show room
@@ -288,18 +279,11 @@ class MyAvatar : public Avatar {
      * @property {number} analogPlusWalkSpeed - The walk speed of your avatar for the "AnalogPlus" control scheme.
      *     <p><strong>Warning:</strong> Setting this value also sets the value of <code>analogPlusSprintSpeed</code> to twice
      *     the value.</p>
-     * @property {number} analogPlusSprintSpeed - The sprint (run) speed of your avatar for the "AnalogPlus" control scheme.
-     * @property {MyAvatar.SitStandModelType} userRecenterModel - Controls avatar leaning and recentering behavior.
-     *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
      * @property {boolean} isInSittingState - <code>true</code> if the user wearing the HMD is determined to be sitting;
      *     <code>false</code> if the user wearing the HMD is determined to be standing.  This can affect whether the avatar
      *     is allowed to stand, lean or recenter its footing, depending on user preferences.
      *     The property value automatically updates as the user sits or stands. Setting the property value overrides the current
      *     sitting / standing state, which is updated when the user next sits or stands.
-     * @property {boolean} isSitStandStateLocked - <code>true</code> to lock the avatar sitting/standing state, i.e., use this
-     *     to disable automatically changing state.
-     *     <p class="important">Deprecated: This property is deprecated and will be removed.
-     *     See also: <code>getUserRecenterModel</code> and <code>setUserRecenterModel</code>.</p>
      * @property {boolean} allowTeleporting - <code>true</code> if teleporting is enabled in the Interface settings,
      *     <code>false</code> if it isn't. <em>Read-only.</em>
      *
@@ -526,30 +510,7 @@ public:
     };
     Q_ENUM(DriveKeys)
 
-    /*@jsdoc
-     * <p>Specifies different avatar leaning and recentering behaviors.</p>
-     * <p class="important">Deprecated: This type is deprecated and will be removed.</p>
-     * <table>
-     *   <thead>
-     *     <tr><th>Value</th><th>Name</th><th>Description</th></tr>
-     *   </thead>
-     *   <tbody>
-     *     <tr><td><code>0</code></td><td>ForceSit</td><td>Assumes the user is seated in the real world. Disables avatar
-     *       leaning regardless of what the avatar is doing in the virtual world (i.e., avatar always recenters).</td></tr>
-     *     <tr><td><code>1</code></td><td>ForceStand</td><td>Assumes the user is standing in the real world. Enables avatar
-     *       leaning regardless of what the avatar is doing in the virtual world (i.e., avatar leans, then if leans too far it
-     *       recenters).</td></tr>
-     *     <tr><td><code>2</code></td><td>Auto</td><td>Interface detects when the user is standing or seated in the real world.
-     *       Avatar leaning is disabled when the user is sitting (i.e., avatar always recenters), and avatar leaning is enabled
-     *       when the user is standing (i.e., avatar leans, then if leans too far it recenters).</td></tr>
-     *     <tr><td><code>3</code></td><td>DisableHMDLean</td><td><p>Both avatar leaning and recentering are disabled regardless of
-     *       what the user is doing in the real world and no matter what their avatar is doing in the virtual world. Enables
-     *       the avatar to sit on the floor when the user sits on the floor.</p>
-     *       <p><strong>Note:</strong> Experimental.</p></td></tr>
-     *   </tbody>
-     * </table>
-     * @typedef {number} MyAvatar.SitStandModelType
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     enum SitStandModelType {
         ForceSit = 0,
         ForceStand,
@@ -1684,19 +1645,10 @@ public:
      */
     Q_INVOKABLE QVariantMap getCollisionCapsule() const;
 
-    /*@jsdoc
-     * @function MyAvatar.setCharacterControllerEnabled
-     * @param {boolean} enabled - <code>true</code> to enable the avatar to collide with entities, <code>false</code> to
-     *     disable.
-     * @deprecated This function is deprecated and will be removed. Use {@link MyAvatar.setCollisionsEnabled} instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void setCharacterControllerEnabled(bool enabled); // deprecated
 
-    /*@jsdoc
-     * @function MyAvatar.getCharacterControllerEnabled
-     * @returns {boolean} <code>true</code> if the avatar will currently collide with entities, <code>false</code> if it won't.
-     * @deprecated This function is deprecated and will be removed. Use {@link MyAvatar.getCollisionsEnabled} instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE bool getCharacterControllerEnabled(); // deprecated
 
     /*@jsdoc
@@ -2074,10 +2026,7 @@ public slots:
      */
     void resetSize();
 
-    /*@jsdoc
-     * @function MyAvatar.animGraphLoaded
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void animGraphLoaded();
 
     /*@jsdoc
@@ -2135,55 +2084,19 @@ public slots:
      */
     void goToLocationAndEnableCollisions(const glm::vec3& newPosition);
 
-    /*@jsdoc
-     * @function MyAvatar.safeLanding
-     * @param {Vec3} position -The new position for the avatar, in world coordinates.
-     * @returns {boolean} <code>true</code> if the avatar was moved, <code>false</code> if it wasn't.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     bool safeLanding(const glm::vec3& position);
 
 
-    /*@jsdoc
-     * @function MyAvatar.restrictScaleFromDomainSettings
-     * @param {object} domainSettings - Domain settings.
-     * @deprecated This function is deprecated and will be removed.
-     */
     void restrictScaleFromDomainSettings(const QJsonObject& domainSettingsObject);
 
-    /*@jsdoc
-     * @function MyAvatar.clearScaleRestriction
-     * @deprecated This function is deprecated and will be removed.
-     */
     void clearScaleRestriction();
 
-
-    /*@jsdoc
-     * Adds a thrust to your avatar's current thrust to be applied for a short while.
-     * @function MyAvatar.addThrust
-     * @param {Vec3} thrust - The thrust direction and magnitude.
-     * @deprecated This function is deprecated and will be removed. Use {@link MyAvatar|MyAvatar.motorVelocity} and related
-     *     properties instead.
-     */
     //  Set/Get update the thrust that will move the avatar around
     void addThrust(glm::vec3 newThrust) { _thrust += newThrust; };
 
-    /*@jsdoc
-     * Gets the thrust currently being applied to your avatar.
-     * @function MyAvatar.getThrust
-     * @returns {Vec3} The thrust currently being applied to your avatar.
-     * @deprecated This function is deprecated and will be removed. Use {@link MyAvatar|MyAvatar.motorVelocity} and related
-     *     properties instead.
-     */
     glm::vec3 getThrust() { return _thrust; };
 
-    /*@jsdoc
-     * Sets the thrust to be applied to your avatar for a short while.
-     * @function MyAvatar.setThrust
-     * @param {Vec3} thrust - The thrust direction and magnitude.
-     * @deprecated This function is deprecated and will be removed. Use {@link MyAvatar|MyAvatar.motorVelocity} and related
-     *     properties instead.
-     */
     void setThrust(glm::vec3 newThrust) { _thrust = newThrust; }
 
 
@@ -2194,11 +2107,6 @@ public slots:
      */
     Q_INVOKABLE void updateMotionBehaviorFromMenu();
 
-    /*@jsdoc
-     * @function MyAvatar.setToggleHips
-     * @param {boolean} enabled - Enabled.
-     * @deprecated This function is deprecated and will be removed.
-     */
     void setToggleHips(bool followHead);
 
     /*@jsdoc
@@ -2370,11 +2278,7 @@ public slots:
      */
     glm::quat getOrientationForAudio();
 
-    /*@jsdoc
-     * @function MyAvatar.setModelScale
-     * @param {number} scale - The scale.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     virtual void setModelScale(float scale) override;
 
     /*@jsdoc
@@ -2470,11 +2374,7 @@ signals:
      */
     void walkBackwardSpeedChanged(float value);
 
-    /*@jsdoc
-     * @function MyAvatar.transformChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void transformChanged();
 
     /*@jsdoc
@@ -2526,12 +2426,7 @@ signals:
      * });     */
     void animGraphUrlChanged(const QUrl& url);
 
-    /*@jsdoc
-     * @function MyAvatar.energyChanged
-     * @param {number} energy - Avatar energy.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void energyChanged(float newEnergy);
 
     /*@jsdoc
@@ -2609,14 +2504,7 @@ signals:
      */
     void sensorToWorldScaleChanged(float sensorToWorldScale);
 
-    /*@jsdoc
-     * Triggered when the a model is attached to or detached from one of the avatar's joints using one of
-     * {@link MyAvatar.attach|attach}, {@link MyAvatar.detachOne|detachOne}, {@link MyAvatar.detachAll|detachAll}, or
-     * {@link MyAvatar.setAttachmentData|setAttachmentData}.
-     * @function MyAvatar.attachmentsChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed. Use avatar entities instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void attachmentsChanged();
 
     /*@jsdoc

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -97,21 +97,21 @@ PickFilter getPickFilter(unsigned int filter) {
  * The properties of a ray pick.
  *
  * @typedef {object} Picks.RayPickProperties
- * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should 
+ * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should
  *     start disabled. Disabled picks do not update their pick results.
- * @property {FilterFlags} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property 
+ * @property {FilterFlags} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property
  *     values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
- * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code> 
+ * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
  *     means no maximum.
  * @property {Uuid} [parentID] - The ID of the parent: an avatar, an entity, or another pick.
- * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint. 
+ * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint.
  *     A value of <code>0</code> means no joint.
  *     <p><em>Used only if <code>parentID</code> is specified.</em></p>
- * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to 
- *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not 
+ * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not
  *     parented to anything.
  *     <p><em>Used only if <code>parentID</code> is not specified.</em></p>
- * @property {Vec3} [position=Vec3.ZERO] - The offset of the ray origin from its parent if parented, otherwise the ray origin 
+ * @property {Vec3} [position=Vec3.ZERO] - The offset of the ray origin from its parent if parented, otherwise the ray origin
  *     in world coordinates.
  * @property {Vec3} [posOffset] - Synonym for <code>position</code>.
  * @property {Vec3} [direction] - The offset of the ray direction from its parent's y-axis if parented, otherwise the ray
@@ -119,12 +119,12 @@ PickFilter getPickFilter(unsigned int filter) {
  *     <p><strong>Default Value:</strong> <code>Vec3.UP</code> direction if <code>joint</code> is specified, otherwise
  *     <code>-Vec3.UP</code>.</p>
  * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
- * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
+ * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the
  *     default <code>direction</code> value.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or
  *     {@link Picks.getPickScriptParameters}. A ray pick's type is {@link PickType.Ray}.
- * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale 
- *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and 
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale
+ *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and
  *     is used to scale the pointer which owns this pick, if any.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMap& propMap) {
@@ -183,7 +183,7 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMa
  * The properties of a stylus pick.
  *
  * @typedef {object} Picks.StylusPickProperties
- * @property {number} [hand=-1] <code>0</code> for the left hand, <code>1</code> for the right hand, invalid (<code>-1</code>) 
+ * @property {number} [hand=-1] <code>0</code> for the left hand, <code>1</code> for the right hand, invalid (<code>-1</code>)
  *     otherwise.
  * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should
  *     start disabled. Disabled picks do not update their pick results.
@@ -192,9 +192,9 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMa
  *     <p><strong>Note:</strong> Stylus picks do not intersect avatars or the HUD.</p>
  * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
  *     means no maximum.
- * @property {Vec3} [tipOffset=0,0.095,0] - The position of the stylus tip relative to the hand position at default avatar 
+ * @property {Vec3} [tipOffset=0,0.095,0] - The position of the stylus tip relative to the hand position at default avatar
  *     scale.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or
  *     {@link Picks.getPickScriptParameters}. A stylus pick's type is {@link PickType.Stylus}.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVariantMap& propMap) {
@@ -229,37 +229,37 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVarian
     return std::make_shared<StylusPick>(side, filter, maxDistance, enabled, tipOffset);
 }
 
-// NOTE: Laser pointer still uses scaleWithAvatar. Until scaleWithAvatar is also deprecated for pointers, scaleWithAvatar 
+// NOTE: Laser pointer still uses scaleWithAvatar. Until scaleWithAvatar is also deprecated for pointers, scaleWithAvatar
 // should not be removed from the pick API.
 /*@jsdoc
  * The properties of a parabola pick.
  *
  * @typedef {object} Picks.ParabolaPickProperties
- * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should 
+ * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should
  *     start disabled. Disabled picks do not update their pick results.
- * @property {number} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property 
+ * @property {number} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property
  *     values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
- * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code> 
+ * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
  *     means no maximum.
  * @property {Uuid} [parentID] - The ID of the parent: an avatar, an entity, or another pick.
  * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint.
  *     A value of <code>0</code> means no joint.
  *     <p><em>Used only if <code>parentID</code> is specified.</em></p>
- * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to 
- *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not 
+ * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not
  *     parented to anything.
  *     <p><em>Used only if <code>parentID</code> is not specified.</em></p>
- * @property {Vec3} [position=Vec3.ZERO] - The offset of the parabola origin from its parent if parented, otherwise the 
+ * @property {Vec3} [position=Vec3.ZERO] - The offset of the parabola origin from its parent if parented, otherwise the
  *     parabola origin in world coordinates.
  * @property {Vec3} [posOffset] - Synonym for <code>position</code>.
- * @property {Vec3} [direction] - The offset of the parabola direction from its parent's y-axis if parented, otherwise the 
+ * @property {Vec3} [direction] - The offset of the parabola direction from its parent's y-axis if parented, otherwise the
  *     parabola direction in world coordinates.
  *     <p><strong>Default Value:</strong> <code>Vec3.UP</code> direction if <code>joint</code> is specified, otherwise
  *     <code>Vec3.FRONT</code>.</p>
  * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
- * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
+ * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the
  *     default <code>direction</code> value.
- * @property {number} [speed=1] - The initial speed of the parabola in m/s, i.e., the initial speed of a virtual projectile 
+ * @property {number} [speed=1] - The initial speed of the parabola in m/s, i.e., the initial speed of a virtual projectile
  *     whose trajectory defines the parabola.
  * @property {Vec3} [accelerationAxis=-Vec3.UP] - The acceleration of the parabola in m/s<sup>2</sup>, i.e., the acceleration
  *     of a virtual projectile whose trajectory defines the parabola, both magnitude and direction.
@@ -269,12 +269,10 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVarian
  *     parent about the parent's y-axis, if available.
  * @property {boolean} [scaleWithParent=true] - <code>true</code> if the velocity and acceleration of the pick should scale
  *     with the avatar or other parent.
- * @property {boolean} [scaleWithAvatar=true] - Synonym for <code>scalewithParent</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or
  *     {@link Picks.getPickScriptParameters}. A parabola pick's type is {@link PickType.Parabola}.
- * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale 
- *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and 
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale
+ *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and
  *     is used to rescale the pick and the pointer which owns this pick, if any.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVariantMap& propMap) {
@@ -361,10 +359,10 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVari
  *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not
  *     parented to anything.
  *     <p><em>Used only if <code>parentID</code> is not specified.</em></p>
- * @property {boolean} [scaleWithParent=true] - <code>true</code> to scale the pick's dimensions and threshold according to the 
+ * @property {boolean} [scaleWithParent=true] - <code>true</code> to scale the pick's dimensions and threshold according to the
  *     scale of the parent.
  *
- * @property {Shape} shape - The collision region's shape and size. Dimensions are in world coordinates but scale with the 
+ * @property {Shape} shape - The collision region's shape and size. Dimensions are in world coordinates but scale with the
  *     parent if defined.
  * @property {Vec3} position - The position of the collision region, relative to the parent if defined.
  * @property {Quat} orientation - The orientation of the collision region, relative to the parent if defined.
@@ -372,10 +370,10 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVari
  *     the collision region. The depth is in world coordinates but scales with the parent if defined.
  * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
  *     masks overlap with the region's collision group are considered to be colliding with the region.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or
  *     {@link Picks.getPickScriptParameters}. A collision pick's type is {@link PickType.Collision}.
- * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale 
- *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and 
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale
+ *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and
  *     is used to rescale the pick, and/or the pointer which owns this pick, if any.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildCollisionPick(const QVariantMap& propMap) {

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -35,13 +35,6 @@ class ScriptValue;
  * @property {FilterFlags} PICK_AVATARS - Include avatars when intersecting. <em>Read-only.</em>
  * @property {FilterFlags} PICK_HUD - Include the HUD surface when intersecting in HMD mode. <em>Read-only.</em>
  *
- * @property {FilterFlags} PICK_ENTITIES - Include domain and avatar entities when intersecting. <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>PICK_DOMAIN_ENTITIES | 
- *     PICK_AVATAR_ENTITIES</code> instead.</p>
- * @property {FilterFlags} PICK_OVERLAYS - Include local entities when intersecting. <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>PICK_LOCAL_ENTITIES</code> 
- *     instead.</p>
- *
  * @property {FilterFlags} PICK_INCLUDE_VISIBLE - Include visible objects when intersecting. <em>Read-only.</em>
  *     <p><strong>Warning:</strong> Is currently always enabled by default but may not be in the future.</p>
  * @property {FilterFlags} PICK_INCLUDE_INVISIBLE - Include invisible objects when intersecting. <em>Read-only.</em>
@@ -53,21 +46,17 @@ class ScriptValue;
  * @property {FilterFlags} PICK_PRECISE - Pick against exact meshes. <em>Read-only.</em>
  * @property {FilterFlags} PICK_COARSE - Pick against coarse meshes. <em>Read-only.</em>
  *
- * @property {FilterFlags} PICK_ALL_INTERSECTIONS - If set, returns all intersections instead of just the closest. 
+ * @property {FilterFlags} PICK_ALL_INTERSECTIONS - If set, returns all intersections instead of just the closest.
  *     <em>Read-only.</em>
  *     <p><strong>Warning:</strong> Not yet implemented.</p>
  *
- * @property {FilterFlags} PICK_BYPASS_IGNORE - Allows pick to intersect entities even when their 
+ * @property {FilterFlags} PICK_BYPASS_IGNORE - Allows pick to intersect entities even when their
  *     <code>ignorePickIntersection</code> property value is <code>true</code>. For debug purposes.
  *     <em>Read-only.</em>
  *
  * @property {IntersectionType} INTERSECTED_NONE - Intersected nothing. <em>Read-only.</em>
  * @property {IntersectionType} INTERSECTED_ENTITY - Intersected an entity. <em>Read-only.</em>
  * @property {IntersectionType} INTERSECTED_LOCAL_ENTITY - Intersected a local entity. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_OVERLAY - Intersected a local entity. (3D overlays no longer exist.) 
- *     <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use 
- *     <code>INTERSECTED_LOCAL_ENTITY</code> instead.</p>
  * @property {IntersectionType} INTERSECTED_AVATAR - Intersected an avatar. <em>Read-only.</em>
  * @property {IntersectionType} INTERSECTED_HUD - Intersected the HUD surface. <em>Read-only.</em>
  *
@@ -112,14 +101,14 @@ public:
     void registerProperties(ScriptEngine* engine);
 
     /*@jsdoc
-     * Creates a new pick. Different {@link PickType}s use different properties, and within one PickType the properties you 
-     * choose can lead to a wide range of behaviors. For example, with <code>PickType.Ray</code>, the properties could 
+     * Creates a new pick. Different {@link PickType}s use different properties, and within one PickType the properties you
+     * choose can lead to a wide range of behaviors. For example, with <code>PickType.Ray</code>, the properties could
      * configure a mouse ray pick, an avatar head ray pick, or a joint ray pick.
-     * <p><strong>Warning:</strong> Picks created using this method currently always intersect at least visible and collidable 
+     * <p><strong>Warning:</strong> Picks created using this method currently always intersect at least visible and collidable
      * things but this may not always be the case.</p>
      * @function Picks.createPick
      * @param {PickType} type - The type of picking to use.
-     * @param {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} 
+     * @param {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties}
      *     properties - Properties of the pick, per the pick <code>type</code>.
      * @returns {number} The ID of the pick created. <code>0</code> if invalid.
      */
@@ -165,12 +154,12 @@ public:
     Q_INVOKABLE QVariantMap getPickProperties(unsigned int uid) const;
 
     /*@jsdoc
-     * Gets the parameters that were passed in to {@link Picks.createPick} to create the pick, if the pick was created through 
+     * Gets the parameters that were passed in to {@link Picks.createPick} to create the pick, if the pick was created through
      * a script. Note that these properties do not reflect the current state of the pick.
      * See {@link Picks.getPickProperties}.
      * @function Picks.getPickScriptParameters
      * @param {number} id - The ID of the pick.
-     * @returns {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} 
+     * @returns {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties}
      *     Script-provided properties, per the pick <code>type</code>.
      */
     Q_INVOKABLE QVariantMap getPickScriptParameters(unsigned int uid) const;
@@ -183,9 +172,9 @@ public:
     Q_INVOKABLE QVector<unsigned int> getPicks() const;
 
     /*@jsdoc
-     * Gets the most recent result from a pick. A pick continues to be updated ready to return a result, as long as it is 
+     * Gets the most recent result from a pick. A pick continues to be updated ready to return a result, as long as it is
      * enabled.
-     * <p><strong>Note:</strong> Stylus picks only intersect with objects in their include list, set using 
+     * <p><strong>Note:</strong> Stylus picks only intersect with objects in their include list, set using
      * {@link Picks.setIncludeItems|setIncludeItems}.</p>
      * @function Picks.getPrevPickResult
      * @param {number} id - The ID of the pick.
@@ -195,7 +184,7 @@ public:
      * var HIGHLIGHT_LIST_NAME = "highlightEntitiesExampleList";
      * var HIGHLIGHT_LIST_TYPE = "entity";
      * Selection.enableListHighlight(HIGHLIGHT_LIST_NAME, {});
-     * 
+     *
      * // Ray pick.
      * var PICK_FILTER = Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES
      *         | Picks.PICK_INCLUDE_COLLIDABLE | Picks.PICK_INCLUDE_NONCOLLIDABLE;
@@ -204,7 +193,7 @@ public:
      *     filter: PICK_FILTER,
      *     joint: HMD.active ? "Avatar" : "Mouse"
      * });
-     * 
+     *
      * // Highlight intersected entity.
      * var highlightedEntityID = null;
      * Script.update.connect(function () {
@@ -224,7 +213,7 @@ public:
      *         }
      *     }
      * });
-     * 
+     *
      * // Clean up.
      * Script.scriptEnding.connect(function () {
      *     if (highlightedEntityID) {
@@ -235,7 +224,7 @@ public:
     Q_INVOKABLE QVariantMap getPrevPickResult(unsigned int uid);
 
     /*@jsdoc
-     * Sets whether or not a pick should use precision picking, i.e., whether it should pick against precise meshes or coarse 
+     * Sets whether or not a pick should use precision picking, i.e., whether it should pick against precise meshes or coarse
      * meshes.
      * This has the same effect as using the <code>PICK_PRECISE</code> or <code>PICK_COARSE</code> filter flags.
      * @function Picks.setPrecisionPicking
@@ -254,7 +243,7 @@ public:
     Q_INVOKABLE void setIgnoreItems(unsigned int uid, const ScriptValue& ignoreItems);
 
     /*@jsdoc
-     * Sets a list of entity and avatar IDs that a pick should include during intersection, instead of intersecting with 
+     * Sets a list of entity and avatar IDs that a pick should include during intersection, instead of intersecting with
      * everything.
      * <p><strong>Note:</strong> Stylus picks only intersect with items in their include list.</p>
      * @function Picks.setIncludeItems
@@ -264,8 +253,8 @@ public:
     Q_INVOKABLE void setIncludeItems(unsigned int uid, const ScriptValue& includeItems);
 
     /*@jsdoc
-     * Checks if a pick is associated with the left hand: a ray or parabola pick with <code>joint</code> property set to 
-     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with 
+     * Checks if a pick is associated with the left hand: a ray or parabola pick with <code>joint</code> property set to
+     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with
      * <code>hand</code> property set to <code>0</code>.
      * @function Picks.isLeftHand
      * @param {number} id - The ID of the pick.
@@ -275,7 +264,7 @@ public:
 
     /*@jsdoc
      * Checks if a pick is associated with the right hand: a ray or parabola pick with <code>joint</code> property set to
-     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with 
+     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with
      * <code>hand</code> property set to <code>1</code>.
      * @function Picks.isRightHand
      * @param {number} id - The ID of the pick.
@@ -284,7 +273,7 @@ public:
     Q_INVOKABLE bool isRightHand(unsigned int uid);
 
     /*@jsdoc
-     * Checks if a pick is associated with the system mouse: a ray or parabola pick with <code>joint</code> property set to 
+     * Checks if a pick is associated with the system mouse: a ray or parabola pick with <code>joint</code> property set to
      * <code>"Mouse"</code>.
      * @function Picks.isMouse
      * @param {number} id - The ID of the pick.
@@ -299,166 +288,64 @@ public slots:
 
     static constexpr unsigned int getPickBypassIgnore() { return PickFilter::getBitMask(PickFilter::FlagBit::PICK_BYPASS_IGNORE); }
 
-    /*@jsdoc
-     * @function Picks.PICK_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_DOMAIN_ENTITIES | 
-     *     Picks.PICK_AVATAR_ENTITIES</code> properties expression instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickEntities() { return PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES); }
 
-    /*@jsdoc
-     * @function Picks.PICK_OVERLAYS
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_LOCAL_ENTITIES</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickOverlays() { return PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES); }
 
-
-    /*@jsdoc
-     * @function Picks.PICK_DOMAIN_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_DOMAIN_ENTITIES</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickDomainEntities() { return PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES); }
 
-    /*@jsdoc
-     * @function Picks.PICK_AVATAR_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_AVATAR_ENTITIES</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickAvatarEntities() { return PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES); }
 
-    /*@jsdoc
-     * @function Picks.PICK_LOCAL_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_LOCAL_ENTITIES</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickLocalEntities() { return PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES); }
 
-    /*@jsdoc
-     * @function Picks.PICK_AVATARS
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_AVATARS</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickAvatars() { return PickFilter::getBitMask(PickFilter::FlagBit::AVATARS); }
 
-    /*@jsdoc
-     * @function Picks.PICK_HUD
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_HUD</code> property instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickHud() { return PickFilter::getBitMask(PickFilter::FlagBit::HUD); }
 
-
-    /*@jsdoc
-     * @function Picks.PICK_INCLUDE_VISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_VISIBLE</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickIncludeVisible() { return PickFilter::getBitMask(PickFilter::FlagBit::VISIBLE); }
 
-    /*@jsdoc
-     * @function Picks.PICK_INCLUDE_INVISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_INVISIBLE</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickIncludeInvisible() { return PickFilter::getBitMask(PickFilter::FlagBit::INVISIBLE); }
 
-
-    /*@jsdoc
-     * @function Picks.PICK_INCLUDE_COLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_COLLIDABLE</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickIncludeCollidable() { return PickFilter::getBitMask(PickFilter::FlagBit::COLLIDABLE); }
 
-    /*@jsdoc
-     * @function Picks.PICK_INCLUDE_NONCOLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_NONCOLLIDABLE</code> 
-     *     property instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickIncludeNoncollidable() { return PickFilter::getBitMask(PickFilter::FlagBit::NONCOLLIDABLE); }
 
-
-    /*@jsdoc
-     * @function Picks.PICK_PRECISE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_PRECISE</code> property instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickPrecise() { return PickFilter::getBitMask(PickFilter::FlagBit::PRECISE); }
 
-    /*@jsdoc
-     * @function Picks.PICK_COARSE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_COARSE</code> property instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickCoarse() { return PickFilter::getBitMask(PickFilter::FlagBit::COARSE); }
 
-
-    /*@jsdoc
-     * @function Picks.PICK_ALL_INTERSECTIONS
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_ALL_INTERSECTIONS</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getPickAllIntersections() { return PickFilter::getBitMask(PickFilter::FlagBit::PICK_ALL_INTERSECTIONS); }
 
-    /*@jsdoc
-     * @function Picks.INTERSECTED_NONE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_NONE</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getIntersectedNone() { return IntersectionType::NONE; }
 
-    /*@jsdoc
-     * @function Picks.INTERSECTED_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_ENTITY</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getIntersectedEntity() { return IntersectionType::ENTITY; }
 
-    /*@jsdoc
-     * @function Picks.INTERSECTED_LOCAL_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_LOCAL_ENTITY</code> 
-     *     property instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getIntersectedLocalEntity() { return IntersectionType::LOCAL_ENTITY; }
 
-    /*@jsdoc
-     * @function Picks.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_LOCAL_ENTITY</code> 
-     *     property instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getIntersectedOverlay() { return getIntersectedLocalEntity(); }
 
-    /*@jsdoc
-     * @function Picks.INTERSECTED_AVATAR
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_AVATAR</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getIntersectedAvatar() { return IntersectionType::AVATAR; }
 
-    /*@jsdoc
-     * @function Picks.INTERSECTED_HUD
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_HUD</code> property 
-     *     instead.
-     * @returns {number}
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     static constexpr unsigned int getIntersectedHud() { return IntersectionType::HUD; }
 
 protected:

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -113,21 +113,21 @@ QVariantMap PointerScriptingInterface::getPointerScriptParameters(unsigned int u
  * The properties of a stylus pointer. These include the properties from the underlying stylus pick that the pointer uses.
  * @typedef {object} Pointers.StylusPointerProperties
  * @property {Pointers.StylusPointerModel} [model] - Override some or all of the default stylus model properties.
- * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events, 
+ * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events,
  *     <code>false</code> if it doesn't.
- * @property {PickType} pointerType - The type of the stylus pointer returned from {@link Pointers.getPointerProperties} 
+ * @property {PickType} pointerType - The type of the stylus pointer returned from {@link Pointers.getPointerProperties}
  *     or {@link Pointers.getPointerScriptParameters}. A stylus pointer's type is {@link PickType(0)|PickType.Stylus}.
- * @property {number} [pickID] - The ID of the pick created alongside this pointer, returned from 
- *     {@link Pointers.getPointerProperties}. 
+ * @property {number} [pickID] - The ID of the pick created alongside this pointer, returned from
+ *     {@link Pointers.getPointerProperties}.
  * @see {@link Picks.StylusPickProperties} for additional properties from the underlying stylus pick.
  */
- 
+
 /*@jsdoc
  * The properties of a stylus pointer model.
  * @typedef {object} Pointers.StylusPointerModel
  * @property {string} [url] - The url of a model to use for the stylus, to override the default stylus mode.
  * @property {Vec3} [dimensions] - The dimensions of the stylus, to override the default stylus dimensions.
- * @property {Vec3} [positionOffset] - The position offset of the model from the stylus tip, to override the default position 
+ * @property {Vec3} [positionOffset] - The position offset of the model from the stylus tip, to override the default position
  *     offset.
  * @property {Quat} [rotationOffset] - The rotation offset of the model from the hand, to override the default rotation offset.
  */
@@ -168,7 +168,7 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildStylus(const PointerPro
 }
 
 /*@jsdoc
- * Properties that define the visual appearance of a ray pointer when the pointer is not intersecting something. These are the 
+ * Properties that define the visual appearance of a ray pointer when the pointer is not intersecting something. These are the
  * properties of {@link Pointers.RayPointerRenderState} but with an additional property.
  * @typedef {object} Pointers.DefaultRayPointerRenderState
  * @property {number} distance - The distance at which to render the end of the ray pointer.
@@ -179,14 +179,14 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildStylus(const PointerPro
  * @typedef {object} Pointers.RayPointerRenderState
  * @property {string} name - When creating using {@link Pointers.createPointer}, the name of the render state.
  * @property {Overlays.OverlayProperties|Uuid} [start]
- *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of 
+ *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
  *     an overlay to render at the start of the ray pointer. The <code>type</code> property must be specified.</p>
  *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the start of the ray;
  *     <code>null</code> if there is no overlay.
  *
  * @property {Overlays.OverlayProperties|Uuid} [path]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
- *     the overlay rendered for the path of the ray pointer. The <code>type</code> property must be specified and be 
+ *     the overlay rendered for the path of the ray pointer. The <code>type</code> property must be specified and be
  *     <code>"line3d"</code>.</p>
  *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered for the path of the ray;
  *     <code>null</code> if there is no overlay.
@@ -194,53 +194,51 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildStylus(const PointerPro
  * @property {Overlays.OverlayProperties|Uuid} [end]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
  *     an overlay to render at the end of the ray pointer. The <code>type</code> property must be specified.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the end of the ray; 
+ *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the end of the ray;
  *     <code>null</code> if there is no overlay.
  */
 /*@jsdoc
  * The properties of a ray pointer. These include the properties from the underlying ray pick that the pointer uses.
  * @typedef {object} Pointers.RayPointerProperties
- * @property {boolean} [faceAvatar=false] - <code>true</code> if the overlay rendered at the end of the ray rotates about the 
+ * @property {boolean} [faceAvatar=false] - <code>true</code> if the overlay rendered at the end of the ray rotates about the
  *     world y-axis to always face the avatar; <code>false</code> if it maintains its world orientation.
- * @property {boolean} [centerEndY=true] - <code>true</code> if the overlay rendered at the end of the ray is centered on 
- *     the ray end; <code>false</code> if the overlay is positioned against the surface if <code>followNormal</code> is 
+ * @property {boolean} [centerEndY=true] - <code>true</code> if the overlay rendered at the end of the ray is centered on
+ *     the ray end; <code>false</code> if the overlay is positioned against the surface if <code>followNormal</code> is
  *     <code>true</code>, or above the ray end if <code>followNormal</code> is <code>false</code>.
-* @property {boolean} [lockEnd=false] - <code>true</code> if the end of the ray is locked to the center of the object at 
+* @property {boolean} [lockEnd=false] - <code>true</code> if the end of the ray is locked to the center of the object at
  *     which the ray is pointing; <code>false</code> if the end of the ray is at the intersected surface.
- * @property {boolean} [distanceScaleEnd=false] - <code>true</code> if the dimensions of the overlay at the end of the ray 
- *     scale linearly with distance; <code>false</code> if they aren't. 
- * @property {boolean} [scaleWithParent=false] - <code>true</code> if the width of the ray's path and the size of the 
+ * @property {boolean} [distanceScaleEnd=false] - <code>true</code> if the dimensions of the overlay at the end of the ray
+ *     scale linearly with distance; <code>false</code> if they aren't.
+ * @property {boolean} [scaleWithParent=false] - <code>true</code> if the width of the ray's path and the size of the
  *     start and end overlays scale linearly with the pointer parent's scale; <code>false</code> if they don't scale.
- * @property {boolean} [scaleWithAvatar=false] - A synonym for <code>scalewithParent</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} [followNormal=false] - <code>true</code> if the overlay rendered at the end of the ray rotates to 
+ * @property {boolean} [followNormal=false] - <code>true</code> if the overlay rendered at the end of the ray rotates to
  *     follow the normal of the surface if one is intersected; <code>false</code> if it doesn't.
- * @property {number} [followNormalStrength=0.0] - How quickly the overlay rendered at the end of the ray rotates to follow 
- *     the normal of an intersected surface. If <code>0</code> or <code>1</code>, the overlay rotation follows instantaneously; 
+ * @property {number} [followNormalStrength=0.0] - How quickly the overlay rendered at the end of the ray rotates to follow
+ *     the normal of an intersected surface. If <code>0</code> or <code>1</code>, the overlay rotation follows instantaneously;
  *    for other values, the larger the value the more quickly the rotation follows.
  * @property {Pointers.RayPointerRenderState[]|Object.<string, Pointers.RayPointerRenderState>} [renderStates]
- *     <p>A set of visual states that can be switched among using {@link Pointers.setRenderState}. These define the visual 
+ *     <p>A set of visual states that can be switched among using {@link Pointers.setRenderState}. These define the visual
  *     appearance of the pointer when it is intersecting something.</p>
- *     <p>When setting using {@link Pointers.createPointer}, an array of 
+ *     <p>When setting using {@link Pointers.createPointer}, an array of
  *     {@link Pointers.RayPointerRenderState|RayPointerRenderState} values.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, an object mapping render state names to 
+ *     <p>When getting using {@link Pointers.getPointerProperties}, an object mapping render state names to
  *     {@link Pointers.RayPointerRenderState|RayPointerRenderState} values.</p>
- * @property {Pointers.DefaultRayPointerRenderState[]|Object.<string, Pointers.DefaultRayPointerRenderState>} 
+ * @property {Pointers.DefaultRayPointerRenderState[]|Object.<string, Pointers.DefaultRayPointerRenderState>}
  *     [defaultRenderStates]
  *     <p>A set of visual states that can be switched among using {@link Pointers.setRenderState}. These define the visual
  *     appearance of the pointer when it is not intersecting something.</p>
- *     <p>When setting using {@link Pointers.createPointer}, an array of 
+ *     <p>When setting using {@link Pointers.createPointer}, an array of
  *     {@link Pointers.DefaultRayPointerRenderState|DefaultRayPointerRenderState} values.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, an object mapping render state names to 
+ *     <p>When getting using {@link Pointers.getPointerProperties}, an object mapping render state names to
  *     {@link Pointers.DefaultRayPointerRenderState|DefaultRayPointerRenderState} values.</p>
- * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events, 
+ * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events,
  *     <code>false</code> if it doesn't.
- * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger 
+ * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger
  *     events on the entity or overlay currently intersected.
- * @property {PickType} pointerType - The type of pointer returned from {@link Pointers.getPointerProperties} or 
+ * @property {PickType} pointerType - The type of pointer returned from {@link Pointers.getPointerProperties} or
  *     {@link Pointers.getPointerScriptParameters}. A laser pointer's type is {@link PickType(0)|PickType.Ray}.
- * @property {number} [pickID] - The ID of the pick created alongside this pointer, returned from 
- *     {@link Pointers.getPointerProperties}. 
+ * @property {number} [pickID] - The ID of the pick created alongside this pointer, returned from
+ *     {@link Pointers.getPointerProperties}.
  * @see {@link Picks.RayPickProperties} for additional properties from the underlying ray pick.
  */
 std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const PointerProperties& properties) {
@@ -362,9 +360,9 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const Poin
  * @property {Color} [color=255,255,255] - The color of the parabola.
  * @property {number} [alpha=1.0] - The opacity of the parabola, range <code>0.0</code> &ndash; <code>1.0</code>.
  * @property {number} [width=0.01] - The width of the parabola, in meters.
- * @property {boolean} [isVisibleInSecondaryCamera=false] - <code>true</code> if the parabola is rendered in the secondary 
- *     camera, <code>false</code> if it isn't. 
- * @property {boolean} [drawInFront=false] - <code>true</code> if the parabola is rendered in front of objects in the world, 
+ * @property {boolean} [isVisibleInSecondaryCamera=false] - <code>true</code> if the parabola is rendered in the secondary
+ *     camera, <code>false</code> if it isn't.
+ * @property {boolean} [drawInFront=false] - <code>true</code> if the parabola is rendered in front of objects in the world,
  *     but behind the HUD, <code>false</code> if it is occluded by objects in front of it.
  */
 /*@jsdoc
@@ -381,7 +379,7 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const Poin
  * @property {Overlays.OverlayProperties|Uuid} [start]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
  *     an overlay to render at the start of the parabola pointer. The <code>type</code> property must be specified.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the start of the 
+ *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the start of the
  *     parabola; <code>null</code> if there is no overlay.
  * @property {Pointers.ParabolaPointerPath|Uuid} [path]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
@@ -407,22 +405,20 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const Poin
  *     scale linearly with distance; <code>false</code> if they aren't.
  * @property {boolean} [scaleWithParent=false] - <code>true</code> if the width of the ray's path and the size of the
  *     start and end overlays scale linearly with the pointer parent's scale; <code>false</code> if they don't scale.
- * @property {boolean} [scaleWithAvatar=false] - A synonym for <code>scalewithParent</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @property {boolean} [followNormal=false] - <code>true</code> if the overlay rendered at the end of the ray rotates to
  *     follow the normal of the surface if one is intersected; <code>false</code> if it doesn't.
  * @property {number} [followNormalStrength=0.0] - How quickly the overlay rendered at the end of the ray rotates to follow
  *     the normal of an intersected surface. If <code>0</code> or <code>1</code>, the overlay rotation follows instantaneously;
  *    for other values, the larger the value the more quickly the rotation follows.
- * @property {Pointers.ParabolaPointerRenderState[]|Object.<string, Pointers.ParabolaPointerRenderState>} [renderStates] 
+ * @property {Pointers.ParabolaPointerRenderState[]|Object.<string, Pointers.ParabolaPointerRenderState>} [renderStates]
  *     <p>A set of visual states that can be switched among using {@link Pointers.setRenderState}. These define the visual
  *     appearance of the pointer when it is intersecting something.</p>
  *     <p>When setting using {@link Pointers.createPointer}, an array of
  *     {@link Pointers.ParabolaPointerRenderState|ParabolaPointerRenderState} values.</p>
  *     <p>When getting using {@link Pointers.getPointerProperties}, an object mapping render state names to
  *     {@link Pointers.ParabolaPointerRenderState|ParabolaPointerRenderState} values.</p>
- * @property {Pointers.DefaultParabolaPointerRenderState[]|Object.<string, Pointers.DefaultParabolaPointerRenderState>} 
- *     [defaultRenderStates] 
+ * @property {Pointers.DefaultParabolaPointerRenderState[]|Object.<string, Pointers.DefaultParabolaPointerRenderState>}
+ *     [defaultRenderStates]
  *     <p>A set of visual states that can be switched among using {@link Pointers.setRenderState}. These define the visual
  *     appearance of the pointer when it is not intersecting something.</p>
  *     <p>When setting using {@link Pointers.createPointer}, an array of
@@ -433,10 +429,10 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const Poin
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger
  *     events on the entity or overlay currently intersected.
- * @property {PickType} pointerType - The type of pointer returned from {@link Pointers.getPointerProperties} or 
+ * @property {PickType} pointerType - The type of pointer returned from {@link Pointers.getPointerProperties} or
  *     {@link Pointers.getPointerScriptParameters}. A parabola pointer's type is {@link PickType(0)|PickType.Parabola}.
- * @property {number} [pickID] - The ID of the pick created alongside this pointer, returned from 
- *     {@link Pointers.getPointerProperties}. 
+ * @property {number} [pickID] - The ID of the pick created alongside this pointer, returned from
+ *     {@link Pointers.getPointerProperties}.
  * @see {@link Picks.ParabolaPickProperties} for additional properties from the underlying parabola pick.
  */
 std::shared_ptr<Pointer> PointerScriptingInterface::buildParabolaPointer(const PointerProperties& properties) {
@@ -563,7 +559,7 @@ void PointerScriptingInterface::editRenderState(unsigned int uid, const QString&
     DependencyManager::get<PointerManager>()->editRenderState(uid, renderState.toStdString(), startProps, pathProps, endProps);
 }
 
-QVariantMap PointerScriptingInterface::getPrevPickResult(unsigned int uid) const { 
+QVariantMap PointerScriptingInterface::getPrevPickResult(unsigned int uid) const {
     QVariantMap result;
     auto pickResult = DependencyManager::get<PointerManager>()->getPrevPickResult(uid);
     if (pickResult) {

--- a/interface/src/raypick/RayPickScriptingInterface.h
+++ b/interface/src/raypick/RayPickScriptingInterface.h
@@ -22,33 +22,7 @@
 
 class ScriptValue;
 
-/*@jsdoc
- * The <code>RayPick</code> API is a subset of the {@link Picks} API, as used for ray picks.
- *
- * @namespace RayPick
- *
- * @deprecated This API is deprecated and will be removed. Use the {@link Picks} API instead.
- *
- * @hifi-interface
- * @hifi-client-entity
- * @hifi-avatar
- *
- * @property {FilterFlags} PICK_ENTITIES - Include domain and avatar entities when intersecting. 
- *     <em>Read-only.</em>
- * @property {FilterFlags} PICK_OVERLAYS - Include local entities when intersecting. <em>Read-only.</em>
- * @property {FilterFlags} PICK_AVATARS - Include avatars when intersecting. <em>Read-only.</em>
- * @property {FilterFlags} PICK_HUD - Include the HUD surface when intersecting in HMD mode. <em>Read-only.</em>
- * @property {FilterFlags} PICK_PRECISE - Pick against exact meshes. <em>Read-only.</em>
- * @property {FilterFlags} PICK_INCLUDE_INVISIBLE - Include invisible objects when intersecting. <em>Read-only.</em>
- * @property {FilterFlags} PICK_INCLUDE_NONCOLLIDABLE - Include non-collidable objects when intersecting. <em>Read-only.</em>
- * @property {FilterFlags} PICK_ALL_INTERSECTIONS - Return all intersections instead of just the closest. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_NONE - Intersected nothing with the given filter flags. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_ENTITY - Intersected an entity. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_LOCAL_ENTITY - Intersected a local entity. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_OVERLAY - Intersected an entity (3D Overlays no longer exist). <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_AVATAR - Intersected an avatar. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_HUD - Intersected the HUD surface. <em>Read-only.</em>
- */
+// TODO: Deprecated by documentation, please review for accuracy
 class RayPickScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
     Q_PROPERTY(unsigned int PICK_ENTITIES READ getPickEntities CONSTANT)
@@ -101,7 +75,7 @@ public:
     Q_INVOKABLE void removeRayPick(unsigned int uid);
 
     /*@jsdoc
-     * Gets the most recent pick result from a ray pick. A ray pick continues to be updated ready to return a result, as long 
+     * Gets the most recent pick result from a ray pick. A ray pick continues to be updated ready to return a result, as long
      * as it is enabled.
      * @function RayPick.getPrevRayPickResult
      * @param {number} id - The ID of the ray pick.
@@ -111,7 +85,7 @@ public:
 
 
     /*@jsdoc
-     * Sets whether or not a ray pick should use precision picking, i.e., whether it should pick against precise meshes or 
+     * Sets whether or not a ray pick should use precision picking, i.e., whether it should pick against precise meshes or
      * coarse meshes.
      * @function RayPick.setPrecisionPicking
      * @param {number} id - The ID of the ray pick.
@@ -128,7 +102,7 @@ public:
     Q_INVOKABLE void setIgnoreItems(unsigned int uid, const ScriptValue& ignoreEntities);
 
     /*@jsdoc
-     * Sets a list of entity and avatar IDs that a ray pick should include during intersection, instead of intersecting with 
+     * Sets a list of entity and avatar IDs that a ray pick should include during intersection, instead of intersecting with
      * everything.
      * @function RayPick.setIncludeItems
      * @param {number} id - The ID of the ray pick.
@@ -139,7 +113,7 @@ public:
 
     /*@jsdoc
      * Checks if a pick is associated with the left hand: a ray or parabola pick with <code>joint</code> property set to
-     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with 
+     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with
      * <code>hand</code> property set to <code>0</code>.
      * @function RayPick.isLeftHand
      * @param {number} id - The ID of the ray pick.
@@ -149,7 +123,7 @@ public:
 
     /*@jsdoc
      * Checks if a pick is associated with the right hand: a ray or parabola pick with <code>joint</code> property set to
-     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with 
+     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with
      * <code>hand</code> property set to <code>1</code>.
      * @function RayPick.isRightHand
      * @param {number} id - The ID of the ray pick.
@@ -158,7 +132,7 @@ public:
     Q_INVOKABLE bool isRightHand(unsigned int uid);
 
     /*@jsdoc
-     * Checks if a pick is associated with the system mouse: a ray or parabola pick with <code>joint</code> property set to 
+     * Checks if a pick is associated with the system mouse: a ray or parabola pick with <code>joint</code> property set to
      * <code>"Mouse"</code>.
      * @function RayPick.isMouse
      * @param {number} id - The ID of the ray pick.
@@ -205,7 +179,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.PICK_INCLUDE_INVISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_INCLUDE_INVISIBLE</code> 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_INCLUDE_INVISIBLE</code>
      *     property instead.
      * @returns {number}
      */
@@ -213,7 +187,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.PICK_INCLUDE_NONCOLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_INCLUDE_NONCOLLIDABLE</code> 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_INCLUDE_NONCOLLIDABLE</code>
      *     property instead.
      * @returns {number}
      */
@@ -221,7 +195,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.PICK_ALL_INTERSECTIONS
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_ALL_INTERSECTIONS</code> 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_ALL_INTERSECTIONS</code>
      *     property instead.
      * @returns {number}
      */
@@ -229,7 +203,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.INTERSECTED_NONE
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_NONE</code> property 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_NONE</code> property
      *     instead.
      * @returns {number}
      */
@@ -237,7 +211,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.INTERSECTED_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_ENTITY</code> property 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_ENTITY</code> property
      *     instead.
      * @returns {number}
      */
@@ -245,7 +219,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_LOCAL_ENTITY</code> 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_LOCAL_ENTITY</code>
      *     property instead.
      * @returns {number}
      */
@@ -253,7 +227,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_OVERLAY</code> property 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_OVERLAY</code> property
      *     instead.
      * @returns {number}
      */
@@ -261,7 +235,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.INTERSECTED_AVATAR
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_AVATAR</code> property 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_AVATAR</code> property
      *     instead.
      * @returns {number}
      */
@@ -269,7 +243,7 @@ public slots:
 
     /*@jsdoc
      * @function RayPick.INTERSECTED_HUD
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_HUD</code> property 
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_HUD</code> property
      *     instead.
      * @returns {number}
      */

--- a/interface/src/scripting/AccountServicesScriptingInterface.h
+++ b/interface/src/scripting/AccountServicesScriptingInterface.h
@@ -40,9 +40,9 @@ class AccountServicesScriptingInterface : public QObject {
     Q_OBJECT
 
     /*@jsdoc
-     * The <code>AccountServices</code> API provides functions that give information on user connectivity, visibility, and 
+     * The <code>AccountServices</code> API provides functions that give information on user connectivity, visibility, and
      * asset download progress.
-     * 
+     *
      * @hifi-interface
      * @hifi-client-entity
      * @hifi-avatar
@@ -51,7 +51,7 @@ class AccountServicesScriptingInterface : public QObject {
      *
      * @property {string} username - The user name of the user logged in. If there is no user logged in, it is
      *     <code>"Unknown user"</code>. <em>Read-only.</em>
-     * @property {boolean} loggedIn - <code>true</code> if the user is logged in, otherwise <code>false</code>. 
+     * @property {boolean} loggedIn - <code>true</code> if the user is logged in, otherwise <code>false</code>.
      *     <em>Read-only.</em>
      * @property {string} findableBy - The user's visibility to other users:
      *     <ul>
@@ -64,98 +64,19 @@ class AccountServicesScriptingInterface : public QObject {
      *     &mdash; typically <code>"https://metaverse.highfidelity.com"</code>. <em>Read-only.</em>
      */
 
-    /*@jsdoc
-     * The <code>Account</code> API provides functions that give information on user connectivity, visibility, and asset 
-     * download progress.
-     *
-     * @deprecated This API is the same as the {@link AccountServices} API and will be removed.
-     * 
-     * @hifi-interface
-     * @hifi-client-entity
-     * @hifi-avatar
-     *
-     * @namespace Account
-     *
-     * @property {string} username - The user name of the user logged in. If there is no user logged in, it is
-     *     <code>"Unknown user"</code>. <em>Read-only.</em>
-     * @property {boolean} loggedIn - <code>true</code> if the user is logged in, otherwise <code>false</code>.
-     *     <em>Read-only.</em>
-     * @property {string} findableBy - The user's visibility to other users:
-     *     <ul>
-     *         <li><code>"none"</code> &mdash; user appears offline.</li>
-     *         <li><code>"friends"</code> &mdash; user is visible only to friends.</li>
-     *         <li><code>"connections"</code> &mdash; user is visible to friends and connections.</li>
-     *         <li><code>"all"</code> &mdash; user is visible to everyone.</li>
-     *     </ul>
-     * @property {string} metaverseServerURL - The directory server that the user is authenticated against when logged in
-     *     &mdash; typically <code>"https://metaverse.highfidelity.com"</code>. <em>Read-only.</em>
-     *
-     * @borrows AccountServices.getDownloadInfo as getDownloadInfo
-     * @borrows AccountServices.updateDownloadInfo as updateDownloadInfo
-     * @borrows AccountServices.isLoggedIn as isLoggedIn
-     * @borrows AccountServices.checkAndSignalForAccessToken as checkAndSignalForAccessToken
-     * @borrows AccountServices.logOut as logOut
-     *
-     * @borrows AccountServices.connected as connected
-     * @borrows AccountServices.disconnected as disconnected
-     * @borrows AccountServices.myUsernameChanged as myUsernameChanged
-     * @borrows AccountServices.downloadInfoChanged as downloadInfoChanged
-     * @borrows AccountServices.findableByChanged as findableByChanged
-     * @borrows AccountServices.loggedInChanged as loggedInChanged
-     */
-
-    /*@jsdoc
-     * The <code>GlobalServices</code> API provides functions that give information on user connectivity, visibility, and asset 
-     * download progress.
-     *
-     * @deprecated This API is the same as the {@link AccountServices} API and will be removed.
-     * 
-     * @hifi-interface
-     * @hifi-client-entity
-     * @hifi-avatar
-     *
-     * @namespace GlobalServices
-     *
-     * @property {string} username - The user name of the user logged in. If there is no user logged in, it is
-     *     <code>"Unknown user"</code>. <em>Read-only.</em>
-     * @property {boolean} loggedIn - <code>true</code> if the user is logged in, otherwise <code>false</code>.
-     *     <em>Read-only.</em>
-     * @property {string} findableBy - The user's visibility to other users:
-     *     <ul>
-     *         <li><code>"none"</code> &mdash; user appears offline.</li>
-     *         <li><code>"friends"</code> &mdash; user is visible only to friends.</li>
-     *         <li><code>"connections"</code> &mdash; user is visible to friends and connections.</li>
-     *         <li><code>"all"</code> &mdash; user is visible to everyone.</li>
-     *     </ul>
-     * @property {string} metaverseServerURL - The directory server that the user is authenticated against when logged in
-     *     &mdash; typically <code>"https://metaverse.highfidelity.com"</code>. <em>Read-only.</em>
-     *
-     * @borrows AccountServices.getDownloadInfo as getDownloadInfo
-     * @borrows AccountServices.updateDownloadInfo as updateDownloadInfo
-     * @borrows AccountServices.isLoggedIn as isLoggedIn
-     * @borrows AccountServices.checkAndSignalForAccessToken as checkAndSignalForAccessToken
-     * @borrows AccountServices.logOut as logOut
-     *
-     * @borrows AccountServices.connected as connected
-     * @borrows AccountServices.disconnected as disconnected
-     * @borrows AccountServices.myUsernameChanged as myUsernameChanged
-     * @borrows AccountServices.downloadInfoChanged as downloadInfoChanged
-     * @borrows AccountServices.findableByChanged as findableByChanged
-     * @borrows AccountServices.loggedInChanged as loggedInChanged
-     */
-
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_PROPERTY(QString username READ getUsername NOTIFY myUsernameChanged)
     Q_PROPERTY(bool loggedIn READ loggedIn NOTIFY loggedInChanged)
     Q_PROPERTY(QString findableBy READ getFindableBy WRITE setFindableBy NOTIFY findableByChanged)
     Q_PROPERTY(QUrl metaverseServerURL READ getMetaverseServerURL CONSTANT)
-    
+
 public:
     static AccountServicesScriptingInterface* getInstance();
 
     const QString getUsername() const;
     bool loggedIn() const { return _loggedIn; }
     QUrl getMetaverseServerURL() { return DependencyManager::get<AccountManager>()->getMetaverseServerURL(); }
-    
+
 public slots:
 
     /*@jsdoc
@@ -166,7 +87,7 @@ public slots:
     DownloadInfoResult getDownloadInfo();
 
     /*@jsdoc
-     * Triggers a {@link AccountServices.downloadInfoChanged|downloadInfoChanged} signal with information on the current 
+     * Triggers a {@link AccountServices.downloadInfoChanged|downloadInfoChanged} signal with information on the current
      * download progress of the assets in the domain.
      * @function AccountServices.updateDownloadInfo
      */
@@ -200,11 +121,11 @@ public slots:
      * @function AccountServices.updateAuthURLFromMetaverseServerURL
      */
     void updateAuthURLFromMetaverseServerURL();
-    
+
 private slots:
     void loggedOut();
     void checkDownloadInfo();
-    
+
     QString getFindableBy() const;
     void setFindableBy(const QString& discoverabilityMode);
     void discoverabilityModeChanged(Discoverability::Mode discoverabilityMode);
@@ -263,7 +184,7 @@ signals:
      * AccountServices.findableByChanged.connect(function (findableBy) {
      *     print("Findable by changed: " + findableBy);
      * });
-     * 
+     *
      * var originalFindableBy = AccountServices.findableBy;
      * Script.setTimeout(function () {
      *     // Change visiblity.
@@ -291,7 +212,7 @@ signals:
 private:
     AccountServicesScriptingInterface();
     ~AccountServicesScriptingInterface();
-    
+
     bool _downloading;
     bool _loggedIn{ false };
 };

--- a/interface/src/scripting/Audio.h
+++ b/interface/src/scripting/Audio.h
@@ -41,7 +41,7 @@ class Audio : public AudioScriptingInterface, protected ReadWriteLockable {
      * @hifi-server-entity
      * @hifi-assignment-client
      *
-     * @property {boolean} muted - <code>true</code> if the audio input is muted for the current user context (desktop or HMD), 
+     * @property {boolean} muted - <code>true</code> if the audio input is muted for the current user context (desktop or HMD),
      *     otherwise <code>false</code>.
      * @property {boolean} mutedDesktop - <code>true</code> if desktop audio input is muted, otherwise <code>false</code>.
      * @property {boolean} mutedHMD - <code>true</code> if the HMD input is muted, otherwise <code>false</code>.
@@ -50,48 +50,46 @@ class Audio : public AudioScriptingInterface, protected ReadWriteLockable {
      * @property {boolean} noiseReduction - <code>true</code> if noise reduction is enabled, otherwise <code>false</code>. When
      *     enabled, the input audio signal is blocked (fully attenuated) when it falls below an adaptive threshold set just
      *     above the noise floor.
-     * @property {boolean} noiseReductionAutomatic - <code>true</code> if audio input noise reduction automatic mode is enabled, 
+     * @property {boolean} noiseReductionAutomatic - <code>true</code> if audio input noise reduction automatic mode is enabled,
      *     <code>false</code> if in manual mode. Manual mode allows you to use <code>Audio.noiseReductionThreshold</code>
      *     to set a manual sensitivity for the noise gate.
-     * @property {number} noiseReductionThreshold - Sets the noise gate threshold before your mic audio is transmitted. 
+     * @property {number} noiseReductionThreshold - Sets the noise gate threshold before your mic audio is transmitted.
      *     (Applies only if <code>Audio.noiseReductionAutomatic</code> is <code>false</code>.)
-     * @property {number} inputVolume - Adjusts the volume of the input audio, range <code>0.0</code> &ndash; <code>1.0</code>. 
-     *     If set to a value, the resulting value depends on the input device: for example, the volume can't be changed on some 
+     * @property {number} inputVolume - Adjusts the volume of the input audio, range <code>0.0</code> &ndash; <code>1.0</code>.
+     *     If set to a value, the resulting value depends on the input device: for example, the volume can't be changed on some
      *     devices, and others might only support values of <code>0.0</code> and <code>1.0</code>.
      * @property {number} inputLevel - The loudness of the audio input, range <code>0.0</code> (no sound) &ndash;
      *     <code>1.0</code> (the onset of clipping). <em>Read-only.</em>
      * @property {boolean} clipping - <code>true</code> if the audio input is clipping, otherwise <code>false</code>.
      * @property {string} context - The current context of the audio: either <code>"Desktop"</code> or <code>"HMD"</code>.
      *     <em>Read-only.</em>
-     * @property {object} devices - <em>Read-only.</em>
-     *     <p class="important">Deprecated: This property is deprecated and will be removed.
-     * @property {boolean} pushToTalk - <code>true</code> if push-to-talk is enabled for the current user context (desktop or 
+     * @property {boolean} pushToTalk - <code>true</code> if push-to-talk is enabled for the current user context (desktop or
      *     HMD), otherwise <code>false</code>.
-     * @property {boolean} pushToTalkDesktop - <code>true</code> if desktop push-to-talk is enabled, otherwise 
+     * @property {boolean} pushToTalkDesktop - <code>true</code> if desktop push-to-talk is enabled, otherwise
      *     <code>false</code>.
      * @property {boolean} pushToTalkHMD - <code>true</code> if HMD push-to-talk is enabled, otherwise <code>false</code>.
-     * @property {boolean} pushingToTalk - <code>true</code> if the user is currently pushing-to-talk, otherwise 
+     * @property {boolean} pushingToTalk - <code>true</code> if the user is currently pushing-to-talk, otherwise
      *     <code>false</code>.
-     
-     * @property {number} avatarGain - The gain (relative volume in dB) that avatars' voices are played at. This gain is used 
+
+     * @property {number} avatarGain - The gain (relative volume in dB) that avatars' voices are played at. This gain is used
      *     at the server.
-     * @property {number} localInjectorGain - The gain (relative volume in dB) that local injectors (local environment sounds) 
+     * @property {number} localInjectorGain - The gain (relative volume in dB) that local injectors (local environment sounds)
      *    are played at.
-     * @property {number} serverInjectorGain - The gain (relative volume in dB) that server injectors (server environment 
+     * @property {number} serverInjectorGain - The gain (relative volume in dB) that server injectors (server environment
      *     sounds) are played at. This gain is used at the server.
      * @property {number} systemInjectorGain - The gain (relative volume in dB) that system sounds are played at.
-     * @property {number} pushingToTalkOutputGainDesktop - The gain (relative volume in dB) that all sounds are played at when 
+     * @property {number} pushingToTalkOutputGainDesktop - The gain (relative volume in dB) that all sounds are played at when
      *     the user is holding the push-to-talk key in desktop mode.
      * @property {boolean} acousticEchoCancellation - <code>true</code> if acoustic echo cancellation is enabled, otherwise
-     *     <code>false</code>. When enabled, sound from the audio output is suppressed when it echos back to the input audio 
+     *     <code>false</code>. When enabled, sound from the audio output is suppressed when it echos back to the input audio
      *     signal.
      *
      * @comment The following properties are from AudioScriptingInterface.h.
      * @property {boolean} isStereoInput - <code>true</code> if the input audio is being used in stereo, otherwise
      *     <code>false</code>. Some devices do not support stereo, in which case the value is always <code>false</code>.
-     * @property {boolean} isSoloing - <code>true</code> if currently audio soloing, i.e., playing audio from only specific 
+     * @property {boolean} isSoloing - <code>true</code> if currently audio soloing, i.e., playing audio from only specific
      *     avatars. <em>Read-only.</em>
-     * @property {Uuid[]} soloList - The list of currently soloed avatar IDs. Empty list if not currently audio soloing. 
+     * @property {Uuid[]} soloList - The list of currently soloed avatar IDs. Empty list if not currently audio soloing.
      *     <em>Read-only.</em>
      */
 
@@ -161,20 +159,10 @@ public:
     void saveData();
     void loadData();
 
-    /*@jsdoc
-     * @function Audio.setInputDevice
-     * @param {object} device - Device.
-     * @param {boolean} isHMD - Is HMD.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void setInputDevice(const HifiAudioDeviceInfo& device, bool isHMD);
 
-    /*@jsdoc
-     * @function Audio.setOutputDevice
-     * @param {object} device - Device.
-     * @param {boolean} isHMD - Is HMD.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void setOutputDevice(const HifiAudioDeviceInfo& device, bool isHMD);
 
     /*@jsdoc
@@ -278,7 +266,7 @@ public:
      * @returns {number} The injector gain (dB) in the client.
     */
     Q_INVOKABLE float getSystemInjectorGain();
-    
+
     /*@jsdoc
      * Sets the noise gate threshold before your mic audio is transmitted. (Applies only if <code>Audio.noiseReductionAutomatic</code> is <code>false</code>.)
      * @function Audio.setNoiseReductionThreshold
@@ -344,18 +332,13 @@ public:
     Q_INVOKABLE float getPushingToTalkOutputGainDesktop();
 
 signals:
-
-    /*@jsdoc
-     * @function Audio.nop
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void nop();
 
     /*@jsdoc
      * Triggered when the audio input is muted or unmuted for the current context (desktop or HMD).
      * @function Audio.mutedChanged
-     * @param {boolean} isMuted - <code>true</code> if the audio input is muted for the current context (desktop or HMD), 
+     * @param {boolean} isMuted - <code>true</code> if the audio input is muted for the current context (desktop or HMD),
      *     otherwise <code>false</code>.
      * @returns {Signal}
      * @example <caption>Report when audio input is muted or unmuted</caption>
@@ -420,7 +403,7 @@ signals:
      * @returns {Signal}
      */
     void noiseReductionChanged(bool isEnabled);
-    
+
     /*@jsdoc
      * Triggered when the audio input noise reduction mode is changed.
      * @function Audio.noiseReductionAutomaticChanged
@@ -428,7 +411,7 @@ signals:
      * @returns {Signal}
      */
     void noiseReductionAutomaticChanged(bool isEnabled);
-    
+
     /*@jsdoc
      * Triggered when the audio input noise reduction threshold is changed.
      * @function Audio.noiseReductionThresholdChanged
@@ -539,11 +522,7 @@ signals:
     void pushingToTalkOutputGainDesktopChanged(float gain);
 
 public slots:
-
-    /*@jsdoc
-     * @function Audio.onContextChanged
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void onContextChanged();
 
     void handlePushedToTalk(bool enabled);

--- a/interface/src/scripting/ControllerScriptingInterface.h
+++ b/interface/src/scripting/ControllerScriptingInterface.h
@@ -156,7 +156,7 @@ class ScriptEngine;
  *
  * <h3>Entity Methods</h3>
  *
- * <p>The default scripts implement hand controller actions that use {@link Entities.callEntityMethod} to call entity script 
+ * <p>The default scripts implement hand controller actions that use {@link Entities.callEntityMethod} to call entity script
  * methods, if present, in the entity being interacted with.</p>
  *
  * <table>
@@ -166,13 +166,13 @@ class ScriptEngine;
  *   <tbody>
  *     <tr>
  *       <td><code>startFarTrigger</code><br /><code>continueFarTrigger</code><br /><code>stopFarTrigger</code></td>
- *       <td>These methods are called when a user is more than 0.3m away from the entity, the entity is triggerable, and the 
+ *       <td>These methods are called when a user is more than 0.3m away from the entity, the entity is triggerable, and the
  *         user starts, continues, or stops squeezing the trigger.</td>
  *       <td>A light switch that can be toggled on and off from a distance.</td>
  *     </tr>
  *     <tr>
  *       <td><code>startNearTrigger</code><br /><code>continueNearTrigger</code><br /><code>stopNearTrigger</code></td>
- *       <td>These methods are called when a user is less than 0.3m away from the entity, the entity is triggerable, and the 
+ *       <td>These methods are called when a user is less than 0.3m away from the entity, the entity is triggerable, and the
  *         user starts, continues, or stops squeezing the trigger.</td>
  *       <td>A doorbell that can be rung when a user is near.</td>
  *     </tr>
@@ -184,13 +184,13 @@ class ScriptEngine;
  *     </tr>
  *     <tr>
  *       <td><code>startNearGrab</code><br /><code>continueNearGrab</code><br /></td>
- *       <td>These methods are called when a user is less than 0.3m away from the entity, the entity is either cloneable, or 
+ *       <td>These methods are called when a user is less than 0.3m away from the entity, the entity is either cloneable, or
  *         grabbable and not locked, and the user starts or continues to squeeze the trigger.</td>
  *       <td>A ball that glows when it's being held close.</td>
  *     </tr>
  *     <tr>
  *       <td><code>releaseGrab</code></td>
- *       <td>This method is called when a user releases the trigger when having been either distance or near grabbing an 
+ *       <td>This method is called when a user releases the trigger when having been either distance or near grabbing an
  *         entity.</td>
  *       <td>Turn off the ball glow or comet trail with the user finishes grabbing it.</td>
  *     </tr>
@@ -217,23 +217,23 @@ class ScriptEngine;
  * @property {Controller.Actions} Actions - Predefined actions on Interface and the user's avatar. These can be used as end
  *     points in a {@link RouteObject} mapping. A synonym for <code>Controller.Hardware.Actions</code>.
  *     <em>Read-only.</em>
- *     <p>Default mappings are provided from the <code>Controller.Hardware.Keyboard</code> and <code>Controller.Standard</code> 
- *     to actions in 
+ *     <p>Default mappings are provided from the <code>Controller.Hardware.Keyboard</code> and <code>Controller.Standard</code>
+ *     to actions in
  *     <a href="https://github.com/highfidelity/hifi/blob/master/interface/resources/controllers/keyboardMouse.json">
- *     keyboardMouse.json</a> and 
+ *     keyboardMouse.json</a> and
  *     <a href="https://github.com/highfidelity/hifi/blob/master/interface/resources/controllers/standard.json">
  *     standard.json</a>, respectively.</p>
  *
- * @property {Controller.Hardware} Hardware - Standard and hardware-specific controller and computer outputs, plus predefined 
- *     actions on Interface and the user's avatar. The outputs can be mapped to <code>Actions</code> or functions in a 
- *     {@link RouteObject} mapping. Additionally, hardware-specific controller outputs can be mapped to 
+ * @property {Controller.Hardware} Hardware - Standard and hardware-specific controller and computer outputs, plus predefined
+ *     actions on Interface and the user's avatar. The outputs can be mapped to <code>Actions</code> or functions in a
+ *     {@link RouteObject} mapping. Additionally, hardware-specific controller outputs can be mapped to
  *     <code>Controller.Standard</code> controller outputs. <em>Read-only.</em>
  *
- * @property {Controller.Standard} Standard - Standard controller outputs that can be mapped to <code>Actions</code> or 
+ * @property {Controller.Standard} Standard - Standard controller outputs that can be mapped to <code>Actions</code> or
  *     functions in a {@link RouteObject} mapping. <em>Read-only.</em>
- *     <p>Each hardware device has a mapping from its outputs to <code>Controller.Standard</code> items, specified in a JSON file. 
+ *     <p>Each hardware device has a mapping from its outputs to <code>Controller.Standard</code> items, specified in a JSON file.
  *     For example, <a href="https://github.com/highfidelity/hifi/blob/master/interface/resources/controllers/leapmotion.json">
- *     leapmotion.json</a> and 
+ *     leapmotion.json</a> and
  *     <a href="https://github.com/highfidelity/hifi/blob/master/interface/resources/controllers/vive.json">vive.json</a>.</p>
  */
 
@@ -241,21 +241,21 @@ class ScriptEngine;
 class ControllerScriptingInterface : public controller::ScriptingInterface {
     Q_OBJECT
 
-public:    
+public:
     virtual ~ControllerScriptingInterface() {}
 
     void emitKeyPressEvent(QKeyEvent* event);
     void emitKeyReleaseEvent(QKeyEvent* event);
-    
+
     void emitMouseMoveEvent(QMouseEvent* event);
-    void emitMousePressEvent(QMouseEvent* event); 
+    void emitMousePressEvent(QMouseEvent* event);
     void emitMouseDoublePressEvent(QMouseEvent* event);
     void emitMouseReleaseEvent(QMouseEvent* event);
 
     void emitTouchBeginEvent(const TouchEvent& event);
-    void emitTouchEndEvent(const TouchEvent& event); 
+    void emitTouchEndEvent(const TouchEvent& event);
     void emitTouchUpdateEvent(const TouchEvent& event);
-    
+
     void emitWheelEvent(QWheelEvent* event);
 
     bool isKeyCaptured(QKeyEvent* event) const;
@@ -268,7 +268,7 @@ public slots:
     /*@jsdoc
      * Disables default Interface actions for a particular key event.
      * @function Controller.captureKeyEvents
-     * @param {KeyEvent} event - Details of the key event to be captured. The <code>key</code> property must be specified. The 
+     * @param {KeyEvent} event - Details of the key event to be captured. The <code>key</code> property must be specified. The
      *     <code>text</code> property is ignored. The other properties default to <code>false</code>.
      * @example <caption>Disable left and right strafing.</caption>
      * var STRAFE_LEFT = { "key": 16777234, isShifted: true };
@@ -285,29 +285,18 @@ public slots:
     virtual void captureKeyEvents(const KeyEvent& event);
 
     /*@jsdoc
-     * Re-enables default Interface actions for a particular key event that has been disabled using 
+     * Re-enables default Interface actions for a particular key event that has been disabled using
      * {@link Controller.captureKeyEvents|captureKeyEvents}.
      * @function Controller.releaseKeyEvents
-     * @param {KeyEvent} event - Details of the key event to release from capture. The <code>key</code> property must be 
+     * @param {KeyEvent} event - Details of the key event to release from capture. The <code>key</code> property must be
      *     specified. The <code>text</code> property is ignored. The other properties default to <code>false</code>.
      */
     virtual void releaseKeyEvents(const KeyEvent& event);
 
-    /*@jsdoc
-     * Disables default Interface actions for a joystick.
-     * @function Controller.captureJoystick
-     * @param {number} joystickID - The integer ID of the joystick.
-     * @deprecated This function is deprecated and will be removed. It no longer has any effect.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     virtual void captureJoystick(int joystickIndex);
 
-    /*@jsdoc
-     * Re-enables default Interface actions for a joystick that has been disabled using 
-     * {@link Controller.captureJoystick|captureJoystick}.
-     * @function Controller.releaseJoystick
-     * @param {number} joystickID - The integer ID of the joystick.
-     * @deprecated This function is deprecated and will be removed. It no longer has any effect.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     virtual void releaseJoystick(int joystickIndex);
 
     /*@jsdoc
@@ -329,7 +318,7 @@ public slots:
     virtual void captureEntityClickEvents();
 
     /*@jsdoc
-     * Re-enables {@link Entities.mousePressOnEntity} and {@link Entities.mouseDoublePressOnEntity} events on entities that were 
+     * Re-enables {@link Entities.mousePressOnEntity} and {@link Entities.mouseDoublePressOnEntity} events on entities that were
      * disabled using {@link Controller.captureEntityClickEvents|captureEntityClickEvents}.
      * @function Controller.releaseEntityClickEvents
      */
@@ -344,7 +333,7 @@ public slots:
     virtual glm::vec2 getViewportDimensions() const;
 
     /*@jsdoc
-     * Gets the recommended area to position UI on the HUD surface if in HMD mode or Interface's window interior if in desktop 
+     * Gets the recommended area to position UI on the HUD surface if in HMD mode or Interface's window interior if in desktop
      * mode.
      * @function Controller.getRecommendedHUDRect
      * @returns {Rect} The recommended area in which to position UI.
@@ -354,9 +343,9 @@ public slots:
     /*@jsdoc
      * Enables or disables the virtual game pad that is displayed on certain devices (e.g., Android).
      * @function Controller.setVPadEnabled
-     * @param {boolean} enable - If <code>true</code> then the virtual game pad doesn't work, otherwise it does work provided 
+     * @param {boolean} enable - If <code>true</code> then the virtual game pad doesn't work, otherwise it does work provided
      *     that it is not hidden by {@link Controller.setVPadHidden|setVPadHidden}.
-     *    
+     *
      */
     virtual void setVPadEnabled(bool enable);
 
@@ -368,7 +357,7 @@ public slots:
     virtual void setVPadHidden(bool hidden); // Call it when a window should hide it
 
     /*@jsdoc
-     * Sets the amount of extra margin between the virtual game pad that is displayed on certain devices (e.g., Android) and 
+     * Sets the amount of extra margin between the virtual game pad that is displayed on certain devices (e.g., Android) and
      * the bottom of the display.
      * @function Controller.setVPadExtraBottomMargin
      * @param {number} margin - Integer number of pixels in the extra margin.

--- a/interface/src/scripting/PlatformInfoScriptingInterface.h
+++ b/interface/src/scripting/PlatformInfoScriptingInterface.h
@@ -60,56 +60,19 @@ public:
     Q_ENUM(PlatformTier);
 
 public slots:
-    /*
-     * @function PlatformInfo.getInstance
-     * @deprecated This function is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Gets the operating system type.
-     * @function PlatformInfo.getOperatingSystemType
-     * @returns {string} The operating system type: <code>"WINDOWS"</code>, <code>"MACOS"</code>, or <code>"UNKNOWN"</code>.
-     * @deprecated This function is deprecated and will be removed.
-     *     Use <code>JSON.parse({@link PlatformInfo.getComputer|PlatformInfo.getComputer()}).OS</code> instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     QString getOperatingSystemType();
 
-    /*@jsdoc
-     * Gets information on the CPU model.
-     * @function PlatformInfo.getCPUBrand
-     * @returns {string} Information on the CPU.
-     * @deprecated This function is deprecated and will be removed.
-     *     Use <code>JSON.parse({@link PlatformInfo.getCPU|PlatformInfo.getCPU(0)}).model</code> instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     QString getCPUBrand();
 
-    /*@jsdoc
-     * Gets the number of logical CPU cores.
-     * @function PlatformInfo.getNumLogicalCores
-     * @returns {number} The number of logical CPU cores.
-     * @deprecated This function is deprecated and will be removed.
-     *     Use <code>JSON.parse({@link PlatformInfo.getCPU|PlatformInfo.getCPU(0)}).numCores</code> instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     unsigned int getNumLogicalCores();
 
-    /*@jsdoc
-     * Gets the total amount of usable physical memory, in MB.
-     * @function PlatformInfo.getTotalSystemMemoryMB
-     * @returns {number} The total system memory in megabytes.
-     * @deprecated This function is deprecated and will be removed.
-     *     Use <code>JSON.parse({@link PlatformInfo.getMemory|PlatformInfo.getMemory()}).memTotal</code> instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     int getTotalSystemMemoryMB();
 
-    /*@jsdoc
-     * Gets the model of the graphics card currently being used.
-     * @function PlatformInfo.getGraphicsCardType
-     * @returns {string} The model of the graphics card currently being used.
-     * @deprecated This function is deprecated and will be removed.
-     *     Use <code>JSON.parse({@link PlatformInfo.getGPU|PlatformInfo.getGPU(} 
-     *     {@link PlatformInfo.getMasterGPU|PlatformInfo.getMasterGPU() )}).model</code> 
-     *     instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     QString getGraphicsCardType();
 
     /*@jsdoc
@@ -129,7 +92,7 @@ public slots:
     /*@jsdoc
      * Checks whether HTML on 3D surfaces (e.g., Web entities) is supported.
      * @function PlatformInfo.has3DHTML
-     * @returns {boolean} <code>true</code> if the current display supports HTML on 3D surfaces, <code>false</code> if it 
+     * @returns {boolean} <code>true</code> if the current display supports HTML on 3D surfaces, <code>false</code> if it
      *     doesn't.
      */
     bool has3DHTML();
@@ -272,7 +235,7 @@ public slots:
     /*@jsdoc
      * Gets whether the current hardware can use deferred rendering.
      * @function PlatformInfo.isRenderMethodDeferredCapable
-     * @returns {boolean} <code>true</code> if the current hardware can use deferred rendering, <code>false</code> if it can't. 
+     * @returns {boolean} <code>true</code> if the current hardware can use deferred rendering, <code>false</code> if it can't.
      */
     bool isRenderMethodDeferredCapable();
 };

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -27,8 +27,8 @@
 
 
 /*@jsdoc
- * The <code>Window</code> API provides various facilities not covered elsewhere, including: window dimensions, window focus, 
- * camera view, announcements, user connections, common dialog boxes, snapshots, file import, domain navigation, domain changes, 
+ * The <code>Window</code> API provides various facilities not covered elsewhere, including: window dimensions, window focus,
+ * camera view, announcements, user connections, common dialog boxes, snapshots, file import, domain navigation, domain changes,
  * domain physics, OS clipboard, build number.
  *
  * @namespace Window
@@ -41,11 +41,11 @@
  *     chrome), in pixels. <em>Read-only.</em>
  * @property {number} innerHeight - The height of the drawable area of the Interface window (i.e., without borders or other
  *     chrome), in pixels. <em>Read-only.</em>
- * @property {number} x - The x display coordinate of the top left corner of the drawable area of the Interface window. 
+ * @property {number} x - The x display coordinate of the top left corner of the drawable area of the Interface window.
  *     <em>Read-only.</em>
- * @property {number} y - The y display coordinate of the top left corner of the drawable area of the Interface window. 
+ * @property {number} y - The y display coordinate of the top left corner of the drawable area of the Interface window.
  *     <em>Read-only.</em>
- * @property {boolean} interstitialModeEnabled=false - <code>true</code> if the interstitial graphics are displayed when a 
+ * @property {boolean} interstitialModeEnabled=false - <code>true</code> if the interstitial graphics are displayed when a
  *     domain is loading, otherwise <code>false</code>.
  * @property {location} location - Provides facilities for working with your current directory services location.
  */
@@ -76,7 +76,7 @@ public slots:
     ScriptValue hasFocus();
 
     /*@jsdoc
-     * Makes the Interface window have focus. On Windows, if Interface doesn't already have focus, the task bar icon flashes to 
+     * Makes the Interface window have focus. On Windows, if Interface doesn't already have focus, the task bar icon flashes to
      * indicate that Interface wants attention but focus isn't taken away from the application that the user is using.
      * @function Window.setFocus
      */
@@ -111,7 +111,7 @@ public slots:
     ScriptValue confirm(const QString& message = "");
 
     /*@jsdoc
-     * Prompts the user to enter some text. Displays a modal dialog with a message and a text box, plus "OK" and "Cancel" 
+     * Prompts the user to enter some text. Displays a modal dialog with a message and a text box, plus "OK" and "Cancel"
      * buttons.
      * @function Window.prompt
      * @param {string} message - The question to display.
@@ -128,8 +128,8 @@ public slots:
     ScriptValue prompt(const QString& message, const QString& defaultText);
 
     /*@jsdoc
-     * Prompts the user to enter some text. Displays a non-modal dialog with a message and a text box, plus "OK" and "Cancel" 
-     * buttons. A {@link Window.promptTextChanged|promptTextChanged} signal is emitted when the user OKs the dialog; no signal 
+     * Prompts the user to enter some text. Displays a non-modal dialog with a message and a text box, plus "OK" and "Cancel"
+     * buttons. A {@link Window.promptTextChanged|promptTextChanged} signal is emitted when the user OKs the dialog; no signal
      * is emitted if the user cancels the dialog.
      * @function Window.promptAsync
      * @param {string} [message=""] - The question to display.
@@ -156,7 +156,7 @@ public slots:
      * print("Directory: " + directory);
      */
     ScriptValue browseDir(const QString& title = "", const QString& directory = "");
-    
+
     /*@jsdoc
      * Prompts the user to choose a directory. Displays a non-modal dialog that navigates the directory tree. A
      * {@link Window.browseDirChanged|browseDirChanged} signal is emitted when a directory is chosen; no signal is emitted if
@@ -180,7 +180,7 @@ public slots:
      * @function Window.browse
      * @param {string} [title=""] - The title to display at the top of the dialog.
      * @param {string} [directory=""] - The initial directory to start browsing at.
-     * @param {string} [nameFilter=""] - The types of files to display. Examples: <code>"*.json"</code> and 
+     * @param {string} [nameFilter=""] - The types of files to display. Examples: <code>"*.json"</code> and
      *     <code>"Images (*.png *.jpg *.svg)"</code>. All files are displayed if a filter isn't specified.
      * @returns {string} The path and name of the file if one is chosen, otherwise <code>null</code>.
      * @example <caption>Ask the user to choose an image file.</caption>
@@ -251,7 +251,7 @@ public slots:
      * @function Window.browseAssets
      * @param {string} [title=""] - The title to display at the top of the dialog.
      * @param {string} [directory=""] - The initial directory to start browsing at.
-     * @param {string} [nameFilter=""] - The types of files to display. Examples: <code>"*.json"</code> and 
+     * @param {string} [nameFilter=""] - The types of files to display. Examples: <code>"*.json"</code> and
      *     <code>"Images (*.png *.jpg *.svg)"</code>. All files are displayed if a filter isn't specified.
      * @returns {string} The path and name of the asset if one is chosen, otherwise <code>null</code>.
      * @example <caption>Ask the user to select an FBX asset.</caption>
@@ -261,7 +261,7 @@ public slots:
     ScriptValue browseAssets(const QString& title = "", const QString& directory = "", const QString& nameFilter = "");
 
     /*@jsdoc
-     * Prompts the user to choose an Asset Server item. Displays a non-modal dialog that navigates the tree of assets on the 
+     * Prompts the user to choose an Asset Server item. Displays a non-modal dialog that navigates the tree of assets on the
      * Asset Server. An {@link Window.assetsDirChanged|assetsDirChanged} signal is emitted when an asset is chosen; no signal is
      * emitted if the user cancels the dialog.
      * @function Window.browseAssetsAsync
@@ -321,25 +321,25 @@ public slots:
     void copyToClipboard(const QString& text);
 
     /*@jsdoc
-     * Takes a snapshot of the current Interface view from the primary camera. When a still image only is captured, 
-     * {@link Window.stillSnapshotTaken|stillSnapshotTaken} is emitted; when a still image plus moving images are captured, 
+     * Takes a snapshot of the current Interface view from the primary camera. When a still image only is captured,
+     * {@link Window.stillSnapshotTaken|stillSnapshotTaken} is emitted; when a still image plus moving images are captured,
      * {@link Window.processingGifStarted|processingGifStarted} and {@link Window.processingGifCompleted|processingGifCompleted}
      * are emitted.
-     * <p>Snapshots are saved to the path specified in Settings &gt; General &gt; Snapshots, which can be accessed via the 
+     * <p>Snapshots are saved to the path specified in Settings &gt; General &gt; Snapshots, which can be accessed via the
      * {@link Snapshot} API.</p>
      *
      * @function Window.takeSnapshot
      * @param {boolean} [notify=true] - This value is passed on through the {@link Window.stillSnapshotTaken|stillSnapshotTaken}
      *     signal.
-     * @param {boolean} [includeAnimated=false] - If <code>true</code>, a moving image is captured as an animated GIF in addition 
+     * @param {boolean} [includeAnimated=false] - If <code>true</code>, a moving image is captured as an animated GIF in addition
      *     to a still image.
      * @param {number} [aspectRatio=0] - The width/height ratio of the snapshot required. If the value is <code>0</code>, the
      *     full resolution is used (window dimensions in desktop mode; HMD display dimensions in HMD mode), otherwise one of the
      *     dimensions is adjusted in order to match the aspect ratio.
-     * @param {string} [filename=""] - If a filename is not provided, the image is saved as "overte-snap-by-&lt;user 
+     * @param {string} [filename=""] - If a filename is not provided, the image is saved as "overte-snap-by-&lt;user
      *     name&gt;-on-YYYY-MM-DD_HH-MM-SS".
-     *     <p>Still images are saved in JPEG, PNG or WEBP format according to the extension provided &mdash; <code>".jpg"</code>, 
-     *     <code>".jpeg"</code>, <code>".png"</code>, or <code>".webp"</code> &mdash; or if not provided then in the format chosen in general settings, 
+     *     <p>Still images are saved in JPEG, PNG or WEBP format according to the extension provided &mdash; <code>".jpg"</code>,
+     *     <code>".jpeg"</code>, <code>".png"</code>, or <code>".webp"</code> &mdash; or if not provided then in the format chosen in general settings,
      *     Default is PNG. Animated images are saved in GIF format.</p>
      *
      * @example <caption>Using the snapshot function and signals.</caption>
@@ -375,29 +375,29 @@ public slots:
      * @function Window.takeSecondaryCameraSnapshot
      * @param {boolean} [notify=true] - This value is passed on through the {@link Window.stillSnapshotTaken|stillSnapshotTaken}
      *     signal.
-     * @param {string} [filename=""] - If a filename is not provided, the image is saved as "overte-snap-by-&lt;user 
+     * @param {string} [filename=""] - If a filename is not provided, the image is saved as "overte-snap-by-&lt;user
      *     name&gt;-on-YYYY-MM-DD_HH-MM-SS".
-     *     <p>Still images are saved in JPEG, PNG or WEBP format according to the extension provided &mdash; <code>".jpg"</code>, 
-     *     <code>".jpeg"</code>, <code>".png"</code>, or <code>".webp"</code> &mdash; or if not provided then in the format chosen in general settings, 
+     *     <p>Still images are saved in JPEG, PNG or WEBP format according to the extension provided &mdash; <code>".jpg"</code>,
+     *     <code>".jpeg"</code>, <code>".png"</code>, or <code>".webp"</code> &mdash; or if not provided then in the format chosen in general settings,
      *     Default is PNG. Animated images are saved in GIF format.</p>
      */
     void takeSecondaryCameraSnapshot(const bool& notify = true, const QString& filename = QString());
 
     /*@jsdoc
-     * Takes a 360&deg; snapshot at a given position for the secondary camera. The secondary camera does not need to have been 
+     * Takes a 360&deg; snapshot at a given position for the secondary camera. The secondary camera does not need to have been
      *     set up.
      * <p>Snapshots are saved to the path specified in Settings &gt; General &gt; Snapshots, which can be accessed via the
      * {@link Snapshot} API.</p>
      * @function Window.takeSecondaryCamera360Snapshot
      * @param {Vec3} cameraPosition - The position of the camera for the snapshot.
-     * @param {boolean} [cubemapOutputFormat=false] - If <code>true</code> then the snapshot is saved as a cube map image, 
+     * @param {boolean} [cubemapOutputFormat=false] - If <code>true</code> then the snapshot is saved as a cube map image,
      *     otherwise it is saved as an equirectangular image.
      * @param {boolean} [notify=true] - This value is passed on through the {@link Window.stillSnapshotTaken|stillSnapshotTaken}
      *     signal.
-     * @param {string} [filename=""] - If a filename is not provided, the image is saved as "overte-snap-by-&lt;user 
+     * @param {string} [filename=""] - If a filename is not provided, the image is saved as "overte-snap-by-&lt;user
      *     name&gt;-on-YYYY-MM-DD_HH-MM-SS".
-     *     <p>Still images are saved in JPEG, PNG or WEBP format according to the extension provided &mdash; <code>".jpg"</code>, 
-     *     <code>".jpeg"</code>, <code>".png"</code>, or <code>".webp"</code> &mdash; or if not provided then in the format chosen in general settings, 
+     *     <p>Still images are saved in JPEG, PNG or WEBP format according to the extension provided &mdash; <code>".jpg"</code>,
+     *     <code>".jpeg"</code>, <code>".png"</code>, or <code>".webp"</code> &mdash; or if not provided then in the format chosen in general settings,
      *     Default is PNG. Animated images are saved in GIF format.</p>
      */
     void takeSecondaryCamera360Snapshot(const glm::vec3& cameraPosition, const bool& cubemapOutputFormat = false, const bool& notify = true, const QString& filename = QString());
@@ -461,7 +461,7 @@ public slots:
     bool isPhysicsEnabled();
 
     /*@jsdoc
-     * Sets what to show on the PC display. For entity camera view, the entity camera is configured using 
+     * Sets what to show on the PC display. For entity camera view, the entity camera is configured using
      * {@link Camera.setCameraEntity} and {@link Camera|Camera.mode}.
      * @function Window.setDisplayTexture
      * @param {Window.DisplayTexture} texture - The view to display.
@@ -493,7 +493,7 @@ public slots:
     int getLastDomainConnectionError() const;
 
     /*@jsdoc
-     * Opens a non-modal message box that can have a variety of button combinations. See also, 
+     * Opens a non-modal message box that can have a variety of button combinations. See also,
      * {@link Window.updateMessageBox|updateMessageBox} and {@link Window.closeMessageBox|closeMessageBox}.
      * @function Window.openMessageBox
      * @param {string} title - The title to display for the message box.
@@ -518,20 +518,20 @@ public slots:
      * }
      * Window.messageBoxClosed.connect(onMessageBoxClosed);
      *
-     * messageBox = Window.openMessageBox("Reset Something", 
+     * messageBox = Window.openMessageBox("Reset Something",
      *     "Do you want to reset something?",
      *     resetButton + cancelButton, cancelButton);
      */
     int openMessageBox(QString title, QString text, int buttons, int defaultButton);
 
     /*@jsdoc
-     * Opens a URL in the Interface window or other application, depending on the URL's scheme. The following schemes are 
+     * Opens a URL in the Interface window or other application, depending on the URL's scheme. The following schemes are
      * supported:
      * <ul>
      *   <li><code>hifi</code>: Navigate to the URL in Interface.</li>
      *   <li><code>hifiapp</code>: Open a system app in Interface.</li>
      * </ul>
-     * <p>Other schemes will either be handled by the OS (e.g. <code>http</code>, <code>https</code>, or <code>mailto</code>) or 
+     * <p>Other schemes will either be handled by the OS (e.g. <code>http</code>, <code>https</code>, or <code>mailto</code>) or
      * will display a dialog asking the user to confirm that they want to try to open the URL.</p>
      * @function Window.openUrl
      * @param {string} url - The URL to open.
@@ -541,9 +541,9 @@ public slots:
     /*@jsdoc
      * Opens an Android activity and optionally return back to the scene when the activity is completed. <em>Android only.</em>
      * @function Window.openAndroidActivity
-     * @param {string} activityName - The name of the activity to open: one of <code>"Home"</code>, <code>"Login"</code>, or 
+     * @param {string} activityName - The name of the activity to open: one of <code>"Home"</code>, <code>"Login"</code>, or
      *     <code>"Privacy Policy"</code>.
-     * @param {boolean} backToScene - If <code>true</code>, the user is automatically returned back to the scene when the 
+     * @param {boolean} backToScene - If <code>true</code>, the user is automatically returned back to the scene when the
      *     activity is completed.
      */
     void openAndroidActivity(const QString& activityName, const bool backToScene);
@@ -567,11 +567,7 @@ public slots:
      */
     void closeMessageBox(int id);
 
-    /*@jsdoc
-     * @function Window.domainLoadingProgress
-     * @returns {number} Progress.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     float domainLoadingProgress();
 
     /*@jsdoc
@@ -584,7 +580,7 @@ public slots:
     /*@jsdoc
      * Gets the name of a display plugin.
      * @function Window.getDisplayPluginName
-     * @param {number} index - The index of the display plugin. Must be less than the value returned by 
+     * @param {number} index - The index of the display plugin. Must be less than the value returned by
      *     {@link Window.getDisplayPluginCount|getDisplayPluginCount}. The first display plugin has an index of <code>0</code>.
      * @returns {string} The name of the display plugin.
      * @example <caption>Print the names of all available display plugins.</caption>
@@ -597,7 +593,7 @@ public slots:
     /*@jsdoc
      * Checks whether a display plugin is an HMD.
      * @function Window.isDisplayPluginHmd
-     * @param {number} index - The index of the display plugin. Must be less than the value returned by 
+     * @param {number} index - The index of the display plugin. Must be less than the value returned by
      *     {@link Window.getDisplayPluginCount|getDisplayPluginCount}. The first display plugin has an index of <code>0</code>.
      * @returns {boolean} <code>true</code> if the display plugin is a HMD, <code>false</code> if it isn't.
      */
@@ -606,7 +602,7 @@ public slots:
     /*@jsdoc
      * Gets the index of the currently active display plugin.
      * @function Window.getActiveDisplayPlugin
-     * @returns {number} The index of the currently active display plugin. The first display plugin has an index of 
+     * @returns {number} The index of the currently active display plugin. The first display plugin has an index of
      *     <code>0</code>.
      */
     int getActiveDisplayPlugin();
@@ -614,7 +610,7 @@ public slots:
     /*@jsdoc
      * Sets the currently active display plugin.
      * @function Window.setActiveDisplayPlugin
-     * @param {number} index - The index of the display plugin. Must be less than the value returned by 
+     * @param {number} index - The index of the display plugin. Must be less than the value returned by
      *     {@link Window.getDisplayPluginCount|getDisplayPluginCount}. The first display plugin has an index of <code>0</code>.
      */
     void setActiveDisplayPlugin(int index);
@@ -670,7 +666,7 @@ signals:
     /*@jsdoc
      * Triggered when you try to visit a domain but are redirected into the error state.
      * @function Window.redirectErrorStateChanged
-     * @param {boolean} isInErrorState - <code>true</code> if the user has been redirected to the error URL, <code>false</code> 
+     * @param {boolean} isInErrorState - <code>true</code> if the user has been redirected to the error URL, <code>false</code>
      *     if they haven't.
      * @returns {Signal}
      */
@@ -679,14 +675,14 @@ signals:
     /*@jsdoc
      * Triggered when the interstitial mode changes.
      * @function Window.interstitialModeChanged
-     * @param {boolean} interstitialMode - <code>true</code> if the interstitial graphics are displayed when the domain is 
+     * @param {boolean} interstitialMode - <code>true</code> if the interstitial graphics are displayed when the domain is
      *     loading, <code>false</code> if they are not.
      * @returns {Signal}
      */
     void interstitialModeChanged(bool interstitialMode);
 
     /*@jsdoc
-     * Triggered when a still snapshot has been taken by calling {@link Window.takeSnapshot|takeSnapshot} with 
+     * Triggered when a still snapshot has been taken by calling {@link Window.takeSnapshot|takeSnapshot} with
      *     <code>includeAnimated = false</code> or {@link Window.takeSecondaryCameraSnapshot|takeSecondaryCameraSnapshot}.
      * @function Window.stillSnapshotTaken
      * @param {string} pathStillSnapshot - The path and name of the snapshot image file.
@@ -697,7 +693,7 @@ signals:
     void stillSnapshotTaken(const QString& pathStillSnapshot, bool notify);
 
     /*@jsdoc
-    * Triggered when a still 360&deg; snapshot has been taken by calling 
+    * Triggered when a still 360&deg; snapshot has been taken by calling
     *     {@link Window.takeSecondaryCamera360Snapshot|takeSecondaryCamera360Snapshot}.
     * @function Window.snapshot360Taken
     * @param {string} pathStillSnapshot - The path and name of the snapshot image file.

--- a/interface/src/ui/AvatarInputs.h
+++ b/interface/src/ui/AvatarInputs.h
@@ -23,7 +23,7 @@ class AvatarInputs : public QObject {
     Q_OBJECT
     HIFI_QML_DECL
 
-    /*@jsdoc 
+    /*@jsdoc
      * The <code>AvatarInputs</code> API provides facilities to manage user inputs.
      *
      * @namespace AvatarInputs
@@ -32,22 +32,17 @@ class AvatarInputs : public QObject {
      * @hifi-client-entity
      * @hifi-avatar
      *
-     * @property {boolean} cameraEnabled - <code>true</code> if webcam face tracking is enabled, <code>false</code> if it is 
-     *     disabled.
-     *     <em>Read-only.</em>
-     *     <p class="important">Deprecated: This property is deprecated and has been removed.</p>
-     * @property {boolean} cameraMuted - <code>true</code> if webcam face tracking is muted (temporarily disabled), 
-     *     <code>false</code> it if isn't.
-     *     <em>Read-only.</em>
+     *
+    // TODO: Deprecated by documentation, please review for accuracy
      *     <p class="important">Deprecated: This property is deprecated and has been removed.</p>
      * @property {boolean} ignoreRadiusEnabled - <code>true</code> if the privacy shield is enabled, <code>false</code> if it
      *     is disabled.
      *     <em>Read-only.</em>
-     * @property {boolean} isHMD - <code>true</code> if the display mode is HMD, <code>false</code> if it isn't. 
+     * @property {boolean} isHMD - <code>true</code> if the display mode is HMD, <code>false</code> if it isn't.
      *     <em>Read-only.</em>
-     * @property {boolean} showAudioTools - <code>true</code> if the microphone mute button and audio level meter are shown, 
+     * @property {boolean} showAudioTools - <code>true</code> if the microphone mute button and audio level meter are shown,
      *     <code>false</code> if they are hidden.
-     * @property {boolean} showBubbleTools - <code>true</code> if the privacy shield UI button is shown, <code>false</code> if 
+     * @property {boolean} showBubbleTools - <code>true</code> if the privacy shield UI button is shown, <code>false</code> if
      *     it is hidden.
      */
 
@@ -81,7 +76,7 @@ public slots:
     /*@jsdoc
      * Sets whether or not the microphone mute button and audio level meter is shown.
      * @function AvatarInputs.setShowAudioTools
-     * @param {boolean} showAudioTools - <code>true</code> to show the microphone mute button and audio level meter, 
+     * @param {boolean} showAudioTools - <code>true</code> to show the microphone mute button and audio level meter,
      *     <code>false</code> to hide it.
      */
     void setShowAudioTools(bool showAudioTools);
@@ -96,20 +91,6 @@ public slots:
 signals:
 
     /*@jsdoc
-     * Triggered when webcam face tracking is enabled or disabled.
-     * @deprecated This signal is deprecated and has been removed.
-     * @function AvatarInputs.cameraEnabledChanged
-     * @returns {Signal}
-     */
-
-    /*@jsdoc
-     * Triggered when webcam face tracking is muted (temporarily disabled) or unmuted.
-     * @deprecated This signal is deprecated and has been removed.
-     * @function AvatarInputs.cameraMutedChanged
-     * @returns {Signal}
-     */
-
-    /*@jsdoc
      * Triggered when the display mode changes between desktop and HMD.
      * @function AvatarInputs.isHMDChanged
      * @returns {Signal}
@@ -119,7 +100,7 @@ signals:
     /*@jsdoc
      * Triggered when the visibility of the microphone mute button and audio level meter changes.
      * @function AvatarInputs.showAudioToolsChanged
-     * @param {boolean} show - <code>true</code> if the microphone mute button and audio level meter are shown, 
+     * @param {boolean} show - <code>true</code> if the microphone mute button and audio level meter are shown,
      *     <code>false</code> if they are is hidden.
      * @returns {Signal}
      */
@@ -128,7 +109,7 @@ signals:
     /*@jsdoc
      * Triggered when the visibility of the privacy shield button changes.
      * @function AvatarInputs.showBubbleToolsChanged
-     * @param {boolean} show - <code>true</code> if the privacy shield UI button is shown, <code>false</code> if 
+     * @param {boolean} show - <code>true</code> if the privacy shield UI button is shown, <code>false</code> if
      *     it is hidden.
      * @returns {Signal}
      */
@@ -146,14 +127,7 @@ signals:
      */
     void avatarEnteredIgnoreRadius(QUuid avatarID);
 
-    /*@jsdoc
-     * Triggered when another user leaves the privacy shield.
-     * <p><strong>Note:</strong> Currently doesn't work.</p>
-     * @function AvatarInputs.avatarLeftIgnoreRadius
-     * @param {QUuid} avatarID - The session ID of the user that exited the privacy shield.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void avatarLeftIgnoreRadius(QUuid avatarID);
 
     /*@jsdoc
@@ -179,13 +153,7 @@ protected:
      */
     Q_INVOKABLE void resetSensors();
 
-    /*@jsdoc
-     * Toggles the muting (temporary disablement) of webcam face tracking on/off.
-     * <p class="important">Deprecated: This function is deprecated and has been removed.</p>
-     * @function AvatarInputs.toggleCameraMute
-     */
-
-private: 
+private:
     void onAvatarEnteredIgnoreRadius();
     void onAvatarLeftIgnoreRadius();
     float _trailingAudioLoudness{ 0 };

--- a/interface/src/ui/InteractiveWindow.h
+++ b/interface/src/ui/InteractiveWindow.h
@@ -60,7 +60,7 @@ namespace InteractiveWindowEnums {
     Q_NAMESPACE
 
     /*@jsdoc
-     * <p>A set of  flags controlling <code>InteractiveWindow</code> behavior. The value is constructed by using the 
+     * <p>A set of  flags controlling <code>InteractiveWindow</code> behavior. The value is constructed by using the
      * <code>|</code> (bitwise OR) operator on the individual flag values.</p>
      * <table>
      *   <thead>
@@ -68,7 +68,7 @@ namespace InteractiveWindowEnums {
      *   </thead>
      *   <tbody>
      *     <tr><td>ALWAYS_ON_TOP</td><td><code>1</code></td><td>The window always displays on top.</td></tr>
-     *     <tr><td>CLOSE_BUTTON_HIDES</td><td><code>2</code></td><td>The window hides instead of closing when the user clicks 
+     *     <tr><td>CLOSE_BUTTON_HIDES</td><td><code>2</code></td><td>The window hides instead of closing when the user clicks
      *       the "close" button.</td></tr>
      *   </tbody>
      * </table>
@@ -155,8 +155,8 @@ namespace InteractiveWindowEnums {
 using namespace InteractiveWindowEnums;
 
 /*@jsdoc
- * An <code>InteractiveWindow</code> can display either inside Interface or in its own window separate from the Interface 
- * window. The window content is defined by a QML file, which can optionally include a <code>WebView</code> control that embeds 
+ * An <code>InteractiveWindow</code> can display either inside Interface or in its own window separate from the Interface
+ * window. The window content is defined by a QML file, which can optionally include a <code>WebView</code> control that embeds
  * an HTML web page. (The <code>WebView</code> control is defined by a "WebView.qml" file included in the Interface install.)
  *
  * <p>Create using {@link Desktop.createWindow}.</p>
@@ -170,13 +170,13 @@ using namespace InteractiveWindowEnums;
  *
  * @property {string} title - The title of the window.
  * @property {Vec2} position - The absolute position of the window, in pixels.
- * @property {InteractiveWindow.RelativePositionAnchor} relativePositionAnchor -  The anchor for the 
+ * @property {InteractiveWindow.RelativePositionAnchor} relativePositionAnchor -  The anchor for the
  *     <code>relativePosition</code>, if used.
- * @property {Vec2} relativePosition - The position of the window, relative to the <code>relativePositionAnchor</code>, in 
+ * @property {Vec2} relativePosition - The position of the window, relative to the <code>relativePositionAnchor</code>, in
  *     pixels. Excludes the window frame.
  * @property {Vec2} size - The size of the window, in pixels.
  * @property {boolean} visible - <code>true</code> if the window is visible, <code>false</code> if it isn't.
- * @property {InteractiveWindow.PresentationMode} presentationMode - The presentation mode of the window: 
+ * @property {InteractiveWindow.PresentationMode} presentationMode - The presentation mode of the window:
  *     <code>Desktop.PresentationMode.VIRTUAL</code> to display the window inside Interface, <code>.NATIVE</code> to display it
  *     as its own separate window.
  */
@@ -204,7 +204,7 @@ private:
 
     Q_INVOKABLE glm::vec2 getPosition() const;
     Q_INVOKABLE void setPosition(const glm::vec2& position);
-    
+
     RelativePositionAnchor _relativePositionAnchor{ RelativePositionAnchor::NO_ANCHOR };
     Q_INVOKABLE RelativePositionAnchor getRelativePositionAnchor() const;
     Q_INVOKABLE void setRelativePositionAnchor(const RelativePositionAnchor& position);
@@ -242,36 +242,36 @@ public slots:
      * @param {string|object} message - The message to send to the QML page.
      * @example <caption>Send and receive messages with a QML window.</caption>
      * // JavaScript file.
-     * 
+     *
      * var interactiveWindow = Desktop.createWindow(Script.resolvePath("InteractiveWindow.qml"), {
      *     title: "Interactive Window",
      *     size: { x: 400, y: 300 }
      * });
-     * 
+     *
      * interactiveWindow.fromQml.connect(function (message) {
      *     print("Message received: " + message);
      * });
-     * 
+     *
      * Script.setTimeout(function () {
      *     interactiveWindow.sendToQml("Hello world!");
      * }, 2000);
-     * 
+     *
      * Script.scriptEnding.connect(function () {
      *     interactiveWindow.close();
      * });
      * @example
      * // QML file, "InteractiveWindow.qml".
-     * 
+     *
      * import QtQuick 2.5
      * import QtQuick.Controls 1.4
-     * 
+     *
      * Rectangle {
-     * 
+     *
      *     function fromScript(message) {
      *         text.text = message;
      *         sendToScript("Hello back!");
      *     }
-     * 
+     *
      *     Label {
      *         id: text
      *         anchors.centerIn: parent
@@ -283,7 +283,7 @@ public slots:
     void sendToQml(const QVariant& message);
 
     /*@jsdoc
-     * Sends a message to an embedded HTML web page. To receive the message, the HTML page's script must connect to the 
+     * Sends a message to an embedded HTML web page. To receive the message, the HTML page's script must connect to the
      * <code>EventBridge</code> that is automatically provided for the script:
      * <pre class="prettyprint"><code>EventBridge.scriptEventReceived.connect(function(message) {
      *     ...
@@ -294,11 +294,7 @@ public slots:
     // QmlWindow content may include WebView requiring EventBridge.
     void emitScriptEvent(const QVariant& scriptMessage);
 
-    /*@jsdoc
-     * @function InteractiveWindow.emitWebEvent
-     * @param {object|string} message - Message.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void emitWebEvent(const QVariant& webMessage);
 
     /*@jsdoc
@@ -373,12 +369,7 @@ signals:
     // Scripts can connect to this signal to receive messages from the QML object
     void fromQml(const QVariant& message);
 
-    /*@jsdoc
-     * @function InteractiveWindow.scriptEventReceived
-     * @param {object} message - Message.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // InteractiveWindow content may include WebView requiring EventBridge.
     void scriptEventReceived(const QVariant& message);
 
@@ -392,11 +383,7 @@ signals:
     void webEventReceived(const QVariant& message);
 
 protected slots:
-    /*@jsdoc
-     * @function InteractiveWindow.qmlToScript
-     * @param {object} message - Message.
-     * @deprecated This method is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void qmlToScript(const QVariant& message);
 
     void forwardKeyPressEvent(int key, int modifiers);

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -36,11 +36,11 @@ private: \
  * @hifi-server-entity
  * @hifi-assignment-client
  *
- * @property {boolean} expanded - <code>true</code> if the statistics overlay should be in expanded form when the overlay is 
+ * @property {boolean} expanded - <code>true</code> if the statistics overlay should be in expanded form when the overlay is
  *     displayed, <code>false</code> if it shouldn't be expanded.
- * @property {boolean} timingExpanded - <code>true</code> if timing details should be displayed when the statistics overlay is 
- *     displayed in expanded form, <code>false</code> if timing details should not be displayed. Set by the menu item, 
- *     Developer &gt; Timing &gt; Performance Timer &gt; Display Timing Details. 
+ * @property {boolean} timingExpanded - <code>true</code> if timing details should be displayed when the statistics overlay is
+ *     displayed in expanded form, <code>false</code> if timing details should not be displayed. Set by the menu item,
+ *     Developer &gt; Timing &gt; Performance Timer &gt; Display Timing Details.
  *     <em>Read-only.</em>
  * @property {string} monospaceFont - The name of the monospace font used in the statistics overlay.
  *     <em>Read-only.</em>
@@ -56,10 +56,10 @@ private: \
  *
  * @property {number} appdropped - The number of times a frame has not been provided to the display device in time.
  *     <em>Read-only.</em>
- * @property {number} longsubmits - The number of times the display device has taken longer than 11ms to return after being 
+ * @property {number} longsubmits - The number of times the display device has taken longer than 11ms to return after being
  *     given a frame.
  *     <em>Read-only.</em>
- * @property {number} longrenders - The number of times it has taken longer than 11ms to submit a new frame to the display 
+ * @property {number} longrenders - The number of times it has taken longer than 11ms to submit a new frame to the display
  *     device.
  *     <em>Read-only.</em>
  * @property {number} longframes - The number of times <code>longsubmits + longrenders</code> has taken longer than 15ms.
@@ -72,8 +72,8 @@ private: \
 
  * @property {number} gameLoopRate - The rate at which the game loop is running, in Hz.
  *     <em>Read-only.</em>
- * @property {number} refreshRateTarget - The current target refresh rate, in Hz, per the current <code>refreshRateMode</code> 
- *     and <code>refreshRateRegime</code> if in desktop mode; a higher rate if in VR mode. 
+ * @property {number} refreshRateTarget - The current target refresh rate, in Hz, per the current <code>refreshRateMode</code>
+ *     and <code>refreshRateRegime</code> if in desktop mode; a higher rate if in VR mode.
  *     <em>Read-only.</em>
  * @property {RefreshRateProfileName} refreshRateMode - The current refresh rate profile.
  *     <em>Read-only.</em>
@@ -87,13 +87,13 @@ private: \
  *     <em>Read-only.</em>
  * @property {number} physicsObjectCount - The number of objects that have collisions enabled.
  *     <em>Read-only.</em>
- * @property {number} updatedAvatarCount - The number of avatars in the domain, other than the client's, that were updated in 
+ * @property {number} updatedAvatarCount - The number of avatars in the domain, other than the client's, that were updated in
  *     the most recent game loop.
  *     <em>Read-only.</em>
- * @property {number} updatedHeroAvatarCount - The number of avatars in a "hero" zone in the domain, other than the client's, 
+ * @property {number} updatedHeroAvatarCount - The number of avatars in a "hero" zone in the domain, other than the client's,
  *     that were updated in the most recent game loop.
  *     <em>Read-only.</em>
- * @property {number} notUpdatedAvatarCount - The number of avatars in the domain, other than the client's, that weren't able 
+ * @property {number} notUpdatedAvatarCount - The number of avatars in the domain, other than the client's, that weren't able
  *     to be updated in the most recent game loop because there wasn't enough time to.
  *     <em>Read-only.</em>
  * @property {number} packetInCount - The number of packets being received from the domain server, in packets per second.
@@ -159,18 +159,18 @@ private: \
  * @property {number} audioMixerOutPps - The number of packets being sent to the audio mixer, in packets per second.
  *     <code>-1</code> if not connected to an audio mixer.
  *     <em>Read-only.</em>
- * @property {number} audioMixerKbps - The total amount of data being sent to and received from the audio mixer, in kilobits 
+ * @property {number} audioMixerKbps - The total amount of data being sent to and received from the audio mixer, in kilobits
  *     per second.
  *     <code>-1</code> if not connected to an audio mixer.
  *     <em>Read-only.</em>
- * @property {number} audioMixerPps - The total number of packets being sent to and received from the audio mixer, in packets 
+ * @property {number} audioMixerPps - The total number of packets being sent to and received from the audio mixer, in packets
  *     per second.
  *     <code>-1</code> if not connected to an audio mixer.
  *     <em>Read-only.</em>
  * @property {number} audioOutboundPPS - The number of non-silent audio packets being sent by the user, in packets per second.
  *     <code>-1</code> if not connected to an audio mixer.
  *     <em>Read-only.</em>
- * @property {number} audioSilentOutboundPPS -  The number of silent audio packets being sent by the user, in packets per 
+ * @property {number} audioSilentOutboundPPS -  The number of silent audio packets being sent by the user, in packets per
  *     second.
  *     <code>-1</code> if not connected to an audio mixer.
  *     <em>Read-only.</em>
@@ -178,13 +178,7 @@ private: \
  *     second.
  *     <code>-1</code> if not connected to an audio mixer.
  *     <em>Read-only.</em>
- * @property {number} audioAudioInboundPPS -  The number of non-silent audio packets being received by the user, in packets per
- *     second.
- *     <code>-1</code> if not connected to an audio mixer.
- *     <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>audioInboundPPS</code> 
- *     instead.</p>
- * @property {number} audioSilentInboundPPS -  The number of silent audio packets being received by the user, in packets per 
+ * @property {number} audioSilentInboundPPS -  The number of silent audio packets being received by the user, in packets per
  *     second.
  *     <code>-1</code> if not connected to an audio mixer.
  *     <em>Read-only.</em>
@@ -198,7 +192,7 @@ private: \
  * @property {Vec2} audioInjectors - The number of audio injectors, local and non-local.
  *     <em>Read-only.</em>
  *     <p><strong>Note:</strong> Property not available in the API.</p>
- * @property {number} entityPacketsInKbps - The average amount of data being received from entity servers, in kilobits per 
+ * @property {number} entityPacketsInKbps - The average amount of data being received from entity servers, in kilobits per
  *     second. (Multiply by the number of entity servers to get the total amount of data being received.)
  *     <code>-1</code> if not connected to an entity server.
  *     <em>Read-only.</em>
@@ -252,8 +246,8 @@ private: \
  *     <em>Read-only.</em>
  * @property {number} numNeededEntityUpdates - The total number of entity updates scheduled for last frame.
  *     <em>Read-only.</em>
- * @property {string} timingStats - Details of the average time (ms) spent in and number of calls made to different parts of 
- *     the code. Provided only if <code>timingExpanded</code> is <code>true</code>. Only the top 10 items are provided if 
+ * @property {string} timingStats - Details of the average time (ms) spent in and number of calls made to different parts of
+ *     the code. Provided only if <code>timingExpanded</code> is <code>true</code>. Only the top 10 items are provided if
  *     Developer &gt; Timing &gt; Performance Timer &gt; Only Display Top 10 is enabled.
  *     <em>Read-only.</em>
  * @property {string} gameUpdateStats - Details of the average time (ms) spent in different parts of the game loop.
@@ -270,22 +264,22 @@ private: \
  *     <em>Read-only.</em>
  * @property {number} localLeaves - The number of leaf elements in the client octree.
  *     <em>Read-only.</em>
- * @property {number} rectifiedTextureCount - The number of textures that have been resized so that their dimensions is a power 
+ * @property {number} rectifiedTextureCount - The number of textures that have been resized so that their dimensions is a power
  *     of 2 if smaller than 128 pixels, or a multiple of 128 if greater than 128 pixels.
  *     <em>Read-only.</em>
- * @property {number} decimatedTextureCount - The number of textures that have been reduced in size because they were over the 
+ * @property {number} decimatedTextureCount - The number of textures that have been reduced in size because they were over the
  *     maximum allowed dimensions of 8192 pixels on desktop or 2048 pixels on mobile.
  *     <em>Read-only.</em>
  * @property {number} gpuBuffers - The number of OpenGL buffer objects managed by the GPU back-end.
  *     <em>Read-only.</em>
- * @property {number} gpuBufferMemory - The total memory size of the <code>gpuBuffers</code>, in MB. 
+ * @property {number} gpuBufferMemory - The total memory size of the <code>gpuBuffers</code>, in MB.
  *     <em>Read-only.</em>
- * @property {number} gpuTextures - The number of OpenGL textures managed by the GPU back-end. This is the sum of the number of 
+ * @property {number} gpuTextures - The number of OpenGL textures managed by the GPU back-end. This is the sum of the number of
  *     textures managed for <code>gpuTextureResidentMemory</code>,  <code>gpuTextureResourceMemory</code>, and
  *     <code>gpuTextureFramebufferMemory</code>.
  *     <em>Read-only.</em>
- * @property {number} gpuTextureMemory - The total memory size of the <code>gpuTextures</code>, in MB. This is the sum of 
- *     <code>gpuTextureResidentMemory</code>,  <code>gpuTextureResourceMemory</code>, and 
+ * @property {number} gpuTextureMemory - The total memory size of the <code>gpuTextures</code>, in MB. This is the sum of
+ *     <code>gpuTextureResidentMemory</code>,  <code>gpuTextureResourceMemory</code>, and
  *     <code>gpuTextureFramebufferMemory</code>.
  *     <em>Read-only.</em>
  * @property {number} glContextSwapchainMemory -  The estimated memory used by the default OpenGL frame buffer, in MB.
@@ -294,32 +288,32 @@ private: \
  *     <em>Read-only.</em>
  * @property {number} texturePendingTransfers - The memory size of textures pending transfer to the GPU, in MB.
  *     <em>Read-only.</em>
- * @property {number} gpuTextureResidentMemory - The memory size of the "strict" textures that always have their full 
+ * @property {number} gpuTextureResidentMemory - The memory size of the "strict" textures that always have their full
  *     resolution in GPU memory, in MB.
  *     <em>Read-only.</em>
  * @property {number} gpuTextureFramebufferMemory - The memory size of the frame buffer on the GPU, in MB.
  *     <em>Read-only.</em>
- * @property {number} gpuTextureResourceMemory - The amount of GPU memory that has been allocated for "variable" textures that 
+ * @property {number} gpuTextureResourceMemory - The amount of GPU memory that has been allocated for "variable" textures that
  *     don't necessarily always have their full resolution in GPU memory, in MB.
  *     <em>Read-only.</em>
- * @property {number} gpuTextureResourceIdealMemory - The amount of memory that "variable" textures would take up if they were 
+ * @property {number} gpuTextureResourceIdealMemory - The amount of memory that "variable" textures would take up if they were
  *     all completely loaded, in MB.
  *     <em>Read-only.</em>
- * @property {number} gpuTextureResourcePopulatedMemory - How much of the GPU memory allocated has actually been populated, in 
+ * @property {number} gpuTextureResourcePopulatedMemory - How much of the GPU memory allocated has actually been populated, in
 *      MB.
  *     <em>Read-only.</em>
  * @property {string} gpuTextureMemoryPressureState - The stats of the texture transfer engine.
  *     <ul>
- *         <li><code>"Undersubscribed"</code>: There is texture data that can fit in memory but that isn't on the GPU, so more 
+ *         <li><code>"Undersubscribed"</code>: There is texture data that can fit in memory but that isn't on the GPU, so more
  *         GPU texture memory should be allocated if possible.</li>
  *         <li><code>"Transfer"</code>: More GPU texture memory has been allocated and texture data is being transferred.</li>
- *         <li><code>"Idle"</code>: Either all texture data has been transferred to the GPU or there is nor more space 
+ *         <li><code>"Idle"</code>: Either all texture data has been transferred to the GPU or there is nor more space
  *         available.</li>
  *     </ul>
  *     <em>Read-only.</em>
- * @property {number} gpuFreeMemory - The amount of GPU memory available after all allocations, in MB. 
+ * @property {number} gpuFreeMemory - The amount of GPU memory available after all allocations, in MB.
  *     <em>Read-only.</em>
- *     <p><strong>Note:</strong> This is not a reliable number because OpenGL doesn't have an official method of getting this 
+ *     <p><strong>Note:</strong> This is not a reliable number because OpenGL doesn't have an official method of getting this
  *     information.</p>
  * @property {number} gpuTextureExternalMemory - The estimated amount of memory consumed by textures being used but that are
  *     not managed by the GPU library, in MB.
@@ -346,7 +340,7 @@ private: \
  *     <em>Read-only.</em>
  * @property {number} collisionPicksCount - The number of collision picks currently in effect.
  *     <em>Read-only.</em>
- * @property {Vec3} stylusPicksUpdated - The number of stylus pick intersection that were found in the most recent game loop: 
+ * @property {Vec3} stylusPicksUpdated - The number of stylus pick intersection that were found in the most recent game loop:
  *     <ul>
  *         <li><code>x</code> = entity intersections.</li>
  *         <li><code>y</code> = avatar intersections.</li>
@@ -390,68 +384,6 @@ private: \
  * @property {number} nodeListThreadQueueDepth - The number of events in the node list thread's event queue.
  *     Only provided if <code>eventQueueDebuggingOn</code> is <code>true</code>.
  *     <em>Read-only.</em>
- *
- * @comment The following property is from Stats.qml. It shouldn't be in the API.
- * @property {string} bgColor
- *     <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- *
- * @comment The following properties are from QQuickItem. They shouldn't be in the API.
- * @property {boolean} activeFocus
- *     <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} activeFocusOnTab
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {object} anchors
- *     <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} antialiasing
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} baselineOffset
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {object[]} children
- *     <em>Read-only.</em>
- *     <p><strong>Note:</strong> Property not available in the API.</p>
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} clip
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {object} containmentMask
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} enabled
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} focus
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} height
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} implicitHeight
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} implicitWidth 
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {object} layer
- *     <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} opacity
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} rotation
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} scale
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} smooth
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {string} state
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} transformOrigin
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} visible
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} width
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} x
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} y
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {number} z
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  */
 // Properties from x onwards are QQuickItem properties.
 
@@ -629,7 +561,7 @@ public slots:
     /*@jsdoc
      * Updates statistics to make current values available to scripts even though the statistics overlay may not be displayed.
      * (Many statistics values are normally updated only if the statistics overlay is displayed.)
-     * <p><strong>Note:</strong> Not all statistics values are updated when the statistics overlay isn't displayed or 
+     * <p><strong>Note:</strong> Not all statistics values are updated when the statistics overlay isn't displayed or
      * expanded.</p>
      * @function Stats.forceUpdateStats
      * @example <caption>Report avatar mixer data and packet rates.</caption>
@@ -640,10 +572,10 @@ public slots:
      *     "avatarMixerOutKbps",
      *     "avatarMixerOutPps"
      * ];
-     * 
+     *
      * // Update the statistics for the script.
      * Stats.forceUpdateStats();
-     * 
+     *
      * // Report the statistics.
      * for (var i = 0; i < stats.length; i++) {
      *     print(stats[i], "=", Stats[stats[i]]);
@@ -1012,13 +944,7 @@ signals:
      */
     void audioInboundPPSChanged();
 
-    /*@jsdoc
-     * Triggered when the value of the <code>audioAudioInboundPPS</code> property changes.
-     * @function Stats.audioAudioInboundPPSChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed. Use 
-     *     {@link Stats.audioInboundPPSChanged|audioInboundPPSChanged} instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void audioAudioInboundPPSChanged();
 
     /*@jsdoc
@@ -1524,289 +1450,6 @@ signals:
      * @returns {Signal}
      */
     void eventQueueDebuggingOnChanged();
-
-
-    // Stats.qml signals: shouldn't be in the API.
-
-    /*@jsdoc
-     * Triggered when the value of the <code>bgColor</code> property changes.
-     * @function Stats.bgColorChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-
-    // QQuickItem signals: shouldn't be in the API.
-
-    /*@jsdoc
-     * Triggered when the value of the <code>activeFocus</code> property changes.
-     * @function Stats.activeFocusChanged
-     * @param {boolean} activeFocus - Active focus.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>activeFocusOnTab</code> property changes.
-     * @function Stats.activeFocusOnTabChanged
-     * @param {boolean} activeFocusOnTab - Active focus on tab.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>antialiasing</code> property changes.
-     * @function Stats.antialiasingChanged
-     * @param {boolean} antialiasing - Antialiasing.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>baselineOffset</code> property changes.
-     * @function Stats.baselineOffsetChanged
-     * @param {number} baselineOffset - Baseline offset.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>children</code> property changes.
-     * @function Stats.childrenChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the position and size of the rectangle containing the children changes.
-     * @function Stats.childrenRectChanged
-     * @param {Rect} childrenRect - Children rect.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-
-    /*@jsdoc
-     * Triggered when the value of the <code>clip</code> property changes.
-     * @function Stats.clipChanged
-     * @param {boolean} clip - Clip.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>containmentMask</code> property changes.
-     * @function Stats.containmentMaskChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>enabled</code> property changes.
-     * @function Stats.enabledChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>focus</code> property changes.
-     * @function Stats.focusChanged
-     * @param {boolean} focus - Focus.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>height</code> property changes.
-     * @function Stats.heightChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>implicitHeight</code> property changes.
-     * @function Stats.implicitHeightChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>implicitWidth</code> property changes.
-     * @function Stats.implicitWidthChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>opacity</code> property changes.
-     * @function Stats.opacityChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the parent item changes.
-     * @function Stats.parentChanged
-     * @param {object} parent - Parent.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>rotation</code> property changes.
-     * @function Stats.rotationChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>scale</code> property changes.
-     * @function Stats.scaleChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>smooth</code> property changes.
-     * @function Stats.smoothChanged
-     * @param {boolean} smooth - Smooth.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>state</code> property changes.
-     * @function Stats.stateChanged
-     * @paramm {string} state - State.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>transformOrigin</code> property changes.
-     * @function Stats.transformOriginChanged
-     * @param {number} transformOrigin - Transformm origin.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>visibleChanged</code> property changes.
-     * @function Stats.visibleChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the list of visible children changes.
-     * @function Stats.visibleChildrenChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>width</code> property changes.
-     * @function Stats.widthChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the stats window changes.
-     * @function Stats.windowChanged
-     * @param {object} window - Window.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>x</code> property changes.
-     * @function Stats.xChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>y</code> property changes.
-     * @function Stats.yChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * Triggered when the value of the <code>z</code> property changes.
-     * @function Stats.zChanged
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-
-
-    // QQuickItem methods: shouldn't be in the API.
-
-    /*@jsdoc
-     * @function Stats.childAt
-     * @param {number} x - X.
-     * @param {number} y - Y.
-     * @returns {object}
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.contains
-     * @param {Vec2} point - Point
-     * @returns {boolean}
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.forceActiveFocus
-     * @param {number} [reason=7] - Reason
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.grabToImage
-     * @param {object} callback - Callback.
-     * @param {Size} [targetSize=0,0] - Target size.
-     * @returns {boolean}
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.mapFromGlobal
-     * @param {object} global - Global.
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.mapFromItem
-     * @param {object} item - Item.
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.mapToGlobal
-     * @param {object} global - Global.
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.mapToItem
-     * @param {object} item - Item
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.nextItemInFocusChain
-     * @param {boolean} [forward=true] - Forward.
-     * @returns {object}
-     * @deprecated This method is deprecated and will be removed.
-     */
-
-    /*@jsdoc
-     * @function Stats.update
-     * @deprecated This method is deprecated and will be removed.
-     */
 
 private:
     int _recentMaxPackets{ 0 } ; // recent max incoming voxel packets to process

--- a/libraries/animation/src/AnimationCacheScriptingInterface.h
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.h
@@ -44,7 +44,6 @@ class AnimationCacheScriptingInterface : public ScriptableResourceCache, public 
      *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
-     * @borrows ResourceCache.updateTotalSize as updateTotalSize
      * @borrows ResourceCache.prefetch as prefetch
      * @borrows ResourceCache.dirty as dirty
      */

--- a/libraries/animation/src/IKTarget.h
+++ b/libraries/animation/src/IKTarget.h
@@ -23,15 +23,12 @@ public:
      *     <tr><th>Value</th><th>Name</th><th>Description</th>
      *   </thead>
      *   <tbody>
-     *     <tr><td><code>0</code></td><td>RotationAndPosition</td><td>Attempt to reach the rotation and position end 
+     *     <tr><td><code>0</code></td><td>RotationAndPosition</td><td>Attempt to reach the rotation and position end
      *       effector.</td></tr>
      *     <tr><td><code>1</code></td><td>RotationOnly</td><td>Attempt to reach the end effector rotation only.</td></tr>
-     *     <tr><td><code>2</code></td><td>HmdHead</td><td>
-     *       <p>A special mode of IK that would attempt to prevent unnecessary bending of the spine.</p>
-     *       <p class="important">Deprecated: This target type is deprecated and will be removed.</p></td></tr>
-     *     <tr><td><code>3</code></td><td>HipsRelativeRotationAndPosition</td><td>Attempt to reach a rotation and position end 
+     *     <tr><td><code>3</code></td><td>HipsRelativeRotationAndPosition</td><td>Attempt to reach a rotation and position end
      *       effector that is not in absolute rig coordinates but is offset by the avatar hips translation.</td></tr>
-     *     <tr><td><code>4</code></td><td>Spline</td><td>Use a cubic Hermite spline to model the human spine. This prevents 
+     *     <tr><td><code>4</code></td><td>Spline</td><td>Use a cubic Hermite spline to model the human spine. This prevents
      *       kinks in the spine and allows for a small amount of stretch and squash.</td></tr>
      *     <tr><td><code>5</code></td><td>Unknown</td><td>IK is disabled.</td></tr>
      *   </tbody>

--- a/libraries/audio/src/SoundCacheScriptingInterface.h
+++ b/libraries/audio/src/SoundCacheScriptingInterface.h
@@ -45,7 +45,6 @@ class SoundCacheScriptingInterface : public ScriptableResourceCache, public Depe
      *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
-     * @borrows ResourceCache.updateTotalSize as updateTotalSize
      * @borrows ResourceCache.prefetch as prefetch
      * @borrows ResourceCache.dirty as dirty
      */
@@ -56,7 +55,7 @@ public:
     /*@jsdoc
      * Loads the content of an audio file into a {@link SoundObject}, ready for playback by {@link Audio.playSound}.
      * @function SoundCache.getSound
-     * @param {string} url - The URL of the audio file to load &mdash; Web, ATP, or file. See {@link SoundObject} for supported 
+     * @param {string} url - The URL of the audio file to load &mdash; Web, ATP, or file. See {@link SoundObject} for supported
      *     formats.
      * @returns {SoundObject} The sound ready for playback.
      */

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -498,12 +498,7 @@ public:
     void setTargetScale(float targetScale) override;
     float getTargetScale() const { return _targetScale; }
 
-    /*@jsdoc
-     * @function MyAvatar.getSimulationRate
-     * @param {AvatarSimulationRate} [rateName=""] - Rate name.
-     * @returns {number} Simulation rate in Hz.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE float getSimulationRate(const QString& rateName = QString("")) const;
 
     bool hasNewJointData() const { return _hasNewJointData; }
@@ -607,26 +602,14 @@ public slots:
      */
     glm::quat getRightPalmRotation() const;
 
-    /*@jsdoc
-     * @function MyAvatar.setModelURLFinished
-     * @param {boolean} success
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // hooked up to Model::setURLFinished signal
     void setModelURLFinished(bool success);
 
-    /*@jsdoc
-     * @function MyAvatar.rigReady
-     * @deprecated This function is deprecated and will be removed.
-     */
-    // Hooked up to Model::rigReady signal
+    // TODO: Deprecated by documentation, please review for accuracy
     void rigReady();
 
-    /*@jsdoc
-     * @function MyAvatar.rigReset
-     * @deprecated This function is deprecated and will be removed.
-     */
-    // Hooked up to Model::rigReset signal
+    // TODO: Deprecated by documentation, please review for accuracy
     void rigReset();
 
 protected:

--- a/libraries/avatars-renderer/src/avatars-renderer/ScriptAvatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/ScriptAvatar.h
@@ -52,14 +52,10 @@
  * @property {string} displayName - The avatar's display name.
  * @property {string} sessionDisplayName - The avatar's display name, sanitized and versioned, as defined by the avatar mixer.
  *     It is unique among all avatars present in the domain at the time.
- * @property {boolean} isReplicated - <span class="important">Deprecated: This property is deprecated and will be
- *     removed.</span>
  * @property {boolean} lookAtSnappingEnabled - <code>true</code> if the avatar's eyes snap to look at another avatar's eyes
  *     when the other avatar is in the line of sight and also has <code>lookAtSnappingEnabled == true</code>.
  *
  * @property {string} skeletonModelURL - The avatar's FST file.
- * @property {AttachmentData[]} attachmentData - Information on the avatar's attachments.
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use avatar entities instead.</p>
  * @property {string[]} jointNames - The list of joints in the avatar model.
  *
  * @property {number} audioLoudness - The instantaneous loudness of the audio input that the avatar is injecting into the
@@ -178,12 +174,7 @@ public slots:
     QVariantList getSkeleton() const;
 
 
-    /*@jsdoc
-     * @function ScriptAvatar.getSimulationRate
-     * @param {AvatarSimulationRate} [rateName=""] - Rate name.
-     * @returns {number} Simulation rate in Hz, or <code>0.0</code> if avatar data aren't available.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     float getSimulationRate(const QString& rateName = QString("")) const;
 
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1143,43 +1143,20 @@ public:
      */
     Q_INVOKABLE void setBlendshape(QString name, float val) { _headData->setBlendshape(name, val); }
 
-
-    /*@jsdoc
-     * Gets information about the models currently attached to your avatar.
-     * @function Avatar.getAttachmentsVariant
-     * @returns {AttachmentData[]} Information about all models attached to your avatar.
-     * @deprecated This function is deprecated and will be removed. Use avatar entities instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // FIXME: Can this name be improved? Can it be deprecated?
     Q_INVOKABLE virtual QVariantList getAttachmentsVariant() const;
 
-    /*@jsdoc
-     * Sets all models currently attached to your avatar. For example, if you retrieve attachment data using
-     * {@link MyAvatar.getAttachmentsVariant} or {@link Avatar.getAttachmentsVariant}, make changes to it, and then want to
-     * update your avatar's attachments per the changed data.
-     * @function Avatar.setAttachmentsVariant
-     * @param {AttachmentData[]} variant - The attachment data defining the models to have attached to your avatar.
-     * @deprecated This function is deprecated and will be removed. Use avatar entities instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // FIXME: Can this name be improved? Can it be deprecated?
     Q_INVOKABLE virtual void setAttachmentsVariant(const QVariantList& variant);
 
     virtual void storeAvatarEntityDataPayload(const QUuid& entityID, const QByteArray& payload);
 
-    /*@jsdoc
-     * @function Avatar.updateAvatarEntity
-     * @param {Uuid} entityID - The entity ID.
-     * @param {ArrayBuffer} entityData - Entity data.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE virtual void updateAvatarEntity(const QUuid& entityID, const QByteArray& entityData);
 
-    /*@jsdoc
-     * @function Avatar.clearAvatarEntity
-     * @param {Uuid} entityID - The entity ID.
-     * @param {boolean} [requiresRemovalFromTree=true] - unused
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE virtual void clearAvatarEntity(const QUuid& entityID, bool requiresRemovalFromTree = true);
 
     // FIXME: Rename to clearAvatarEntity() once the API call is removed.
@@ -1189,15 +1166,7 @@ public:
 
     QList<QUuid> getAvatarEntityIDs() const;
 
-    /*@jsdoc
-     * Enables blend shapes set using {@link Avatar.setBlendshape} or {@link MyAvatar.setBlendshape} to be transmitted to other
-     * users so that they can see the animation of your avatar's face.
-     * <p class="important">Deprecated: This method is deprecated and will be removed. Use the
-     * <code>Avatar.hasScriptedBlendshapes</code> or <code>MyAvatar.hasScriptedBlendshapes</code>  property instead.</p>
-     * @function Avatar.setForceFaceTrackerConnected
-     * @param {boolean} connected - <code>true</code> to enable blend shape changes to be transmitted to other users,
-     *     <code>false</code> to disable.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void setForceFaceTrackerConnected(bool connected) { setHasScriptedBlendshapes(connected); }
 
     // key state
@@ -1252,107 +1221,23 @@ public:
     }
     virtual bool isCertifyFailed() const { return _verificationFailed; }
 
-    /*@jsdoc
-     * Gets information about the models currently attached to your avatar.
-     * @function Avatar.getAttachmentData
-     * @returns {AttachmentData[]} Information about all models attached to your avatar.
-     * @deprecated This function is deprecated and will be removed. Use avatar entities instead.
-     * @example <caption>Report the URLs of all current attachments.</caption>
-     * var attachments = MyAvatar.getaAttachmentData();
-     * for (var i = 0; i < attachments.length; i++) {
-     *     print(attachments[i].modelURL);
-     * }
-     *
-     * // Note: If using from the Avatar API, replace "MyAvatar" with "Avatar".
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
+    // Note: If using from the Avatar API, replace "MyAvatar" with "Avatar".
     Q_INVOKABLE virtual QVector<AttachmentData> getAttachmentData() const;
 
-    /*@jsdoc
-     * Sets all models currently attached to your avatar. For example, if you retrieve attachment data using
-     * {@link MyAvatar.getAttachmentData} or {@link Avatar.getAttachmentData}, make changes to it, and then want to update your avatar's attachments per the
-     * changed data. You can also remove all attachments by using setting <code>attachmentData</code> to <code>null</code>.
-     * @function Avatar.setAttachmentData
-     * @param {AttachmentData[]} attachmentData - The attachment data defining the models to have attached to your avatar. Use
-     *     <code>null</code> to remove all attachments.
-     * @deprecated This function is deprecated and will be removed. Use avatar entities instead.
-     * @example <caption>Remove a hat attachment if your avatar is wearing it.</caption>
-     * var hatURL = "https://apidocs.overte.org/examples/cowboy-hat.fbx";
-     * var attachments = MyAvatar.getAttachmentData();
-     *
-     * for (var i = 0; i < attachments.length; i++) {
-     *     if (attachments[i].modelURL === hatURL) {
-     *         attachments.splice(i, 1);
-     *         MyAvatar.setAttachmentData(attachments);
-     *         break;
-     *     }
-     *  }
-     *
-     * // Note: If using from the Avatar API, replace all occurrences of "MyAvatar" with "Avatar".
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE virtual void setAttachmentData(const QVector<AttachmentData>& attachmentData);
 
-    /*@jsdoc
-     * Attaches a model to your avatar. For example, you can give your avatar a hat to wear, a guitar to hold, or a surfboard to
-     * stand on.
-     * @function Avatar.attach
-     * @param {string} modelURL - The URL of the glTF, FBX, or OBJ model to attach. glTF models may be in JSON or binary format
-     *     (".gltf" or ".glb" URLs respectively).
-     * @param {string} [jointName=""] - The name of the avatar joint (see {@link MyAvatar.getJointNames} or
-     *     {@link Avatar.getJointNames}) to attach the model to.
-     * @param {Vec3} [translation=Vec3.ZERO] - The offset to apply to the model relative to the joint position.
-     * @param {Quat} [rotation=Quat.IDENTITY] - The rotation to apply to the model relative to the joint orientation.
-     * @param {number} [scale=1.0] - The scale to apply to the model.
-     * @param {boolean} [isSoft=false] -  If the model has a skeleton, set this to <code>true</code> so that the bones of the
-     *     attached model's skeleton are rotated to fit the avatar's current pose. <code>isSoft</code> is used, for example,
-     *     to have clothing that moves with the avatar.
-     *     <p>If <code>true</code>, the <code>translation</code>, <code>rotation</code>, and <code>scale</code> parameters are
-     *     ignored.</p>
-     * @param {boolean} [allowDuplicates=false] - If <code>true</code> then more than one copy of any particular model may be
-     *     attached to the same joint; if <code>false</code> then the same model cannot be attached to the same joint.
-     * @param {boolean} [useSaved=true] - <em>Not used.</em>
-     * @deprecated This function is deprecated and will be removed. Use avatar entities instead.
-     * @example <caption>Attach a cowboy hat to your avatar's head.</caption>
-     * var attachment = {
-     *     modelURL: "https://apidocs.overte.org/examples/cowboy-hat.fbx",
-     *     jointName: "Head",
-     *     translation: {"x": 0, "y": 0.25, "z": 0},
-     *     rotation: {"x": 0, "y": 0, "z": 0, "w": 1},
-     *     scale: 0.01,
-     *     isSoft: false
-     * };
-     *
-     *  MyAvatar.attach(attachment.modelURL,
-     *                  attachment.jointName,
-     *                  attachment.translation,
-     *                  attachment.rotation,
-     *                  attachment.scale,
-     *                  attachment.isSoft);
-     *
-     * // Note: If using from the Avatar API, replace "MyAvatar" with "Avatar".
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE virtual void attach(const QString& modelURL, const QString& jointName = QString(),
                                     const glm::vec3& translation = glm::vec3(), const glm::quat& rotation = glm::quat(),
                                     float scale = 1.0f, bool isSoft = false,
                                     bool allowDuplicates = false, bool useSaved = true);
 
-    /*@jsdoc
-     * Detaches the most recently attached instance of a particular model from either a specific joint or any joint.
-     * @function Avatar.detachOne
-     * @param {string} modelURL - The URL of the model to detach.
-     * @param {string} [jointName=""] - The name of the joint to detach the model from. If <code>""</code>, then the most
-     *     recently attached model is removed from which ever joint it was attached to.
-     * @deprecated This function is deprecated and will be removed. Use avatar entities instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE virtual void detachOne(const QString& modelURL, const QString& jointName = QString());
 
-    /*@jsdoc
-     * Detaches all instances of a particular model from either a specific joint or all joints.
-     * @function Avatar.detachAll
-     * @param {string} modelURL - The URL of the model to detach.
-     * @param {string} [jointName=""] - The name of the joint to detach the model from. If <code>""</code>, then the model is
-     *     detached from all joints.
-     * @deprecated This function is deprecated and will be removed. Use avatar entities instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE virtual void detachAll(const QString& modelURL, const QString& jointName = QString());
 
     QString getSkeletonModelURLFromScript() const { return _skeletonModelURL.toString(); }
@@ -1584,27 +1469,13 @@ signals:
     void sessionUUIDChanged();
 
 public slots:
-
-/*@jsdoc
-     * @function Avatar.sendAvatarDataPacket
-     * @param {boolean} [sendAll=false] - Send all.
-     * @returns {number}
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     virtual int sendAvatarDataPacket(bool sendAll = false);
 
-    /*@jsdoc
-     * @function Avatar.sendIdentityPacket
-     * @returns {number}
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     int sendIdentityPacket();
 
-    /*@jsdoc
-     * @function Avatar.setSessionUUID
-     * @param {Uuid} sessionUUID - Session UUID.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     virtual void setSessionUUID(const QUuid& sessionUUID) {
         if (sessionUUID != getID()) {
             if (sessionUUID == QUuid()) {
@@ -1668,10 +1539,7 @@ public slots:
      */
     float getTargetScale() const { return _targetScale; } // why is this a slot?
 
-    /*@jsdoc
-     * @function Avatar.resetLastSent
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void resetLastSent() { _lastToByteArray = 0; }
 
 protected:

--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -38,7 +38,7 @@ const quint64 MIN_TIME_BETWEEN_MY_AVATAR_DATA_SENDS = USECS_PER_SECOND / CLIENT_
 /*@jsdoc
  * The <code>AvatarList</code> API provides information about avatars within the current domain.
  *
- * <p><strong>Warning:</strong> An API named "<code>AvatarList</code>" is also provided for Interface, client entity, and avatar 
+ * <p><strong>Warning:</strong> An API named "<code>AvatarList</code>" is also provided for Interface, client entity, and avatar
  * scripts, however, it is a synonym for the {@link AvatarManager} API.</p>
  *
  * @namespace AvatarList
@@ -79,10 +79,10 @@ public:
     int size() { QReadLocker lock(&_hashLock); return _avatarHash.size(); }
 
     // Currently, your own avatar will be included as the null avatar id.
-    
+
     /*@jsdoc
      * Gets the IDs of all avatars in the domain.
-     * <p><strong>Warning:</strong> If the AC script is acting as an avatar (i.e., <code>Agent.isAvatar == true</code>) the 
+     * <p><strong>Warning:</strong> If the AC script is acting as an avatar (i.e., <code>Agent.isAvatar == true</code>) the
      * avatar's ID is NOT included in results.</p>
      * @function AvatarList.getAvatarIdentifiers
      * @returns {Uuid[]} The IDs of all avatars in the domain (excluding AC script's avatar).
@@ -176,51 +176,25 @@ public slots:
      * @function AvatarList.isAvatarInRange
      * @param {string} position - The test position.
      * @param {string} range - The test distance.
-     * @returns {boolean} <code>true</code> if there's an avatar within the specified distance of the point, <code>false</code> 
+     * @returns {boolean} <code>true</code> if there's an avatar within the specified distance of the point, <code>false</code>
      *     if not.
      */
     bool isAvatarInRange(const glm::vec3 & position, const float range);
 
 protected slots:
-
-    /*@jsdoc
-     * @function AvatarList.sessionUUIDChanged
-     * @param {Uuid} sessionUUID - New session ID.
-     * @param {Uuid} oldSessionUUID - Old session ID.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void sessionUUIDChanged(const QUuid& sessionUUID, const QUuid& oldUUID);
 
-    /*@jsdoc
-     * @function AvatarList.processAvatarDataPacket
-     * @param {object} message - Message.
-     * @param {object} sendingNode - Sending node.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void processAvatarDataPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
-   
-    /*@jsdoc
-     * @function AvatarList.processAvatarIdentityPacket
-     * @param {object} message - Message.
-     * @param {object} sendingNode - Sending node.
-     * @deprecated This function is deprecated and will be removed.
-     */
+
+    // TODO: Deprecated by documentation, please review for accuracy
     void processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
-    
-    /*@jsdoc
-     * @function AvatarList.processBulkAvatarTraits
-     * @param {object} message - Message.
-     * @param {object} sendingNode - Sending node.
-     * @deprecated This function is deprecated and will be removed.
-     */
+
+    // TODO: Deprecated by documentation, please review for accuracy
     void processBulkAvatarTraits(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
-    
-    /*@jsdoc
-     * @function AvatarList.processKillAvatar
-     * @param {object} message - Message.
-     * @param {object} sendingNode - Sending node.
-     * @deprecated This function is deprecated and will be removed.
-     */
+
+    // TODO: Deprecated by documentation, please review for accuracy
     void processKillAvatar(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
 
 protected:
@@ -233,9 +207,9 @@ protected:
         bool& isNew);
     virtual AvatarSharedPointer findAvatar(const QUuid& sessionUUID) const; // uses a QReadLocker on the hashLock
     virtual void removeAvatar(const QUuid& sessionUUID, KillAvatarReason removalReason = KillAvatarReason::NoReason);
-    
+
     virtual void handleRemovedAvatar(const AvatarSharedPointer& removedAvatar, KillAvatarReason removalReason = KillAvatarReason::NoReason);
-    
+
     mutable QReadWriteLock _hashLock;
     AvatarHash _avatarHash;
 

--- a/libraries/avatars/src/ScriptAvatarData.h
+++ b/libraries/avatars/src/ScriptAvatarData.h
@@ -204,13 +204,7 @@ public:
      */
     Q_INVOKABLE QStringList getJointNames() const;
 
-    /*@jsdoc
-     * Gets information about the models currently attached to the avatar.
-     * @function ScriptAvatar.getAttachmentData
-     * @returns {AttachmentData[]} Information about all models attached to the avatar, or <code>[]</code> if the avatar data
-     *     aren't available.
-     * @deprecated This function is deprecated and will be removed. Use avatar entities instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE QVector<AttachmentData> getAttachmentData() const;
 
 #if DEV_BUILD || PR_BUILD

--- a/libraries/controllers/src/controllers/Actions.cpp
+++ b/libraries/controllers/src/controllers/Actions.cpp
@@ -34,9 +34,9 @@ namespace controller {
     }
 
     /*@jsdoc
-     * <p>The <code>Controller.Actions</code> object has properties representing predefined actions on the user's avatar and 
+     * <p>The <code>Controller.Actions</code> object has properties representing predefined actions on the user's avatar and
      * Interface. The property values are integer IDs, uniquely identifying each action. <em>Read-only.</em></p>
-     * <p>These actions can be used as end points in the routes of a {@link MappingObject}. The data item routed to each action 
+     * <p>These actions can be used as end points in the routes of a {@link MappingObject}. The data item routed to each action
      * is either a number or a {@link Pose}.</p>
      *
      * <table>
@@ -45,29 +45,29 @@ namespace controller {
      *   </thead>
      *   <tbody>
      *     <tr><td colSpan=4><strong>Avatar Movement</strong></td></tr>
-     *     <tr><td><code>TranslateX</code></td><td>number</td><td>number</td><td>Move the user's avatar in the direction of its 
+     *     <tr><td><code>TranslateX</code></td><td>number</td><td>number</td><td>Move the user's avatar in the direction of its
      *       x-axis, if the camera isn't in independent or mirror modes.</td></tr>
-     *     <tr><td><code>TranslateY</code></td><td>number</td><td>number</td><td>Move the user's avatar in the direction of its 
+     *     <tr><td><code>TranslateY</code></td><td>number</td><td>number</td><td>Move the user's avatar in the direction of its
      *       y-axis, if the camera isn't in independent or mirror modes.</td></tr>
-     *     <tr><td><code>TranslateZ</code></td><td>number</td><td>number</td><td>Move the user's avatar in the direction of its 
+     *     <tr><td><code>TranslateZ</code></td><td>number</td><td>number</td><td>Move the user's avatar in the direction of its
      *       z-axis, if the camera isn't in independent or mirror modes.</td></tr>
-     *     <tr><td><code>Pitch</code></td><td>number</td><td>number</td><td>Rotate the user's avatar head and attached camera 
-     *       about its negative x-axis (i.e., positive values pitch down) at a rate proportional to the control value, if the 
+     *     <tr><td><code>Pitch</code></td><td>number</td><td>number</td><td>Rotate the user's avatar head and attached camera
+     *       about its negative x-axis (i.e., positive values pitch down) at a rate proportional to the control value, if the
      *       camera isn't in HMD, independent, or mirror modes.</td></tr>
-     *     <tr><td><code>Yaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis at a rate 
+     *     <tr><td><code>Yaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis at a rate
      *       proportional to the control value, if the camera isn't in independent or mirror modes.</td></tr>
      *     <tr><td><code>Roll</code></td><td>number</td><td>number</td><td>No action.</td></tr>
-     *     <tr><td><code>DeltaPitch</code></td><td>number</td><td>number</td><td>Rotate the user's avatar head and attached 
-     *       camera about its negative x-axis (i.e., positive values pitch down) by an amount proportional to the control value, 
+     *     <tr><td><code>DeltaPitch</code></td><td>number</td><td>number</td><td>Rotate the user's avatar head and attached
+     *       camera about its negative x-axis (i.e., positive values pitch down) by an amount proportional to the control value,
      *       if the camera isn't in HMD, independent, or mirror modes.</td></tr>
-     *     <tr><td><code>DeltaYaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis by an 
+     *     <tr><td><code>DeltaYaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis by an
      *       amount proportional to the control value, if the camera isn't in independent or mirror modes.</td></tr>
      *     <tr><td><code>DeltaRoll</code></td><td>number</td><td>number</td><td>No action.</td></tr>
      *     <tr><td><code>StepTranslateX</code></td><td>number</td><td>number</td><td>No action.</td></tr>
      *     <tr><td><code>StepTranslateY</code></td><td>number</td><td>number</td><td>No action.</td></tr>
      *     <tr><td><code>StepTranslateZ</code></td><td>number</td><td>number</td><td>No action.</td></tr>
      *     <tr><td><code>StepPitch</code></td><td>number</td><td>number</td><td>No action.</td></tr>
-     *     <tr><td><code>StepYaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis in a 
+     *     <tr><td><code>StepYaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis in a
      *       step increment, if the camera isn't in independent or mirror modes.</td></tr>
      *     <tr><td><code>StepRoll</code></td><td>number</td><td>number</td><td>No action.</td></tr>
      *
@@ -80,91 +80,91 @@ namespace controller {
      *       </td></tr>
      *     <tr><td><code>LeftArm</code></td><td>number</td><td>{@link Pose}</td><td>Set the left arm pose of the user's avatar.
      *       </td></tr>
-     *     <tr><td><code>RightArm</code></td><td>number</td><td>{@link Pose}</td><td>Set the right arm pose of the user's 
+     *     <tr><td><code>RightArm</code></td><td>number</td><td>{@link Pose}</td><td>Set the right arm pose of the user's
      *       avatar.</td></tr>
      *     <tr><td><code>LeftHand</code></td><td>number</td><td>{@link Pose}</td><td>Set the left hand pose of the user's
      *       avatar.</td></tr>
-     *     <tr><td><code>LeftHandThumb1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left thumb 1 finger joint 
+     *     <tr><td><code>LeftHandThumb1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left thumb 1 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandThumb2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left thumb 2 finger joint 
+     *     <tr><td><code>LeftHandThumb2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left thumb 2 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandThumb3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left thumb 3 finger joint 
+     *     <tr><td><code>LeftHandThumb3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left thumb 3 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandThumb4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left thumb 4 finger joint 
+     *     <tr><td><code>LeftHandThumb4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left thumb 4 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandIndex1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left index 1 finger joint 
+     *     <tr><td><code>LeftHandIndex1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left index 1 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandIndex2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left index 2 finger joint 
+     *     <tr><td><code>LeftHandIndex2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left index 2 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandIndex3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left index 3 finger joint 
+     *     <tr><td><code>LeftHandIndex3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left index 3 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandIndex4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left index 4 finger joint 
+     *     <tr><td><code>LeftHandIndex4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left index 4 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandMiddle1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left middle 1 finger joint 
+     *     <tr><td><code>LeftHandMiddle1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left middle 1 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandMiddle2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left middle 2 finger joint 
+     *     <tr><td><code>LeftHandMiddle2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left middle 2 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandMiddle3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left middle 3 finger joint 
+     *     <tr><td><code>LeftHandMiddle3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left middle 3 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandMiddle4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left middle 4 finger joint 
+     *     <tr><td><code>LeftHandMiddle4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left middle 4 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandRing1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left ring 1 finger joint pose 
+     *     <tr><td><code>LeftHandRing1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left ring 1 finger joint pose
      *       of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandRing2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left ring 2 finger joint pose 
+     *     <tr><td><code>LeftHandRing2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left ring 2 finger joint pose
      *       of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandRing3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left ring 3 finger joint pose 
+     *     <tr><td><code>LeftHandRing3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left ring 3 finger joint pose
      *       of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandRing4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left ring 4 finger joint pose 
+     *     <tr><td><code>LeftHandRing4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left ring 4 finger joint pose
      *       of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandPinky1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left pinky 1 finger joint 
+     *     <tr><td><code>LeftHandPinky1</code></td><td>number</td><td>{@link Pose}</td><td>Set the left pinky 1 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandPinky2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left pinky 2 finger joint 
+     *     <tr><td><code>LeftHandPinky2</code></td><td>number</td><td>{@link Pose}</td><td>Set the left pinky 2 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandPinky3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left pinky 3 finger joint 
+     *     <tr><td><code>LeftHandPinky3</code></td><td>number</td><td>{@link Pose}</td><td>Set the left pinky 3 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>LeftHandPinky4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left pinky 4 finger joint 
+     *     <tr><td><code>LeftHandPinky4</code></td><td>number</td><td>{@link Pose}</td><td>Set the left pinky 4 finger joint
      *       pose of the user's avatar.</td></tr>
      *     <tr><td><code>RightHand</code></td><td>number</td><td>{@link Pose}</td><td>Set the right hand of the user's avatar.
      *       </td></tr>
-     *     <tr><td><code>RightHandThumb1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right thumb 1 finger joint 
+     *     <tr><td><code>RightHandThumb1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right thumb 1 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandThumb2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right thumb 2 finger joint 
+     *     <tr><td><code>RightHandThumb2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right thumb 2 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandThumb3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right thumb 3 finger joint 
+     *     <tr><td><code>RightHandThumb3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right thumb 3 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandThumb4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right thumb 4 finger joint 
+     *     <tr><td><code>RightHandThumb4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right thumb 4 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandIndex1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right index 1 finger joint 
+     *     <tr><td><code>RightHandIndex1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right index 1 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandIndex2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right index 2 finger joint 
+     *     <tr><td><code>RightHandIndex2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right index 2 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandIndex3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right index 3 finger joint 
+     *     <tr><td><code>RightHandIndex3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right index 3 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandIndex4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right index 4 finger joint 
+     *     <tr><td><code>RightHandIndex4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right index 4 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandMiddle1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right middle 1 finger 
+     *     <tr><td><code>RightHandMiddle1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right middle 1 finger
      *       joint pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandMiddle2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right middle 2 finger 
+     *     <tr><td><code>RightHandMiddle2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right middle 2 finger
      *       joint pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandMiddle3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right middle 3 finger 
+     *     <tr><td><code>RightHandMiddle3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right middle 3 finger
      *       joint pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandMiddle4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right middle 4 finger 
+     *     <tr><td><code>RightHandMiddle4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right middle 4 finger
      *       joint pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandRing1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right ring 1 finger joint 
+     *     <tr><td><code>RightHandRing1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right ring 1 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandRing2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right ring 2 finger joint 
+     *     <tr><td><code>RightHandRing2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right ring 2 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandRing3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right ring 3 finger joint 
+     *     <tr><td><code>RightHandRing3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right ring 3 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandRing4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right ring 4 finger joint 
+     *     <tr><td><code>RightHandRing4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right ring 4 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandPinky1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right pinky 1 finger joint 
+     *     <tr><td><code>RightHandPinky1</code></td><td>number</td><td>{@link Pose}</td><td>Set the right pinky 1 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandPinky2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right pinky 2 finger joint 
+     *     <tr><td><code>RightHandPinky2</code></td><td>number</td><td>{@link Pose}</td><td>Set the right pinky 2 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandPinky3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right pinky 3 finger joint 
+     *     <tr><td><code>RightHandPinky3</code></td><td>number</td><td>{@link Pose}</td><td>Set the right pinky 3 finger joint
      *       pose of the user's avatar.</td></tr>
-     *     <tr><td><code>RightHandPinky4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right pinky 4 finger joint 
+     *     <tr><td><code>RightHandPinky4</code></td><td>number</td><td>{@link Pose}</td><td>Set the right pinky 4 finger joint
      *       pose of the user's avatar.</td></tr>
      *     <tr><td><code>LeftFoot</code></td><td>number</td><td>{@link Pose}</td><td>Set the left foot pose of the user's
      *       avatar.</td></tr>
@@ -172,11 +172,11 @@ namespace controller {
      *       avatar.</td></tr>
      *
      *     <tr><td colSpan=4><strong>Application</strong></td></tr>
-     *     <tr><td><code>BoomIn</code></td><td>number</td><td>number</td><td>Zoom camera in from third person toward first 
+     *     <tr><td><code>BoomIn</code></td><td>number</td><td>number</td><td>Zoom camera in from third person toward first
      *       person view.</td></tr>
-     *     <tr><td><code>BoomOut</code></td><td>number</td><td>number</td><td>Zoom camera out from first person to third 
+     *     <tr><td><code>BoomOut</code></td><td>number</td><td>number</td><td>Zoom camera out from first person to third
      *       person view.</td></tr>
-     *     <tr><td><code>CycleCamera</code></td><td>number</td><td>number</td><td>Cycle the camera view from first person look 
+     *     <tr><td><code>CycleCamera</code></td><td>number</td><td>number</td><td>Cycle the camera view from first person look
      *       at, to (third person) look at, to selfie if in desktop mode, then back to first person and repeat.</td></tr>
      *     <tr><td><code>ContextMenu</code></td><td>number</td><td>number</td><td>Show/hide the tablet.</td></tr>
      *     <tr><td><code>ToggleMute</code></td><td>number</td><td>number</td><td>Toggle the microphone mute.</td></tr>
@@ -192,30 +192,20 @@ namespace controller {
      *     <tr><td><code>ReticleRight</code></td><td>number</td><td>number</td><td>Move the cursor right.</td></tr>
      *     <tr><td><code>ReticleUp</code></td><td>number</td><td>number</td><td>Move the cursor up.</td></tr>
      *     <tr><td><code>ReticleDown</code></td><td>number</td><td>number</td><td>Move the cursor down.</td></tr>
-     *     <tr><td><code>UiNavLateral</code></td><td>number</td><td>number</td><td>Generate a keyboard left or right arrow key 
+     *     <tr><td><code>UiNavLateral</code></td><td>number</td><td>number</td><td>Generate a keyboard left or right arrow key
      *       event.</td></tr>
-     *     <tr><td><code>UiNavVertical</code></td><td>number</td><td>number</td><td>Generate a keyboard up or down arrow key 
+     *     <tr><td><code>UiNavVertical</code></td><td>number</td><td>number</td><td>Generate a keyboard up or down arrow key
      *       event.</td></tr>
      *     <tr><td><code>UiNavGroup</code></td><td>number</td><td>number</td><td>Generate a keyboard tab or back-tab key event.
      *       </td></tr>
      *     <tr><td><code>UiNavSelect</code></td><td>number</td><td>number</td><td>Generate a keyboard Enter key event.
      *       </td></tr>
      *     <tr><td><code>UiNavBack</code></td><td>number</td><td>number</td><td>Generate a keyboard Esc key event.</td></tr>
-     *     <tr><td><code>LeftHandClick</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>RightHandClick</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>Shift</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>PrimaryAction</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>SecondaryAction</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. It takes no action.</span></td></tr>
      *
      *     <tr><td colSpan=4><strong>Aliases</strong></td></tr>
-     *     <tr><td><code>Backward</code></td><td>number</td><td>number</td><td>Alias for <code>TranslateZ</code> in the 
+     *     <tr><td><code>Backward</code></td><td>number</td><td>number</td><td>Alias for <code>TranslateZ</code> in the
      *       positive direction.</td></tr>
-     *     <tr><td><code>Forward</code></td><td>number</td><td>number</td><td>Alias for <code>TranslateZ</code> in the negative 
+     *     <tr><td><code>Forward</code></td><td>number</td><td>number</td><td>Alias for <code>TranslateZ</code> in the negative
      *       direction.</td></tr>
      *     <tr><td><code>StrafeRight</code></td><td>number</td><td>number</td><td>Alias for <code>TranslateX</code> in the
      *       positive direction.</td></tr>
@@ -223,98 +213,16 @@ namespace controller {
      *       negative direction.</td></tr>
      *     <tr><td><code>Up</code></td><td>number</td><td>number</td><td>Alias for <code>TranslateY</code> in the positive
      *       direction.</td></tr>
-     *     <tr><td><code>Down</code></td><td>number</td><td>number</td><td>Alias for <code>TranslateY</code> in the negative 
+     *     <tr><td><code>Down</code></td><td>number</td><td>number</td><td>Alias for <code>TranslateY</code> in the negative
      *       direction.</td></tr>
-     *     <tr><td><code>PitchDown</code></td><td>number</td><td>number</td><td>Alias for <code>Pitch</code> in the positive 
+     *     <tr><td><code>PitchDown</code></td><td>number</td><td>number</td><td>Alias for <code>Pitch</code> in the positive
      *       direction.</td></tr>
      *     <tr><td><code>PitchUp</code></td><td>number</td><td>number</td><td>Alias for <code>Pitch</code> in the negative
      *       direction.</td></tr>
      *     <tr><td><code>YawLeft</code></td><td>number</td><td>number</td><td>Alias for <code>Yaw</code> in the positive
      *       direction.</td></tr>
-     *     <tr><td><code>YawRight</code></td><td>number</td><td>number</td><td>Alias for <code>Yaw</code> in the negative 
+     *     <tr><td><code>YawRight</code></td><td>number</td><td>number</td><td>Alias for <code>Yaw</code> in the negative
      *       direction.</td></tr>
-     *
-     *     <tr><td colSpan=4><strong>Deprecated Aliases</strong></td></tr>
-     *     <tr><td><code>LEFT_HAND</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>LeftHand</code> instead.</span></td></tr>
-     *     <tr><td><code>RIGHT_HAND</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>RightHand</code> instead.</span></td></tr>
-     *     <tr><td><code>BOOM_IN</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>BoomIn</code> instead.</span></td></tr>
-     *     <tr><td><code>BOOM_OUT</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>BoomOut</code> instead.</span></td></tr>
-     *     <tr><td><code>CONTEXT_MENU</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>ContextMenu</code> instead.</span></td></tr>
-     *     <tr><td><code>TOGGLE_MUTE</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>ToggleMute</code> instead.</span></td></tr>
-     *     <tr><td><code>TOGGLE_PUSHTOTALK</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>TogglePushToTalk</code> instead.</span></td></tr>
-     *     <tr><td><code>SPRINT</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>Sprint</code> instead.</span></td></tr>
-     *     <tr><td><code>LONGITUDINAL_BACKWARD</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>Backward</code> instead.</span></td></tr>
-     *     <tr><td><code>LONGITUDINAL_FORWARD</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>Forward</code> instead.</span></td></tr>
-     *     <tr><td><code>LATERAL_LEFT</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>StrafeLeft</code> instead.</span></td></tr>
-     *     <tr><td><code>LATERAL_RIGHT</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>StrafeRight</code> instead.</span></td></tr>
-     *     <tr><td><code>VERTICAL_UP</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>Up</code> instead.</span></td></tr>
-     *     <tr><td><code>VERTICAL_DOWN</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>Down</code> instead.</span></td></tr>
-     *     <tr><td><code>PITCH_DOWN</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>PitchDown</code> instead.</span></td></tr>
-     *     <tr><td><code>PITCH_UP</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>PitchUp</code> instead.</span></td></tr>
-     *     <tr><td><code>YAW_LEFT</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>YawLeft</code> instead.</span></td></tr>
-     *     <tr><td><code>YAW_RIGHT</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>YawRight</code> instead.</span></td></tr>
-     *     <tr><td><code>LEFT_HAND_CLICK</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>LeftHandClick</code> instead.</span></td></tr>
-     *     <tr><td><code>RIGHT_HAND_CLICK</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>RightHandClick</code> instead.</span></td></tr>
-     *     <tr><td><code>SHIFT</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>Shift</code> instead.</span></td></tr>
-     *     <tr><td><code>ACTION1</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>PrimaryAction</code> instead.</span></td></tr>
-     *     <tr><td><code>ACTION2</code></td><td>number</td><td>number</td><td><span class="important">Deprecated: This 
-     *       action is deprecated and will be removed. Use <code>SecondaryAction</code> instead.</span></td></tr>
-     *
-     *     <tr><td colSpan=4><strong>Deprecated Trackers</strong></td><tr>
-     *     <tr><td><code>TrackedObject00</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject01</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject02</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject03</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject04</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject05</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject06</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject07</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject08</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject09</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject10</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject11</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject12</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject13</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject14</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
-     *     <tr><td><code>TrackedObject15</code></td><td>number</td><td>{@link Pose}</td><td><span class="important">Deprecated: 
-     *       This action is deprecated and will be removed. It takes no action.</span></td></tr>
      *   </tbody>
      * </table>
      * @typedef {object} Controller.Actions

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -123,12 +123,12 @@ namespace controller {
          * // ["Standard","Keyboard","LeapMotion","OculusTouch","Application","Actions"] or similar.
          */
         Q_INVOKABLE QVector<QString> getDeviceNames();
-        
+
         /*@jsdoc
          * Finds the ID of an action from its name.
          * @function Controller.findAction
          * @param {string} actionName - The name of the action: one of the {@link Controller.Actions} property names.
-         * @returns {number} The integer ID of the action if found, otherwise <code>4095</code>. Note that this value is not 
+         * @returns {number} The integer ID of the action if found, otherwise <code>4095</code>. Note that this value is not
          * the same as the value of the relevant {@link Controller.Actions} property.
          * @example <caption>Get the ID of the "TranslateY" action. Compare with the property value.</caption>
          * var actionID = Controller.findAction("TranslateY");
@@ -149,10 +149,10 @@ namespace controller {
         Q_INVOKABLE QVector<QString> getActionNames() const;
 
         /*@jsdoc
-         * Gets the value of a controller button or axis output. Note: Also gets the value of a controller axis output. 
+         * Gets the value of a controller button or axis output. Note: Also gets the value of a controller axis output.
          * @function Controller.getValue
          * @param {number} source - The {@link Controller.Standard} or {@link Controller.Hardware} item.
-         * @returns {number} The current value of the controller item output if <code>source</code> is valid, otherwise 
+         * @returns {number} The current value of the controller item output if <code>source</code> is valid, otherwise
          *     <code>0</code>.
          * @example <caption>Report the Standard and Vive right trigger values.</caption>
          * var triggerValue = Controller.getValue(Controller.Standard.RT);
@@ -171,7 +171,7 @@ namespace controller {
          * Gets the value of a controller axis output. Note: Also gets the value of a controller button output.
          * @function Controller.getAxisValue
          * @param {number} source - The {@link Controller.Standard} or {@link Controller.Hardware} item.
-         * @returns {number} The current value of the controller item output if <code>source</code> is valid, otherwise 
+         * @returns {number} The current value of the controller item output if <code>source</code> is valid, otherwise
          *     <code>0</code>.
          */
         // TODO: getAxisValue() should use const int& parameter? Or others shouldn't?
@@ -181,7 +181,7 @@ namespace controller {
          * Gets the value of a controller pose output.
          * @function Controller.getPoseValue
          * @param {number} source - The {@link Controller.Standard} or {@link Controller.Hardware} pose output.
-         * @returns {Pose} The current value of the controller pose output if <code>source</code> is a pose output, otherwise 
+         * @returns {Pose} The current value of the controller pose output if <code>source</code> is a pose output, otherwise
          *     an invalid pose with <code>Pose.valid == false</code>.
          * @exammple <caption>Report the right hand's pose.</caption>
          * var pose = Controller.getPoseValue(Controller.Standard.RightHand);
@@ -250,11 +250,11 @@ namespace controller {
         Q_INVOKABLE bool triggerShortHapticPulseOnDevice(unsigned int device, float strength, uint16_t index = 2) const;
 
         /*@jsdoc
-         * Creates a new controller mapping. Routes can then be added to the mapping using {@link MappingObject} methods and 
-         * routed to <code>Standard</code> controls, <code>Actions</code>, or script functions using {@link RouteObject} 
+         * Creates a new controller mapping. Routes can then be added to the mapping using {@link MappingObject} methods and
+         * routed to <code>Standard</code> controls, <code>Actions</code>, or script functions using {@link RouteObject}
          * methods. The mapping can then be enabled using {@link Controller.enableMapping|enableMapping} for it to take effect.
          * @function Controller.newMapping
-         * @param {string} [mappingName=Uuid.generate()] - A unique name for the mapping. If not specified a new UUID generated 
+         * @param {string} [mappingName=Uuid.generate()] - A unique name for the mapping. If not specified a new UUID generated
          *     by {@link Uuid(0).generate|Uuid.generate} is used.
          * @returns {MappingObject} A controller mapping object.
          * @example <caption>Create a simple mapping that makes the right trigger move your avatar up.</caption>
@@ -286,7 +286,7 @@ namespace controller {
         Q_INVOKABLE void disableMapping(const QString& mappingName) { enableMapping(mappingName, false); }
 
         /*@jsdoc
-         * Creates a new controller mapping from a {@link Controller.MappingJSON|MappingJSON} string. Use 
+         * Creates a new controller mapping from a {@link Controller.MappingJSON|MappingJSON} string. Use
          * {@link Controller.enableMapping|enableMapping} to enable the mapping for it to take effect.
          * @function Controller.parseMapping
          * @param {string} jsonString - A JSON string of the {@link Controller.MappingJSON|MappingJSON}.
@@ -309,9 +309,9 @@ namespace controller {
         Q_INVOKABLE QObject* parseMapping(const QString& json);
 
         /*@jsdoc
-         * Creates a new controller mapping from a {@link Controller.MappingJSON|MappingJSON} JSON file at a URL. Use 
+         * Creates a new controller mapping from a {@link Controller.MappingJSON|MappingJSON} JSON file at a URL. Use
          * {@link Controller.enableMapping|enableMapping} to enable the mapping for it to take effect.
-         * <p><strong>Warning:</strong> This function is not yet implemented; it doesn't load a mapping and just returns 
+         * <p><strong>Warning:</strong> This function is not yet implemented; it doesn't load a mapping and just returns
          * <code>null</code>.
          * @function Controller.loadMapping
          * @param {string} jsonURL - The URL the {@link Controller.MappingJSON|MappingJSON} JSON file.
@@ -321,7 +321,7 @@ namespace controller {
 
 
         /*@jsdoc
-         * Gets the {@link Controller.Hardware} property tree. Calling this function is the same as using the {@link Controller} 
+         * Gets the {@link Controller.Hardware} property tree. Calling this function is the same as using the {@link Controller}
          * property, <code>Controller.Hardware</code>.
          * @function Controller.getHardware
          * @returns {Controller.Hardware} The {@link Controller.Hardware} property tree.
@@ -329,7 +329,7 @@ namespace controller {
         Q_INVOKABLE const QVariantMap getHardware() { return _hardware; }
 
         /*@jsdoc
-         * Gets the {@link Controller.Actions} property tree. Calling this function is the same as using the {@link Controller} 
+         * Gets the {@link Controller.Actions} property tree. Calling this function is the same as using the {@link Controller}
          * property, <code>Controller.Actions</code>.
          * @function Controller.getActions
          * @returns {Controller.Actions} The {@link Controller.Actions} property tree.
@@ -337,7 +337,7 @@ namespace controller {
         Q_INVOKABLE const QVariantMap getActions() { return _actions; }  //undefined
 
         /*@jsdoc
-         * Gets the {@link Controller.Standard} property tree. Calling this function is the same as using the {@link Controller} 
+         * Gets the {@link Controller.Standard} property tree. Calling this function is the same as using the {@link Controller}
          * property, <code>Controller.Standard</code>.
          * @function Controller.getStandard
          * @returns {Controller.Standard} The {@link Controller.Standard} property tree.
@@ -372,10 +372,10 @@ namespace controller {
         Q_INVOKABLE void stopInputRecording();
 
         /*@jsdoc
-         * Plays back the current recording from the beginning. The current recording may have been recorded by 
-         * {@link Controller.startInputRecording|startInputRecording} and 
-         * {@link Controller.stopInputRecording|stopInputRecording}, or loaded by 
-         * {@link Controller.loadInputRecording|loadInputRecording}. Playback repeats in a loop until 
+         * Plays back the current recording from the beginning. The current recording may have been recorded by
+         * {@link Controller.startInputRecording|startInputRecording} and
+         * {@link Controller.stopInputRecording|stopInputRecording}, or loaded by
+         * {@link Controller.loadInputRecording|loadInputRecording}. Playback repeats in a loop until
          * {@link Controller.stopInputPlayback|stopInputPlayback} is called.
          * @function Controller.startInputPlayback
          * @example <caption>Play back a controller recording.</caption>
@@ -404,7 +404,7 @@ namespace controller {
          * Saves the current recording to a file. The current recording may have been recorded by
          * {@link Controller.startInputRecording|startInputRecording} and
          * {@link Controller.stopInputRecording|stopInputRecording}, or loaded by
-         * {@link Controller.loadInputRecording|loadInputRecording}. It is saved in the directory returned by 
+         * {@link Controller.loadInputRecording|loadInputRecording}. It is saved in the directory returned by
          * {@link Controller.getInputRecorderSaveDirectory|getInputRecorderSaveDirectory}.
          * @function Controller.saveInputRecording
          */
@@ -441,7 +441,7 @@ namespace controller {
     public slots:
 
         /*@jsdoc
-         * Disables processing of mouse "move", "press", "double-press", and "release" events into 
+         * Disables processing of mouse "move", "press", "double-press", and "release" events into
          * {@link Controller.Hardware|Controller.Hardware.Keyboard} outputs.
          * @function Controller.captureMouseEvents
          * @example <caption>Disable Controller.Hardware.Keyboard mouse events for a short period.</caption>
@@ -469,8 +469,8 @@ namespace controller {
         virtual void captureMouseEvents() { _mouseCaptured = true; }
 
         /*@jsdoc
-         * Enables processing of mouse "move", "press", "double-press", and "release" events into 
-         * {@link Controller.Hardware-Keyboard|Controller.Hardware.Keyboard} outputs that were disabled using 
+         * Enables processing of mouse "move", "press", "double-press", and "release" events into
+         * {@link Controller.Hardware-Keyboard|Controller.Hardware.Keyboard} outputs that were disabled using
          * {@link Controller.captureMouseEvents|captureMouseEvents}.
          * @function Controller.releaseMouseEvents
          */
@@ -478,19 +478,19 @@ namespace controller {
 
 
         /*@jsdoc
-         * Disables processing of touch "begin", "update", and "end" events into 
-         * {@link Controller.Hardware|Controller.Hardware.Keyboard}, 
-         * {@link Controller.Hardware|Controller.Hardware.Touchscreen}, and 
+         * Disables processing of touch "begin", "update", and "end" events into
+         * {@link Controller.Hardware|Controller.Hardware.Keyboard},
+         * {@link Controller.Hardware|Controller.Hardware.Touchscreen}, and
          * {@link Controller.Hardware|Controller.Hardware.TouchscreenVirtualPad} outputs.
          * @function Controller.captureTouchEvents
          */
         virtual void captureTouchEvents() { _touchCaptured = true; }
 
         /*@jsdoc
-         * Enables processing of touch "begin", "update", and "end" events into 
-         * {@link Controller.Hardware|Controller.Hardware.Keyboard}, 
-         * {@link Controller.Hardware|Controller.Hardware.Touchscreen}, and 
-         * {@link Controller.Hardware|Controller.Hardware.TouchscreenVirtualPad} outputs that were disabled using 
+         * Enables processing of touch "begin", "update", and "end" events into
+         * {@link Controller.Hardware|Controller.Hardware.Keyboard},
+         * {@link Controller.Hardware|Controller.Hardware.Touchscreen}, and
+         * {@link Controller.Hardware|Controller.Hardware.TouchscreenVirtualPad} outputs that were disabled using
          * {@link Controller.captureTouchEvents|captureTouchEvents}.
          * @function Controller.releaseTouchEvents
          */
@@ -498,14 +498,14 @@ namespace controller {
 
 
         /*@jsdoc
-         * Disables processing of mouse wheel rotation events into {@link Controller.Hardware|Controller.Hardware.Keyboard} 
+         * Disables processing of mouse wheel rotation events into {@link Controller.Hardware|Controller.Hardware.Keyboard}
          * outputs.
          * @function Controller.captureWheelEvents
          */
         virtual void captureWheelEvents() { _wheelCaptured = true; }
 
         /*@jsdoc
-         * Enables processing of mouse wheel rotation events into {@link Controller.Hardware|Controller.Hardware.Keyboard} 
+         * Enables processing of mouse wheel rotation events into {@link Controller.Hardware|Controller.Hardware.Keyboard}
          * outputs that wer disabled using {@link Controller.captureWheelEvents|captureWheelEvents}.
          * @function Controller.releaseWheelEvents
          */
@@ -527,19 +527,13 @@ namespace controller {
         virtual void captureActionEvents() { _actionsCaptured = true; }
 
         /*@jsdoc
-         * Enables translating and rotating the user's avatar in response to keyboard and controller controls that were disabled 
+         * Enables translating and rotating the user's avatar in response to keyboard and controller controls that were disabled
          * using {@link Controller.captureActionEvents|captureActionEvents}.
          * @function Controller.releaseActionEvents
          */
         virtual void releaseActionEvents() { _actionsCaptured = false; }
 
-        /*@jsdoc
-         * @function Controller.updateRunningInputDevices
-         * @param {string} deviceName - Device name.
-         * @param {boolean} isRunning - Is running.
-         * @param {string[]} runningDevices - Running devices.
-         * @deprecated This function is deprecated and will be removed.
-         */
+        // TODO: Deprecated by documentation, please review for accuracy
         void updateRunningInputDevices(const QString& deviceName, bool isRunning, const QStringList& runningDevices);
 
     signals:
@@ -593,8 +587,8 @@ namespace controller {
         void inputEvent(int action, float state);
 
         /*@jsdoc
-         * Triggered when a device is registered or unregistered by a plugin. Not all plugins generate 
-         * <code>hardwareChanged</code> events: for example, connecting or disconnecting a mouse will not generate an event but 
+         * Triggered when a device is registered or unregistered by a plugin. Not all plugins generate
+         * <code>hardwareChanged</code> events: for example, connecting or disconnecting a mouse will not generate an event but
          * connecting or disconnecting an Xbox controller will.
          * @function Controller.hardwareChanged
          * @returns {Signal}
@@ -602,7 +596,7 @@ namespace controller {
         void hardwareChanged();
 
         /*@jsdoc
-         * Triggered when an input device starts or stops being active and running (enabled). For example, enabling or 
+         * Triggered when an input device starts or stops being active and running (enabled). For example, enabling or
          * disabling the LeapMotion in Settings &gt; Controls &gt; Calibration will trigger this signal.
          * @function Controller.inputDeviceRunningChanged
          * @param {string} deviceName - The name of the device.

--- a/libraries/entities/src/EntityDynamicInterface.cpp
+++ b/libraries/entities/src/EntityDynamicInterface.cpp
@@ -101,11 +101,11 @@ variables.  These argument variables are used by the code which is run when bull
  *   </thead>
  *   <tbody>
  *     <tr><td><code>"far-grab"</code></td><td>Avatar action</td>
- *       <td>Moves and rotates an entity to a target position and orientation, optionally relative to another entity. Collisions 
+ *       <td>Moves and rotates an entity to a target position and orientation, optionally relative to another entity. Collisions
  *       between the entity and the user's avatar are disabled during the far-grab.</td>
  *       <td>{@link Entities.ActionArguments-FarGrab}</td></tr>
  *     <tr><td><code>"hold"</code></td><td>Avatar action</td>
- *       <td>Positions and rotates an entity relative to an avatar's hand. Collisions between the entity and the user's avatar 
+ *       <td>Positions and rotates an entity relative to an avatar's hand. Collisions between the entity and the user's avatar
  *       are disabled during the hold.</td>
  *       <td>{@link Entities.ActionArguments-Hold}</td></tr>
  *     <tr><td><code>"offset"</code></td><td>Object action</td>
@@ -121,7 +121,7 @@ variables.  These argument variables are used by the code which is run when bull
  *       <td>Lets an entity pivot about an axis or connects two entities with a hinge joint.</td>
  *       <td>{@link Entities.ActionArguments-Hinge}</td></tr>
  *     <tr><td><code>"slider"</code></td><td>Object constraint</td>
- *       <td>Lets an entity slide and rotate along an axis, or connects two entities that slide and rotate along a shared 
+ *       <td>Lets an entity slide and rotate along an axis, or connects two entities that slide and rotate along a shared
  *       axis.</td>
  *       <td>{@link Entities.ActionArguments-Slider|ActionArguments-Slider}</td></tr>
  *     <tr><td><code>"cone-twist"</code></td><td>Object constraint</td>
@@ -130,8 +130,6 @@ variables.  These argument variables are used by the code which is run when bull
  *     <tr><td><code>"ball-socket"</code></td><td>Object constraint</td>
  *       <td>Connects two entities with a ball and socket joint.</td>
  *       <td>{@link Entities.ActionArguments-BallSocket}</td></tr>
- *     <tr><td><code>"spring"</code></td><td>&nbsp;</td><td>Synonym for <code>"tractor"</code>. 
- *       <p class="important">Deprecated.</p></td><td>&nbsp;</td></tr>
  *   </tbody>
  * </table>
  * @typedef {string} Entities.ActionType

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -733,8 +733,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  *     to an entity's motion only if its <code>dynamic</code> property is <code>true</code>.
  *     <p>If changing an entity's <code>gravity</code> from {@link Vec3(0)|Vec3.ZERO}, you need to give it a small
  *     <code>velocity</code> in order to kick off physics simulation.</p>
- * @property {Vec3} acceleration - The current, measured acceleration of the entity, in m/s<sup>2</sup>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @property {number} restitution=0.5 - The "bounciness" of an entity when it collides, range <code>0.0</code> &ndash;
  *     <code>0.99</code>. The higher the value, the more bouncy.
  * @property {number} friction=0.5 - How much an entity slows down when it's moving against another, range <code>0.0</code>
@@ -885,34 +883,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  */
 
 /*@jsdoc
- * The <code>"Line"</code> {@link Entities.EntityType|EntityType} draws thin, straight lines between a sequence of two or more
- * points. It has properties in addition to the common {@link Entities.EntityProperties|EntityProperties}.
- * <p class=important>Deprecated: Use {@link Entities.EntityProperties-PolyLine|PolyLine} entities instead.</p>
- *
- * @typedef {object} Entities.EntityProperties-Line
- * @property {Vec3} dimensions=0.1,0.1,0.1 - The dimensions of the entity. Must be sufficient to contain all the
- *     <code>linePoints</code>.
- * @property {Vec3[]} linePoints=[]] - The sequence of points to draw lines between. The values are relative to the entity's
- *     position. A maximum of 70 points can be specified. The property's value is set only if all the <code>linePoints</code>
- *     lie within the entity's <code>dimensions</code>.
- * @property {Color} color=255,255,255 - The color of the line.
- * @example <caption>Draw lines in a "V".</caption>
- * var entity = Entities.addEntity({
- *     type: "Line",
- *     position: Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 0.75, z: -5 })),
- *     rotation: MyAvatar.orientation,
- *     dimensions: { x: 2, y: 2, z: 1 },
- *     linePoints: [
- *         { x: -1, y: 1, z: 0 },
- *         { x: 0, y: -1, z: 0 },
- *         { x: 1, y: 1, z: 0 },
- *     ],
- *     color: { red: 255, green: 0, blue: 0 },
- *     lifetime: 300  // Delete after 5 minutes.
- * });
- */
-
-/*@jsdoc
  * The <code>"Material"</code> {@link Entities.EntityType|EntityType} modifies existing materials on entities and avatars. It
  * has properties in addition to the common {@link Entities.EntityProperties|EntityProperties}.
  * <p>To apply a material to an entity, set the material entity's <code>parentID</code> property to the entity ID.
@@ -992,8 +962,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @property {string} modelURL="" - The URL of the glTF, FBX, or OBJ model. glTF models may be in JSON or binary format
  *     (".gltf" or ".glb" URLs respectively). Baked models' URLs have ".baked" before the file type. Model files may also be
  *     compressed in GZ format, in which case the URL ends in ".gz".
- * @property {Vec3} modelScale - The scale factor applied to the model's dimensions.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @property {string} blendshapeCoefficients - A JSON string of a map of blendshape names to values.  Only stores set values.
  *     When editing this property, only coefficients that you are editing will change; it will not explicitly reset other
  *     coefficients.
@@ -1134,8 +1102,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @property {number} alphaSpread=0 - The spread in alpha that each particle is given. For example, if
  *     <code>alpha == 0.5</code> and <code>alphaSpread == 0.25</code>, each particle will have an alpha in the range
  *     <code>0.25</code> &ndash; <code>0.75</code>.
- * @property {Entities.Pulse} pulse - Color and alpha pulse.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @property {number} particleSpin=0 - The rotation of each particle at the middle of its life, range <code>-2 * Math.PI</code>
  *     &ndash; <code>2 * Math.PI</code> radians.
  * @property {number} spinStart=null - The rotation of each particle at the start of its life, range <code>-2 * Math.PI</code>
@@ -1283,8 +1249,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @property {Vec3} dimensions=0.1,0.1,0.1 - The dimensions of the entity.
  * @property {Color} color=255,255,255 - The color of the entity.
  * @property {number} alpha=1 - The opacity of the entity, range <code>0.0</code> &ndash; <code>1.0</code>.
- * @property {Entities.Pulse} pulse - Color and alpha pulse.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @example <caption>Create a cylinder.</caption>
  * var shape = Entities.addEntity({
  *     type: "Shape",
@@ -1319,8 +1283,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @property {number} textAlpha=1.0 - The opacity of the text.
  * @property {Color} backgroundColor=0,0,0 - The color of the background rectangle.
  * @property {number} backgroundAlpha=1.0 - The opacity of the background.
- * @property {Entities.Pulse} pulse - Color and alpha pulse.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @property {number} leftMargin=0.0 - The left margin, in meters.
  * @property {number} rightMargin=0.0 - The right margin, in meters.
  * @property {number} topMargin=0.0 - The top margin, in meters.
@@ -1333,13 +1295,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @property {Color} textEffectColor=255,255,255 - The color of the effect.
  * @property {number} textEffectThickness=0.2 - The magnitude of the text effect, range <code>0.0</code> &ndash; <code>0.5</code>.
  * @property {Entities.TextAlignment} alignment="left" - How the text is aligned against its background.
- * @property {boolean} faceCamera - <code>true</code> if <code>billboardMode</code> is <code>"yaw"</code>, <code>false</code>
- *     if it isn't. Setting this property to <code>false</code> sets the <code>billboardMode</code> to <code>"none"</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} isFacingAvatar - <code>true</code> if <code>billboardMode</code> is <code>"full"</code>,
- *     <code>false</code> if it isn't. Setting this property to <code>false</code> sets the <code>billboardMode</code> to
- *     <code>"none"</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @example <caption>Create a text entity.</caption>
  * var text = Entities.addEntity({
  *     type: "Text",
@@ -1367,15 +1322,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  *     colors on the web page are multiplied by the property color. For example, a value of
  *     <code>{ red: 255, green: 0, blue: 0 }</code> lets only the red channel of pixels' colors through.
  * @property {number} alpha=1 - The opacity of the web surface.
- * @property {Entities.Pulse} pulse - Color and alpha pulse.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} faceCamera - <code>true</code> if <code>billboardMode</code> is <code>"yaw"</code>, <code>false</code>
- *     if it isn't. Setting this property to <code>false</code> sets the <code>billboardMode</code> to <code>"none"</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} isFacingAvatar - <code>true</code> if <code>billboardMode</code> is <code>"full"</code>,
- *     <code>false</code> if it isn't. Setting this property to <code>false</code> sets the <code>billboardMode</code> to
- *     <code>"none"</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @property {number} dpi=30 - The resolution to display the page at, in dots per inch. If you convert this to dots per meter
  *     (multiply by 1 / 0.0254 = 39.3701) then multiply <code>dimensions.x</code> and <code>dimensions.y</code> by that value
  *     you get the resolution in pixels.
@@ -1487,16 +1433,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @property {Rect} subImage=0,0,0,0 - The portion of the image to display. If width or height are <code>0</code>, it defaults
  *     to the full image in that dimension.
  * @property {Color} color=255,255,255 - The color of the image.
- * @property {number} alpha=1 - The opacity of the image.
- * @property {Entities.Pulse} pulse - Color and alpha pulse.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} faceCamera - <code>true</code> if <code>billboardMode</code> is <code>"yaw"</code>, <code>false</code>
- *     if it isn't. Setting this property to <code>false</code> sets the <code>billboardMode</code> to <code>"none"</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} isFacingAvatar - <code>true</code> if <code>billboardMode</code> is <code>"full"</code>,
- *     <code>false</code> if it isn't. Setting this property to <code>false</code> sets the <code>billboardMode</code> to
- *     <code>"none"</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @example <caption>Create an image entity.</caption>
  * var image = Entities.addEntity({
  *     type: "Image",
@@ -1515,9 +1451,6 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @typedef {object} Entities.EntityProperties-Grid
  * @property {Vec3} dimensions - 0.1,0.1,0.01 - The dimensions of the entity.
  * @property {Color} color=255,255,255 - The color of the grid.
- * @property {number} alpha=1 - The opacity of the grid.
- * @property {Entities.Pulse} pulse - Color and alpha pulse.
- *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  * @property {boolean} followCamera=true - <code>true</code> if the grid is always visible even as the camera moves to another
  *     position, <code>false</code> if it doesn't follow the camrmea.
  * @property {number} majorGridEvery=5 - Integer number of <code>minorGridEvery</code> intervals at which to draw a thick grid

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -68,7 +68,7 @@ private:
 /*@jsdoc
  * The result of a {@link Entities.findRayIntersection|findRayIntersection} search using a {@link PickRay}.
  * @typedef {object} Entities.RayToEntityIntersectionResult
- * @property {boolean} intersects - <code>true</code> if the {@link PickRay} intersected an entity, <code>false</code> if it 
+ * @property {boolean} intersects - <code>true</code> if the {@link PickRay} intersected an entity, <code>false</code> if it
  *     didn't.
  * @property {boolean} accurate - Is always <code>true</code>.
  * @property {Uuid} entityID - The ID if the entity intersected, if any, otherwise <code>null</code>.
@@ -76,8 +76,8 @@ private:
  * @property {Vec3} intersection - The intersection point.
  * @property {Vec3} surfaceNormal - The surface normal of the entity at the intersection point.
  * @property {BoxFace} face - The face of the entity's axis-aligned box that the ray intersects.
- * @property {object} extraInfo - Extra information depending on the entity intersected. Currently, only <code>Model</code> 
- *     entities provide extra information, and the information provided depends on the <code>precisionPicking</code> parameter 
+ * @property {object} extraInfo - Extra information depending on the entity intersected. Currently, only <code>Model</code>
+ *     entities provide extra information, and the information provided depends on the <code>precisionPicking</code> parameter
  *     value that the search function was called with.
  */
 // "accurate" is currently always true because the ray intersection is always performed with an Octree::Lock.
@@ -110,26 +110,26 @@ public:
 };
 
 /*@jsdoc
- * The <code>Entities</code> API provides facilities to create and interact with entities. Entities are 2D or 3D objects 
- * displayed in-world. Depending on their {@link Entities.EntityHostType|EntityHostType}, they may persist in the domain as 
- * "domain" entities, travel to different domains with a user as "avatar" entities, or be visible only to an individual user as 
+ * The <code>Entities</code> API provides facilities to create and interact with entities. Entities are 2D or 3D objects
+ * displayed in-world. Depending on their {@link Entities.EntityHostType|EntityHostType}, they may persist in the domain as
+ * "domain" entities, travel to different domains with a user as "avatar" entities, or be visible only to an individual user as
  * "local" entities (a.k.a. "overlays").
  *
- * <p>Note: For Interface, avatar, and client entity scripts, the entities available to scripts are those that Interface has 
- * displayed and so knows about. For assignment client scripts, the entities available are those that are "seen" by the 
+ * <p>Note: For Interface, avatar, and client entity scripts, the entities available to scripts are those that Interface has
+ * displayed and so knows about. For assignment client scripts, the entities available are those that are "seen" by the
  * {@link EntityViewer}. For entity server scripts, all entities are available.</p>
  *
  * <h3>Entity Types & Properties</h3>
  *
  * <p>For a list of the entity types that you can use, see {@link Entities.EntityType|Entity Types}.</p>
- * 
+ *
  * <p>For the properties of the different entity types, see {@link Entities.EntityProperties|Entity Properties}. Some properties are universal to all entity types, and some are specific to particular entity types.</p>
  *
  * <h3>Entity Methods</h3>
  *
- * <p>Some of the API's signals correspond to entity methods that are called, if present, in the entity being interacted with. 
- * The client or server entity script must expose them as a property. However, unlike {@link Entities.callEntityMethod}, server 
- * entity scripts do not need to list them in an <code>remotelyCallable</code> property. The entity methods are called with 
+ * <p>Some of the API's signals correspond to entity methods that are called, if present, in the entity being interacted with.
+ * The client or server entity script must expose them as a property. However, unlike {@link Entities.callEntityMethod}, server
+ * entity scripts do not need to list them in an <code>remotelyCallable</code> property. The entity methods are called with
  * parameters per their corresponding signal.</p>
  * <table>
  *   <thead>
@@ -147,8 +147,6 @@ public:
  *     <tr><td><code>leaveEntity</code></td><td>{@link Entities.leaveEntity}</td></tr>
  *     <tr><td><code>mouseDoublePressOnEntity</code></td><td>{@link Entities.mouseDoublePressOnEntity}</td></tr>
  *     <tr><td><code>mouseMoveOnEntity</code></td><td>{@link Entities.mouseMoveOnEntity}</td></tr>
- *     <tr><td><code>mouseMoveEvent</code></td><td><span class="important">Deprecated: Use <code>mouseMoveOnEntity</code> 
- *       instead.</span></td></tr>
  *     <tr><td><code>mousePressOnEntity</code></td><td>{@link Entities.mousePressOnEntity}</td></tr>
  *     <tr><td><code>mouseReleaseOnEntity</code></td><td>{@link Entities.mouseReleaseOnEntity}</td></tr>
  *   </tbody>
@@ -163,8 +161,8 @@ public:
  * @hifi-server-entity
  * @hifi-assignment-client
  *
- * @property {Uuid} keyboardFocusEntity -  The {@link Entities.EntityProperties-Web|Web} entity that has keyboard focus. If no 
- *     Web entity has keyboard focus, returns <code>null</code>; set to <code>null</code> or {@link Uuid(0)|Uuid.NULL} to clear 
+ * @property {Uuid} keyboardFocusEntity -  The {@link Entities.EntityProperties-Web|Web} entity that has keyboard focus. If no
+ *     Web entity has keyboard focus, returns <code>null</code>; set to <code>null</code> or {@link Uuid(0)|Uuid.NULL} to clear
  *     keyboard focus.
  */
 /// handles scripting of Entity commands from JS passed to assigned clients
@@ -204,11 +202,11 @@ public:
      * Gets the properties of multiple entities.
      * @function Entities.getMultipleEntityProperties
      * @param {Uuid[]} entityIDs - The IDs of the entities to get the properties of.
-     * @param {string[]|string} [desiredProperties=[]] - The name or names of the properties to get. For properties that are 
-     *     objects (e.g., the <code>"keyLight"</code> property), use the property and subproperty names in dot notation (e.g., 
+     * @param {string[]|string} [desiredProperties=[]] - The name or names of the properties to get. For properties that are
+     *     objects (e.g., the <code>"keyLight"</code> property), use the property and subproperty names in dot notation (e.g.,
      *     <code>"keyLight.color"</code>).
-     * @returns {Entities.EntityProperties[]} The specified properties of each entity for each entity that can be found. If 
-     *     none of the entities can be found, then an empty array is returned. If no properties are specified, then all 
+     * @returns {Entities.EntityProperties[]} The specified properties of each entity for each entity that can be found. If
+     *     none of the entities can be found, then an empty array is returned. If no properties are specified, then all
      *     properties are returned.
      * @example <caption>Retrieve the names of the nearby entities</caption>
      * var SEARCH_RADIUS = 50; // meters
@@ -227,7 +225,7 @@ public slots:
      * Checks whether or not the script can change the <code>locked</code> property of entities. Locked entities have their
      * <code>locked</code> property set to <code>true</code> and cannot be edited or deleted.
      * @function Entities.canAdjustLocks
-     * @returns {boolean} <code>true</code> if the domain server will allow the script to change the <code>locked</code> 
+     * @returns {boolean} <code>true</code> if the domain server will allow the script to change the <code>locked</code>
      *     property of entities, otherwise <code>false</code>.
      * @example <caption>Lock an entity if you can.</caption>
      * if (Entities.canAdjustLocks()) {
@@ -241,13 +239,13 @@ public slots:
     /*@jsdoc
      * Checks whether or not the script can rez (create) new entities in the domain.
      * @function Entities.canRez
-     * @returns {boolean} <code>true</code> if the domain server will allow the script to rez (create) new entities, otherwise 
+     * @returns {boolean} <code>true</code> if the domain server will allow the script to rez (create) new entities, otherwise
      *     <code>false</code>.
      */
     Q_INVOKABLE bool canRez();
 
     /*@jsdoc
-     * Checks whether or not the script can rez (create) new temporary entities in the domain. Temporary entities are entities 
+     * Checks whether or not the script can rez (create) new temporary entities in the domain. Temporary entities are entities
      * with a finite <code>lifetime</code> property value set.
      * @function Entities.canRezTmp
      * @returns {boolean} <code>true</code> if the domain server will allow the script to rez (create) new temporary entities,
@@ -258,7 +256,7 @@ public slots:
     /*@jsdoc
      * Checks whether or not the script can make changes to the asset server's assets.
      * @function Entities.canWriteAssets
-     * @returns {boolean} <code>true</code> if the domain server will allow the script to make changes to the asset server's 
+     * @returns {boolean} <code>true</code> if the domain server will allow the script to make changes to the asset server's
      *     assets, otherwise <code>false</code>.
      */
     Q_INVOKABLE bool canWriteAssets();
@@ -266,7 +264,7 @@ public slots:
     /*@jsdoc
      * Checks whether or not the script can replace the domain's content set.
      * @function Entities.canReplaceContent
-     * @returns {boolean} <code>true</code> if the domain server will allow the script to replace the domain's content set, 
+     * @returns {boolean} <code>true</code> if the domain server will allow the script to replace the domain's content set,
      *     otherwise <code>false</code>.
      */
     Q_INVOKABLE bool canReplaceContent();
@@ -274,11 +272,11 @@ public slots:
     /*@jsdoc
      * Checks whether or not the script can get and set the <code>privateUserData</code> property of entities.
      * @function Entities.canGetAndSetPrivateUserData
-     * @returns {boolean} <code>true</code> if the domain server will allow the script to get and set the 
+     * @returns {boolean} <code>true</code> if the domain server will allow the script to get and set the
      *     <code>privateUserData</code> property of entities, otherwise <code>false</code>.
      */
     Q_INVOKABLE bool canGetAndSetPrivateUserData();
-    
+
     /*@jsdoc
      * Checks whether or not the script can rez avatar entities.
      * @function Entities.canRezAvatarEntities
@@ -294,14 +292,14 @@ public slots:
      *     <tr><th>Value</th><th>Description</th></tr>
      *   </thead>
      *   <tbody>
-     *     <tr><td><code>"domain"</code></td><td>Domain entities are stored on the domain, are visible to everyone, and are 
+     *     <tr><td><code>"domain"</code></td><td>Domain entities are stored on the domain, are visible to everyone, and are
      *       sent to everyone by the entity server.</td></tr>
-     *     <tr><td><code>"avatar"</code></td><td>Avatar entities are stored on an Interface client, are visible to everyone, 
-     *       and are sent to everyone by the avatar mixer. They follow the client to each domain visited, displaying at the 
+     *     <tr><td><code>"avatar"</code></td><td>Avatar entities are stored on an Interface client, are visible to everyone,
+     *       and are sent to everyone by the avatar mixer. They follow the client to each domain visited, displaying at the
      *       same domain coordinates unless parented to the client's avatar.</td></tr>
-     *     <tr><td><code>"local"</code></td><td>Local entities are ephemeral &mdash; they aren't stored anywhere &mdash; and 
-     *       are visible only to the client. They follow the client to each domain visited, displaying at the same domain 
-     *       coordinates unless parented to the client's avatar. Additionally, local entities are always 
+     *     <tr><td><code>"local"</code></td><td>Local entities are ephemeral &mdash; they aren't stored anywhere &mdash; and
+     *       are visible only to the client. They follow the client to each domain visited, displaying at the same domain
+     *       coordinates unless parented to the client's avatar. Additionally, local entities are always
      *       collisionless.</td></tr>
      *   </tbody>
      * </table>
@@ -313,7 +311,7 @@ public slots:
      * @function Entities.addEntity
      * @param {Entities.EntityProperties} properties - The properties of the entity to create.
      * @param {Entities.EntityHostType} [entityHostType="domain"] - The type of entity to create.
-     
+
      * @returns {Uuid} The ID of the entity if successfully created, otherwise {@link Uuid(0)|Uuid.NULL}.
      * @example <caption>Create a box domain entity in front of your avatar.</caption>
      * var entityID = Entities.addEntity({
@@ -338,12 +336,12 @@ public slots:
     }
 
     /*@jsdoc
-     * Adds a new avatar entity (<code>{@link Entities.EntityProperties|entityHostType}</code> property is 
-     * <code>"avatar"</code>) or domain entity (<code>{@link Entities.EntityProperties|entityHostType}</code> property is 
+     * Adds a new avatar entity (<code>{@link Entities.EntityProperties|entityHostType}</code> property is
+     * <code>"avatar"</code>) or domain entity (<code>{@link Entities.EntityProperties|entityHostType}</code> property is
      * <code>"domain"</code>).
      * @function Entities.addEntity
      * @param {Entities.EntityProperties} properties - The properties of the entity to create.
-     * @param {boolean} [avatarEntity=false] - <code>true</code> to create an avatar entity, <code>false</code> to create a 
+     * @param {boolean} [avatarEntity=false] - <code>true</code> to create an avatar entity, <code>false</code> to create a
      *     domain entity.
      * @returns {Uuid} The ID of the entity if successfully created, otherwise {@link Uuid(0)|Uuid.NULL}.
      */
@@ -361,11 +359,11 @@ public slots:
     /*@jsdoc
      * Creates a clone of an entity. The clone has the same properties as the original except that: it has a modified
      * <code>name</code> property, clone-related properties are set per the original entity's clone-related
-     * {@link Entities.EntityProperties|properties} (e.g., <code>cloneLifetime</code>), and its clone-related properties are 
+     * {@link Entities.EntityProperties|properties} (e.g., <code>cloneLifetime</code>), and its clone-related properties are
      * set to their defaults.
-     * <p>Domain entities must have their <code>cloneable</code> property value be <code>true</code> in order to be cloned. A 
+     * <p>Domain entities must have their <code>cloneable</code> property value be <code>true</code> in order to be cloned. A
      * domain entity can be cloned by a client that doesn't have rez permissions in the domain.</p>
-     * <p>Avatar entities must have their <code>cloneable</code> and <code>cloneAvatarEntity</code> property values be 
+     * <p>Avatar entities must have their <code>cloneable</code> and <code>cloneAvatarEntity</code> property values be
      * <code>true</code> in order to be cloned.</p>
      * @function Entities.cloneEntity
      * @param {Uuid} entityID - The ID of the entity to clone.
@@ -377,10 +375,10 @@ public slots:
      * Gets an entity's property values.
      * @function Entities.getEntityProperties
      * @param {Uuid} entityID - The ID of the entity to get the properties of.
-     * @param {string|string[]} [desiredProperties=[]] - The name or names of the properties to get. For properties that are 
-     *     objects (e.g., the <code>"keyLight"</code> property), use the property and subproperty names in dot notation (e.g., 
+     * @param {string|string[]} [desiredProperties=[]] - The name or names of the properties to get. For properties that are
+     *     objects (e.g., the <code>"keyLight"</code> property), use the property and subproperty names in dot notation (e.g.,
      *     <code>"keyLight.color"</code>).
-     * @returns {Entities.EntityProperties} The specified properties of the entity if the entity can be found, otherwise an 
+     * @returns {Entities.EntityProperties} The specified properties of the entity if the entity can be found, otherwise an
      *     empty object. If no properties are specified, then all properties are returned.
      * @example <caption>Report the color of a new box entity.</caption>
      * var entityID = Entities.addEntity({
@@ -452,7 +450,7 @@ public slots:
     Q_INVOKABLE QString getEntityType(const QUuid& entityID);
 
     /*@jsdoc
-     * Gets an entity's script object. In particular, this is useful for accessing a {@link Entities.EntityProperties-Web|Web} 
+     * Gets an entity's script object. In particular, this is useful for accessing a {@link Entities.EntityProperties-Web|Web}
      * entity's HTML <code>EventBridge</code> script object to exchange messages with the web page script.
      * <p>To send a message from an Interface script to a Web entity over its event bridge:</p>
      * <pre class="prettyprint"><code>var entityObject = Entities.getEntityObject(entityID);
@@ -481,9 +479,9 @@ public slots:
      *             // Message received from the script.
      *             console.log("Message received: " + message);
      *         }
-     *    
+     *
      *         EventBridge.scriptEventReceived.connect(onScriptEventReceived);
-     *    
+     *
      *         setTimeout(function () {
      *             // Send a message to the script.
      *             EventBridge.emitWebEvent("hello");
@@ -491,7 +489,7 @@ public slots:
      *     </script>
      * </body>
      * </html>
-     * 
+     *
      * // Interface script file.
      * var webEntity = Entities.addEntity({
      *     type: "Web",
@@ -503,7 +501,7 @@ public slots:
      * });
      *
      * var webEntityObject;
-     * 
+     *
      * function onWebEventReceived(message) {
      *     // Message received.
      *     print("Message received: " + message);
@@ -511,12 +509,12 @@ public slots:
      *     // Send a message back.
      *     webEntityObject.emitScriptEvent(message + " back");
      * }
-     * 
+     *
      * Script.setTimeout(function () {
      *     webEntityObject = Entities.getEntityObject(webEntity);
      *     webEntityObject.webEventReceived.connect(onWebEventReceived);
      * }, 500);
-     * 
+     *
      * Script.scriptEnding.connect(function () {
      *     Entities.deleteEntity(webEntity);
      * });
@@ -541,7 +539,7 @@ public slots:
     Q_INVOKABLE bool isAddedEntity(const QUuid& id);
 
     /*@jsdoc
-     * Calculates the size of some text in a {@link Entities.EntityProperties-Text|Text} entity. The entity need not be set 
+     * Calculates the size of some text in a {@link Entities.EntityProperties-Text|Text} entity. The entity need not be set
      * visible.
      * <p><strong>Note:</strong> The size of text in a Text entity cannot be calculated immediately after the
      * entity is created; a short delay is required while the entity finishes being created.</p>
@@ -554,13 +552,13 @@ public slots:
     Q_INVOKABLE QSizeF textSize(const QUuid& id, const QString& text);
 
     /*@jsdoc
-     * Calls a method in a client entity script from an Interface, avatar, or client entity script, or calls a method in a 
-     * server entity script from a server entity script. The entity script method must be exposed as a property in the target 
-     * entity script. Additionally, if calling a server entity script, the server entity script must include the method's name 
+     * Calls a method in a client entity script from an Interface, avatar, or client entity script, or calls a method in a
+     * server entity script from a server entity script. The entity script method must be exposed as a property in the target
+     * entity script. Additionally, if calling a server entity script, the server entity script must include the method's name
      * in an exposed property called <code>remotelyCallable</code> that is an array of method names that can be called.
      * @function Entities.callEntityMethod
      * @param {Uuid} entityID - The ID of the entity to call the method in.
-     * @param {string} method - The name of the method to call. The method is called with the entity ID as the first parameter 
+     * @param {string} method - The name of the method to call. The method is called with the entity ID as the first parameter
      *     and the <code>parameters</code> value as the second parameter.
      * @param {string[]} [parameters=[]] - The additional parameters to call the specified method with.
      * @example <caption>Call a method in a client entity script from an Interface script.</caption>
@@ -570,7 +568,7 @@ public slots:
      *         print("Method at entity : " + id + " ; " + params[0] + ", " + params[1]);
      *     };
      * });
-     * 
+     *
      * // Entity that hosts the client entity script.
      * var entityID = Entities.addEntity({
      *     type: "Box",
@@ -579,7 +577,7 @@ public slots:
      *     script: "(" + entityScript + ")",  // Could host the script on a Web server instead.
      *     lifetime: 300  // Delete after 5 minutes.
      * });
-     * 
+     *
      * // Interface script call to the client entity script.
      * Script.setTimeout(function () {
      *     Entities.callEntityMethod(entityID, "entityMethod", ["hello", 12]);
@@ -588,13 +586,13 @@ public slots:
     Q_INVOKABLE void callEntityMethod(const QUuid& entityID, const QString& method, const QStringList& params = QStringList());
 
     /*@jsdoc
-     * Calls a method in a server entity script from an Interface, avatar, or client entity script. The server entity script 
-     * method must be exposed as a property in the target server entity script. Additionally, the server entity script must 
-     * include the method's name in an exposed property called <code>remotelyCallable</code> that is an array of method names 
+     * Calls a method in a server entity script from an Interface, avatar, or client entity script. The server entity script
+     * method must be exposed as a property in the target server entity script. Additionally, the server entity script must
+     * include the method's name in an exposed property called <code>remotelyCallable</code> that is an array of method names
      * that can be called.
      * @function Entities.callEntityServerMethod
      * @param {Uuid} entityID - The ID of the entity to call the method in.
-     * @param {string} method - The name of the method to call. The method is called with the entity ID as the first parameter 
+     * @param {string} method - The name of the method to call. The method is called with the entity ID as the first parameter
      *     and the <code>parameters</code> value as the second parameter.
      * @param {string[]} [parameters=[]] - The additional parameters to call the specified method with.
      * @example <caption>Call a method in a server entity script from an Interface script.</caption>
@@ -607,7 +605,7 @@ public slots:
      *         "entityMethod"
      *     ];
      * });
-     * 
+     *
      * // Entity that hosts the server entity script.
      * var entityID = Entities.addEntity({
      *     type: "Box",
@@ -616,7 +614,7 @@ public slots:
      *     serverScripts: "(" + entityScript + ")",  // Could host the script on a Web server instead.
      *     lifetime: 300  // Delete after 5 minutes.
      * });
-     * 
+     *
      * // Interface script call to the server entity script.
      * Script.setTimeout(function () {
      *     Entities.callEntityServerMethod(entityID, "entityMethod", ["hello", 12]);
@@ -626,13 +624,13 @@ public slots:
 
     /*@jsdoc
      * Calls a method in a specific user's client entity script from a server entity script. The entity script method must be
-     * exposed as a property in the target client entity script. Additionally, the client entity script must 
-     * include the method's name in an exposed property called <code>remotelyCallable</code> that is an array of method names 
+     * exposed as a property in the target client entity script. Additionally, the client entity script must
+     * include the method's name in an exposed property called <code>remotelyCallable</code> that is an array of method names
      * that can be called.
      * @function Entities.callEntityClientMethod
      * @param {Uuid} clientSessionID - The session ID of the user to call the method in.
      * @param {Uuid} entityID - The ID of the entity to call the method in.
-     * @param {string} method - The name of the method to call. The method is called with the entity ID as the first parameter 
+     * @param {string} method - The name of the method to call. The method is called with the entity ID as the first parameter
      *     and the <code>parameters</code> value as the second parameter.
      * @param {string[]} [parameters=[]] - The additional parameters to call the specified method with.
      * @example <caption>Call a method in a client entity script from a server entity script.</caption>
@@ -645,17 +643,17 @@ public slots:
      *         "entityMethod"
      *     ];
      * });
-     * 
+     *
      * // Server entity script.
      * var serverEntityScript = (function () {
      *     var clientSessionID,
      *         clientEntityID;
-     * 
+     *
      *     function callClientMethod() {
      *         // Server entity script call to client entity script.
      *         Entities.callEntityClientMethod(clientSessionID, clientEntityID, "entityMethod", ["hello", 12]);
      *     }
-     * 
+     *
      *     // Obtain client entity details then call client entity method.
      *     this.entityMethod = function (id, params) {
      *         clientSessionID = params[0];
@@ -666,7 +664,7 @@ public slots:
      *         "entityMethod"
      *     ];
      * });
-     * 
+     *
      * // Entity that hosts the client entity script.
      * var clientEntityID = Entities.addEntity({
      *     type: "Box",
@@ -675,7 +673,7 @@ public slots:
      *     script: "(" + clientEntityScript + ")",  // Could host the script on a Web server instead.
      *     lifetime: 300  // Delete after 5 minutes.
      * });
-     * 
+     *
      * // Entity that hosts the server entity script.
      * var serverEntityID = Entities.addEntity({
      *     type: "Box",
@@ -684,7 +682,7 @@ public slots:
      *     serverScripts: "(" + serverEntityScript + ")",  // Could host the script on a Web server instead.
      *     lifetime: 300  // Delete after 5 minutes.
      * });
-     * 
+     *
      * // Interface script call to the server entity script.
      * Script.setTimeout(function () {
      *     Entities.callEntityServerMethod(serverEntityID, "entityMethod", [MyAvatar.sessionUUID, clientEntityID]);
@@ -714,7 +712,7 @@ public slots:
      * @function Entities.findEntities
      * @param {Vec3} center - The point about which to search.
      * @param {number} radius - The radius within which to search.
-     * @returns {Uuid[]} An array of entity IDs that intersect the search sphere. The array is empty if no entities could be 
+     * @returns {Uuid[]} An array of entity IDs that intersect the search sphere. The array is empty if no entities could be
      *     found.
      * @example <caption>Report how many entities are within 10m of your avatar.</caption>
      * var entityIDs = Entities.findEntities(MyAvatar.position, 10);
@@ -741,10 +739,10 @@ public slots:
      * <p><strong>Note:</strong> Server entity scripts only find entities that have a server entity script
      * running in them or a parent entity. You can apply a dummy script to entities that you want found in a search.</p>
      * @function Entities.findEntitiesInFrustum
-     * @param {ViewFrustum} frustum - The frustum to search in. The <code>position</code>, <code>orientation</code>, 
-     *     <code>projection</code>, and <code>centerRadius</code> properties must be specified. The <code>fieldOfView</code> 
+     * @param {ViewFrustum} frustum - The frustum to search in. The <code>position</code>, <code>orientation</code>,
+     *     <code>projection</code>, and <code>centerRadius</code> properties must be specified. The <code>fieldOfView</code>
      *     and <code>aspectRatio</code> properties are not used; these values are specified by the <code>projection</code>.
-     * @returns {Uuid[]} An array of entity IDs whose axis-aligned boxes intersect the search frustum. The array is empty if no 
+     * @returns {Uuid[]} An array of entity IDs whose axis-aligned boxes intersect the search frustum. The array is empty if no
      *     entities could be found.
      * @example <caption>Report the number of entities in view.</caption>
      * var entityIDs = Entities.findEntitiesInFrustum(Camera.frustum);
@@ -778,9 +776,9 @@ public slots:
      * @param {string} entityName - The name of the entity to search for.
      * @param {Vec3} center - The point about which to search.
      * @param {number} radius - The radius within which to search.
-     * @param {boolean} [caseSensitive=false] - <code>true</code> if the search is case-sensitive, <code>false</code> if it is 
+     * @param {boolean} [caseSensitive=false] - <code>true</code> if the search is case-sensitive, <code>false</code> if it is
      *     case-insensitive.
-     * @returns {Uuid[]} An array of entity IDs that have the specified name and intersect the search sphere. The array is 
+     * @returns {Uuid[]} An array of entity IDs that have the specified name and intersect the search sphere. The array is
      *     empty if no entities could be found.
      * @example <caption>Report the number of entities with the name, "Light-Target".</caption>
      * var entityIDs = Entities.findEntitiesByName("Light-Target", MyAvatar.position, 10, false);
@@ -790,22 +788,22 @@ public slots:
         bool caseSensitiveSearch = false) const;
 
     /*@jsdoc
-     * Finds the first avatar or domain entity intersected by a {@link PickRay}. <code>Light</code> and <code>Zone</code> 
-     * entities are not intersected unless they've been configured as pickable using 
-     * {@link Entities.setLightsArePickable|setLightsArePickable} and {@link Entities.setZonesArePickable|setZonesArePickable}, 
+     * Finds the first avatar or domain entity intersected by a {@link PickRay}. <code>Light</code> and <code>Zone</code>
+     * entities are not intersected unless they've been configured as pickable using
+     * {@link Entities.setLightsArePickable|setLightsArePickable} and {@link Entities.setZonesArePickable|setZonesArePickable},
      * respectively.
      * @function Entities.findRayIntersection
      * @param {PickRay} pickRay - The pick ray to use for finding entities.
-     * @param {boolean} [precisionPicking=false] - <code>true</code> to pick against precise meshes, <code>false</code> to pick 
-     *     against coarse meshes. If <code>true</code> and the intersected entity is a <code>Model</code> entity, the result's 
+     * @param {boolean} [precisionPicking=false] - <code>true</code> to pick against precise meshes, <code>false</code> to pick
+     *     against coarse meshes. If <code>true</code> and the intersected entity is a <code>Model</code> entity, the result's
      *     <code>extraInfo</code> property includes more information than it otherwise would.
      * @param {Uuid[]} [entitiesToInclude=[]] - If not empty, then the search is restricted to these entities.
      * @param {Uuid[]} [entitiesToDiscard=[]] - Entities to ignore during the search.
-     * @param {boolean} [visibleOnly=false] - <code>true</code> if only entities that are 
-     *     <code>{@link Entities.EntityProperties|visible}</code> are searched for, <code>false</code> if their visibility 
+     * @param {boolean} [visibleOnly=false] - <code>true</code> if only entities that are
+     *     <code>{@link Entities.EntityProperties|visible}</code> are searched for, <code>false</code> if their visibility
      *     doesn't matter.
-     * @param {boolean} [collideableOnly=false] - <code>true</code> if only entities that are not 
-     *     <code>{@link Entities.EntityProperties|collisionless}</code> are searched, <code>false</code> if their 
+     * @param {boolean} [collideableOnly=false] - <code>true</code> if only entities that are not
+     *     <code>{@link Entities.EntityProperties|collisionless}</code> are searched, <code>false</code> if their
      *     collideability doesn't matter.
      * @returns {Entities.RayToEntityIntersectionResult} The result of the search for the first intersected entity.
      * @example <caption>Find the entity directly in front of your avatar.</caption>
@@ -832,7 +830,7 @@ public slots:
      * Reloads an entity's server entity script such that the latest version re-downloaded.
      * @function Entities.reloadServerScripts
      * @param {Uuid} entityID - The ID of the entity to reload the server entity script of.
-     * @returns {boolean} <code>true</code> if the reload request was successfully sent to the server, otherwise 
+     * @returns {boolean} <code>true</code> if the reload request was successfully sent to the server, otherwise
      *     <code>false</code>.
      */
     Q_INVOKABLE bool reloadServerScripts(const QUuid& entityID);
@@ -847,11 +845,11 @@ public slots:
     /*@jsdoc
      * Called when a {@link Entities.getServerScriptStatus} call is complete.
      * @callback Entities~getServerScriptStatusCallback
-     * @param {boolean} success - <code>true</code> if the server entity script status could be obtained, otherwise 
+     * @param {boolean} success - <code>true</code> if the server entity script status could be obtained, otherwise
      *     <code>false</code>.
      * @param {boolean} isRunning - <code>true</code> if there is a server entity script running, otherwise <code>false</code>.
      * @param {string} status - <code>"running"</code> if there is a server entity script running, otherwise an error string.
-     * @param {string} errorInfo - <code>""</code> if there is a server entity script running, otherwise it may contain extra 
+     * @param {string} errorInfo - <code>""</code> if there is a server entity script running, otherwise it may contain extra
      *     information on the error.
      */
     //Q_INVOKABLE bool getServerScriptStatus(const QUuid& entityID, const ScriptValue& callback);
@@ -863,7 +861,7 @@ public slots:
      * @param {Uuid} entityID - The ID of the entity to get the metadata for.
      * @param {string} property - The property name to get the metadata for.
      * @param {Entities~queryPropertyMetadataCallback} callback - The function to call upon completion.
-     * @returns {boolean} <code>true</code> if the request for metadata was successfully sent to the server, otherwise 
+     * @returns {boolean} <code>true</code> if the request for metadata was successfully sent to the server, otherwise
      *     <code>false</code>.
      * @throws Throws an error if <code>property</code> is not handled yet or <code>callback</code> is not a function.
      */
@@ -874,7 +872,7 @@ public slots:
      * @param {string} property - The property name to get the metadata for.
      * @param {object} scope - The "<code>this</code>" context that the callback will be executed within.
      * @param {Entities~queryPropertyMetadataCallback} callback - The function to call upon completion.
-     * @returns {boolean} <code>true</code> if the request for metadata was successfully sent to the server, otherwise 
+     * @returns {boolean} <code>true</code> if the request for metadata was successfully sent to the server, otherwise
      *     <code>false</code>.
      * @throws Throws an error if <code>property</code> is not handled yet or <code>callback</code> is not a function.
      */
@@ -890,62 +888,62 @@ public slots:
 
 
     /*@jsdoc
-     * Sets whether or not ray picks intersect the bounding box of {@link Entities.EntityProperties-Light|Light} entities. By 
-     * default, Light entities are not intersected. The setting lasts for the Interface session. Ray picks are performed using 
+     * Sets whether or not ray picks intersect the bounding box of {@link Entities.EntityProperties-Light|Light} entities. By
+     * default, Light entities are not intersected. The setting lasts for the Interface session. Ray picks are performed using
      * {@link Entities.findRayIntersection|findRayIntersection}, or the {@link Picks} API.
      * @function Entities.setLightsArePickable
-     * @param {boolean} value - <code>true</code> to make ray picks intersect the bounding box of 
+     * @param {boolean} value - <code>true</code> to make ray picks intersect the bounding box of
      *     {@link Entities.EntityProperties-Light|Light} entities, otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE void setLightsArePickable(bool value);
 
     /*@jsdoc
-     * Gets whether or not ray picks intersect the bounding box of {@link Entities.EntityProperties-Light|Light} entities. Ray 
+     * Gets whether or not ray picks intersect the bounding box of {@link Entities.EntityProperties-Light|Light} entities. Ray
      * picks are performed using {@link Entities.findRayIntersection|findRayIntersection}, or the {@link Picks} API.
      * @function Entities.getLightsArePickable
-     * @returns {boolean} <code>true</code> if ray picks intersect the bounding box of 
+     * @returns {boolean} <code>true</code> if ray picks intersect the bounding box of
      *     {@link Entities.EntityProperties-Light|Light} entities, otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE bool getLightsArePickable() const;
 
     /*@jsdoc
-     * Sets whether or not ray picks intersect the bounding box of {@link Entities.EntityProperties-Zone|Zone} entities. By 
-     * default, Zone entities are not intersected. The setting lasts for the Interface session. Ray picks are performed using 
+     * Sets whether or not ray picks intersect the bounding box of {@link Entities.EntityProperties-Zone|Zone} entities. By
+     * default, Zone entities are not intersected. The setting lasts for the Interface session. Ray picks are performed using
      * {@link Entities.findRayIntersection|findRayIntersection}, or the {@link Picks} API.
      * @function Entities.setZonesArePickable
-     * @param {boolean} value - <code>true</code> to make ray picks intersect the bounding box of 
+     * @param {boolean} value - <code>true</code> to make ray picks intersect the bounding box of
      *     {@link Entities.EntityProperties-Zone|Zone} entities, otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE void setZonesArePickable(bool value);
 
     /*@jsdoc
-     * Gets whether or not ray picks intersect the bounding box of {@link Entities.EntityProperties-Zone|Zone} entities. Ray 
+     * Gets whether or not ray picks intersect the bounding box of {@link Entities.EntityProperties-Zone|Zone} entities. Ray
      * picks are performed using {@link Entities.findRayIntersection|findRayIntersection}, or the {@link Picks} API.
      * @function Entities.getZonesArePickable
-     * @returns {boolean} <code>true</code> if ray picks intersect the bounding box of 
+     * @returns {boolean} <code>true</code> if ray picks intersect the bounding box of
      *      {@link Entities.EntityProperties-Zone|Zone} entities, otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE bool getZonesArePickable() const;
 
     /*@jsdoc
-     * Sets whether or not {@link Entities.EntityProperties-Zone|Zone} entities' boundaries should be drawn. <em>Currently not 
+     * Sets whether or not {@link Entities.EntityProperties-Zone|Zone} entities' boundaries should be drawn. <em>Currently not
      * used.</em>
      * @function Entities.setDrawZoneBoundaries
-     * @param {boolean} value - <code>true</code> if {@link Entities.EntityProperties-Zone|Zone} entities' boundaries should be 
+     * @param {boolean} value - <code>true</code> if {@link Entities.EntityProperties-Zone|Zone} entities' boundaries should be
      *     drawn, otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE void setDrawZoneBoundaries(bool value);
 
     /*@jsdoc
-     * Gets whether or not {@link Entities.EntityProperties-Zone|Zone} entities' boundaries should be drawn. <em>Currently 
+     * Gets whether or not {@link Entities.EntityProperties-Zone|Zone} entities' boundaries should be drawn. <em>Currently
      * not used.</em>
      * @function Entities.getDrawZoneBoundaries
-     * @returns {boolean} <code>true</code> if {@link Entities.EntityProperties-Zone|Zone} entities' boundaries should be 
+     * @returns {boolean} <code>true</code> if {@link Entities.EntityProperties-Zone|Zone} entities' boundaries should be
      *    drawn, otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
@@ -972,7 +970,7 @@ public slots:
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE bool setVoxelSphere(const QUuid& entityID, const glm::vec3& center, float radius, int value);
-    
+
     /*@jsdoc
      * Sets the values of all voxels in a capsule-shaped portion of a {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
      * @function Entities.setVoxelCapsule
@@ -1001,8 +999,8 @@ public slots:
      * Sets the value of a particular voxel in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
      * @function Entities.setVoxel
      * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
-     * @param {Vec3} position - The position relative to the minimum axes values corner of the entity. The 
-     *     <code>position</code> coordinates are rounded to the nearest integer to get the voxel coordinate. The minimum axes 
+     * @param {Vec3} position - The position relative to the minimum axes values corner of the entity. The
+     *     <code>position</code> coordinates are rounded to the nearest integer to get the voxel coordinate. The minimum axes
      *     corner voxel is <code>{ x: 0, y: 0, z: 0 }</code>.
      * @param {number} value - If <code>value % 256 == 0</code> then voxel is cleared, otherwise the voxel is set.
      * @example <caption>Create a cube PolyVox entity and clear the minimum axes' corner voxel.</caption>
@@ -1041,7 +1039,7 @@ public slots:
      * Sets the values of all voxels in a cubic portion of a {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
      * @function Entities.setVoxelsInCuboid
      * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
-     * @param {Vec3} lowPosition - The position of the minimum axes value corner of the cube of voxels to set, in voxel 
+     * @param {Vec3} lowPosition - The position of the minimum axes value corner of the cube of voxels to set, in voxel
      *     coordinates.
      * @param {Vec3} cuboidSize - The size of the cube of voxels to set, in voxel coordinates.
      * @param {number} value - If <code>value % 256 == 0</code> then each voxel is cleared, otherwise each voxel is set.
@@ -1063,13 +1061,13 @@ public slots:
     Q_INVOKABLE bool setVoxelsInCuboid(const QUuid& entityID, const glm::vec3& lowPosition, const glm::vec3& cuboidSize, int value);
 
     /*@jsdoc
-     * Converts voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity to world coordinates. Voxel 
-     * coordinates are relative to the minimum axes values corner of the entity with a scale of <code>Vec3.ONE</code> being the 
+     * Converts voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity to world coordinates. Voxel
+     * coordinates are relative to the minimum axes values corner of the entity with a scale of <code>Vec3.ONE</code> being the
      * dimensions of each voxel.
      * @function Entities.voxelCoordsToWorldCoords
      * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
      * @param {Vec3} voxelCoords - The voxel coordinates. May be fractional and outside the entity's bounding box.
-     * @returns {Vec3} The world coordinates of the <code>voxelCoords</code> if the <code>entityID</code> is a 
+     * @returns {Vec3} The world coordinates of the <code>voxelCoords</code> if the <code>entityID</code> is a
      *     {@link Entities.EntityProperties-PolyVox|PolyVox} entity, otherwise {@link Vec3(0)|Vec3.ZERO}.
      * @example <caption>Create a PolyVox cube with the 0,0,0 voxel replaced by a sphere.</caption>
      * // Cube PolyVox with 0,0,0 voxel missing.
@@ -1098,28 +1096,28 @@ public slots:
     Q_INVOKABLE glm::vec3 voxelCoordsToWorldCoords(const QUuid& entityID, glm::vec3 voxelCoords);
 
     /*@jsdoc
-     * Converts world coordinates to voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity. Voxel 
-     * coordinates are relative to the minimum axes values corner of the entity, with a scale of <code>Vec3.ONE</code> being 
+     * Converts world coordinates to voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity. Voxel
+     * coordinates are relative to the minimum axes values corner of the entity, with a scale of <code>Vec3.ONE</code> being
      * the dimensions of each voxel.
      * @function Entities.worldCoordsToVoxelCoords
      * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
      * @param {Vec3} worldCoords - The world coordinates. The value may be outside the entity's bounding box.
-     * @returns {Vec3} The voxel coordinates of the <code>worldCoords</code> if the <code>entityID</code> is a 
-     *     {@link Entities.EntityProperties-PolyVox|PolyVox} entity, otherwise {@link Vec3(0)|Vec3.ZERO}. The value may be 
+     * @returns {Vec3} The voxel coordinates of the <code>worldCoords</code> if the <code>entityID</code> is a
+     *     {@link Entities.EntityProperties-PolyVox|PolyVox} entity, otherwise {@link Vec3(0)|Vec3.ZERO}. The value may be
      *     fractional and outside the entity's bounding box.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE glm::vec3 worldCoordsToVoxelCoords(const QUuid& entityID, glm::vec3 worldCoords);
 
     /*@jsdoc
-     * Converts voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity to local coordinates. Local 
-     * coordinates are relative to the minimum axes value corner of the entity, with the scale being the same as world 
-     * coordinates. Voxel coordinates are relative to the minimum axes values corner of the entity, with a scale of 
+     * Converts voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity to local coordinates. Local
+     * coordinates are relative to the minimum axes value corner of the entity, with the scale being the same as world
+     * coordinates. Voxel coordinates are relative to the minimum axes values corner of the entity, with a scale of
      * <code>Vec3.ONE</code> being the dimensions of each voxel.
      * @function Entities.voxelCoordsToLocalCoords
      * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
      * @param {Vec3} voxelCoords - The voxel coordinates. The value may be fractional and outside the entity's bounding box.
-     * @returns {Vec3} The local coordinates of the <code>voxelCoords</code> if the <code>entityID</code> is a 
+     * @returns {Vec3} The local coordinates of the <code>voxelCoords</code> if the <code>entityID</code> is a
      *     {@link Entities.EntityProperties-PolyVox|PolyVox} entity, otherwise {@link Vec3(0)|Vec3.ZERO}.
      * @example <caption>Get the world dimensions of a voxel in a PolyVox entity.</caption>
      * var polyVox = Entities.addEntity({
@@ -1136,90 +1134,28 @@ public slots:
     Q_INVOKABLE glm::vec3 voxelCoordsToLocalCoords(const QUuid& entityID, glm::vec3 voxelCoords);
 
     /*@jsdoc
-     * Converts local coordinates to voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity. Local 
-     * coordinates are relative to the minimum axes value corner of the entity, with the scale being the same as world 
-     * coordinates. Voxel coordinates are relative to the minimum axes values corner of the entity, with a scale of 
+     * Converts local coordinates to voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity. Local
+     * coordinates are relative to the minimum axes value corner of the entity, with the scale being the same as world
+     * coordinates. Voxel coordinates are relative to the minimum axes values corner of the entity, with a scale of
      * <code>Vec3.ONE</code> being the dimensions of each voxel.
      * @function Entities.localCoordsToVoxelCoords
      * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
      * @param {Vec3} localCoords - The local coordinates. The value may be outside the entity's bounding box.
-     * @returns {Vec3} The voxel coordinates of the <code>worldCoords</code> if the <code>entityID</code> is a 
-     *     {@link Entities.EntityProperties-PolyVox|PolyVox} entity, otherwise {@link Vec3(0)|Vec3.ZERO}. The value may be 
+     * @returns {Vec3} The voxel coordinates of the <code>worldCoords</code> if the <code>entityID</code> is a
+     *     {@link Entities.EntityProperties-PolyVox|PolyVox} entity, otherwise {@link Vec3(0)|Vec3.ZERO}. The value may be
      *     fractional and outside the entity's bounding box.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE glm::vec3 localCoordsToVoxelCoords(const QUuid& entityID, glm::vec3 localCoords);
 
-    /*@jsdoc
-     * Sets all the points in a {@link Entities.EntityProperties-Line|Line} entity.
-     * @function Entities.setAllPoints
-     * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-Line|Line} entity.
-     * @param {Vec3[]} points - The points that the entity should draw lines between.
-     * @returns {boolean} <code>true</code> if the entity was updated, otherwise <code>false</code>. The property may fail to 
-     *     be updated if the entity does not exist, the entity is not a {@link Entities.EntityProperties-Line|Line} entity, 
-     *     one of the points is outside the entity's dimensions, or the number of points is greater than the maximum allowed.
-     * @deprecated This function is deprecated and will be removed. Use {@link Entities.EntityProperties-PolyLine|PolyLine}
-     *     entities instead.
-     * @example <caption>Change the shape of a Line entity.</caption>
-     * // Draw a horizontal line between two points.
-     * var entity = Entities.addEntity({
-     *     type: "Line",
-     *     position: Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 0.75, z: -5 })),
-     *     rotation: MyAvatar.orientation,
-     *     dimensions: { x: 2, y: 2, z: 1 },
-     *     linePoints: [
-     *         { x: -1, y: 0, z: 0 },
-     *         { x:1, y: -0, z: 0 }
-     *     ],
-     *     color: { red: 255, green: 0, blue: 0 },
-     *     lifetime: 300  // Delete after 5 minutes.
-     * });
-     *
-     * // Change the line to be a "V".
-     * Script.setTimeout(function () {
-     *     Entities.setAllPoints(entity, [
-     *         { x: -1, y: 1, z: 0 },
-     *         { x: 0, y: -1, z: 0 },
-     *         { x: 1, y: 1, z: 0 },
-     *     ]);
-     * }, 2000);
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE bool setAllPoints(const QUuid& entityID, const QVector<glm::vec3>& points);
-    
-    /*@jsdoc
-     * Appends a point to a {@link Entities.EntityProperties-Line|Line} entity.
-     * @function Entities.appendPoint
-     * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-Line|Line} entity.
-     * @param {Vec3} point - The point to add to the line. The coordinates are relative to the entity's position.
-     * @returns {boolean} <code>true</code> if the point was added to the line, otherwise <code>false</code>. The point may 
-     *     fail to be added if the entity does not exist, the entity is not a {@link Entities.EntityProperties-Line|Line}
-     *     entity, the point is outside the entity's dimensions, or the maximum number of points has been reached.
-     * @deprecated This function is deprecated and will be removed. Use {@link Entities.EntityProperties-PolyLine|PolyLine} 
-     *     entities instead.
-     * @example <caption>Append a point to a Line entity.</caption>
-     * // Draw a line between two points.
-     * var entity = Entities.addEntity({
-     *     type: "Line",
-     *     position: Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 0.75, z: -5 })),
-     *     rotation: MyAvatar.orientation,
-     *     dimensions: { x: 2, y: 2, z: 1 },
-     *     linePoints: [
-     *         { x: -1, y: 1, z: 0 },
-     *         { x: 0, y: -1, z: 0 }
-     *     ],
-     *     color: { red: 255, green: 0, blue: 0 },
-     *     lifetime: 300  // Delete after 5 minutes.
-     * });
-     *
-     * // Add a third point to create a "V".
-     * Script.setTimeout(function () {
-     *     Entities.appendPoint(entity, { x: 1, y: 1, z: 0 });
-     * }, 50); // Wait for the entity to be created.
-     */
+
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE bool appendPoint(const QUuid& entityID, const glm::vec3& point);
 
     /*@jsdoc
-     * Dumps debug information about all entities in Interface's local in-memory tree of entities it knows about to the program 
+     * Dumps debug information about all entities in Interface's local in-memory tree of entities it knows about to the program
      * log.
      * @function Entities.dumpTree
      */
@@ -1228,7 +1164,7 @@ public slots:
 
     /*@jsdoc
      * Adds an action to an entity. An action is registered with the physics engine and is applied every physics simulation
-     * step. Any entity may have more than one action associated with it, but only as many as will fit in an entity's 
+     * step. Any entity may have more than one action associated with it, but only as many as will fit in an entity's
      * <code>{@link Entities.EntityProperties|actionData}</code> property.
      * @function Entities.addAction
      * @param {Entities.ActionType} actionType - The type of action.
@@ -1292,18 +1228,18 @@ public slots:
 
 
     /*@jsdoc
-     * Gets the translation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's 
+     * Gets the translation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's
      * position and orientation.
      * @function Entities.getAbsoluteJointTranslationInObjectFrame
      * @param {Uuid} entityID - The ID of the entity.
      * @param {number} jointIndex - The integer index of the joint.
      * @returns {Vec3} The translation of the joint relative to the entity's position and orientation if the entity is a
-     *     {@link Entities.EntityProperties-Model|Model} entity, the entity is loaded, and the joint index is valid; otherwise 
+     *     {@link Entities.EntityProperties-Model|Model} entity, the entity is loaded, and the joint index is valid; otherwise
      *     <code>{@link Vec3(0)|Vec3.ZERO}</code>.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE glm::vec3 getAbsoluteJointTranslationInObjectFrame(const QUuid& entityID, int jointIndex);
-    
+
     /*@jsdoc
      * Gets the index of the parent joint of a joint in a {@link Entities.EntityProperties-Model|Model} entity.
      * @function Entities.getJointParent
@@ -1312,15 +1248,15 @@ public slots:
      * @returns {number} The index of the parent joint if found, otherwise <code>-1</code>.
      */
     Q_INVOKABLE int getJointParent(const QUuid& entityID, int index);
-    
+
     /*@jsdoc
-     * Gets the rotation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's 
+     * Gets the rotation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's
      * position and orientation.
      * @function Entities.getAbsoluteJointRotationInObjectFrame
      * @param {Uuid} entityID - The ID of the entity.
      * @param {number} jointIndex - The integer index of the joint.
      * @returns {Quat} The rotation of the joint relative to the entity's orientation if the entity is a
-     *     {@link Entities.EntityProperties-Model|Model} entity, the entity is loaded, and the joint index is valid; otherwise 
+     *     {@link Entities.EntityProperties-Model|Model} entity, the entity is loaded, and the joint index is valid; otherwise
      *     <code>{@link Quat(0)|Quat.IDENTITY}</code>.
      * @example <caption>Compare the local and absolute rotations of an avatar model's left hand joint.</caption>
      * entityID = Entities.addEntity({
@@ -1344,28 +1280,28 @@ public slots:
     Q_INVOKABLE glm::quat getAbsoluteJointRotationInObjectFrame(const QUuid& entityID, int jointIndex);
 
     /*@jsdoc
-     * Sets the translation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's 
+     * Sets the translation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's
      * position and orientation.
      * @function Entities.setAbsoluteJointTranslationInObjectFrame
      * @param {Uuid} entityID - The ID of the entity.
      * @param {number} jointIndex - The integer index of the joint.
      * @param {Vec3} translation - The translation to set the joint to relative to the entity's position and orientation.
-     * @returns {boolean} <code>true</code>if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity 
-     *     is loaded, the joint index is valid, and the translation is different to the joint's current translation; otherwise 
+     * @returns {boolean} <code>true</code>if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity
+     *     is loaded, the joint index is valid, and the translation is different to the joint's current translation; otherwise
      *     <code>false</code>.
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE bool setAbsoluteJointTranslationInObjectFrame(const QUuid& entityID, int jointIndex, glm::vec3 translation);
 
     /*@jsdoc
-     * Sets the rotation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's position 
+     * Sets the rotation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's position
      * and orientation.
      * @function Entities.setAbsoluteJointRotationInObjectFrame
      * @param {Uuid} entityID - The ID of the entity.
      * @param {number} jointIndex - The integer index of the joint.
      * @param {Quat} rotation - The rotation to set the joint to relative to the entity's orientation.
-     * @returns {boolean} <code>true</code> if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity 
-     *     is loaded, the joint index is valid, and the rotation is different to the joint's current rotation; otherwise 
+     * @returns {boolean} <code>true</code> if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity
+     *     is loaded, the joint index is valid, and the rotation is different to the joint's current rotation; otherwise
      *     <code>false</code>.
      * @example <caption>Raise an avatar model's left palm.</caption>
      * entityID = Entities.addEntity({
@@ -1394,7 +1330,7 @@ public slots:
      * @function Entities.getLocalJointTranslation
      * @param {Uuid} entityID - The ID of the entity.
      * @param {number} jointIndex - The integer index of the joint.
-     * @returns {Vec3} The local translation of the joint if the entity is a {@link Entities.EntityProperties-Model|Model} 
+     * @returns {Vec3} The local translation of the joint if the entity is a {@link Entities.EntityProperties-Model|Model}
      *     entity, the entity is loaded, and the joint index is valid; otherwise <code>{@link Vec3(0)|Vec3.ZERO}</code>.
      */
     // FIXME move to a renderable entity interface
@@ -1405,7 +1341,7 @@ public slots:
      * @function Entities.getLocalJointRotation
      * @param {Uuid} entityID - The ID of the entity.
      * @param {number} jointIndex - The integer index of the joint.
-     * @returns {Quat} The local rotation of the joint if the entity is a {@link Entities.EntityProperties-Model|Model} entity, 
+     * @returns {Quat} The local rotation of the joint if the entity is a {@link Entities.EntityProperties-Model|Model} entity,
      *     the entity is loaded, and the joint index is valid; otherwise <code>{@link Quat(0)|Quat.IDENTITY}</code>.
      * @example <caption>Report the local rotation of an avatar model's head joint.</caption>
      * entityID = Entities.addEntity({
@@ -1432,8 +1368,8 @@ public slots:
      * @param {Uuid} entityID - The ID of the entity.
      * @param {number} jointIndex - The integer index of the joint.
      * @param {Vec3} translation - The local translation to set the joint to.
-     * @returns {boolean} <code>true</code>if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity 
-     *     is loaded, the joint index is valid, and the translation is different to the joint's current translation; otherwise 
+     * @returns {boolean} <code>true</code>if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity
+     *     is loaded, the joint index is valid, and the translation is different to the joint's current translation; otherwise
      *     <code>false</code>.
      */
     // FIXME move to a renderable entity interface
@@ -1445,8 +1381,8 @@ public slots:
      * @param {Uuid} entityID - The ID of the entity.
      * @param {number} jointIndex - The integer index of the joint.
      * @param {Quat} rotation - The local rotation to set the joint to.
-     * @returns {boolean} <code>true</code> if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity 
-     *     is loaded, the joint index is valid, and the rotation is different to the joint's current rotation; otherwise 
+     * @returns {boolean} <code>true</code> if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity
+     *     is loaded, the joint index is valid, and the rotation is different to the joint's current rotation; otherwise
      *     <code>false</code>.
      * @example <caption>Make an avatar model turn its head left.</caption>
      * entityID = Entities.addEntity({
@@ -1474,8 +1410,8 @@ public slots:
      * @function Entities.setLocalJointTranslations
      * @param {Uuid} entityID - The ID of the entity.
      * @param {Vec3[]} translations - The local translations to set the joints to.
-     * @returns {boolean} <code>true</code>if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity 
-     *     is loaded, the model has joints, and at least one of the translations is different to the model's current 
+     * @returns {boolean} <code>true</code>if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity
+     *     is loaded, the model has joints, and at least one of the translations is different to the model's current
      *     translations; otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
@@ -1486,8 +1422,8 @@ public slots:
      * @function Entities.setLocalJointRotations
      * @param {Uuid} entityID - The ID of the entity.
      * @param {Quat[]} rotations - The local rotations to set the joints to.
-     * @returns {boolean} <code>true</code> if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity 
-     *     is loaded, the model has joints, and at least one of the rotations is different to the model's current rotations; 
+     * @returns {boolean} <code>true</code> if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity
+     *     is loaded, the model has joints, and at least one of the rotations is different to the model's current rotations;
      *     otherwise <code>false</code>.
      * @example <caption>Raise both palms of an avatar model.</caption>
      * entityID = Entities.addEntity({
@@ -1524,15 +1460,15 @@ public slots:
     Q_INVOKABLE bool setLocalJointRotations(const QUuid& entityID, const QVector<glm::quat>& rotations);
 
     /*@jsdoc
-     * Sets the local rotations and translations of joints in a {@link Entities.EntityProperties-Model|Model} entity. This is 
-     * the same as calling both {@link Entities.setLocalJointRotations|setLocalJointRotations} and 
+     * Sets the local rotations and translations of joints in a {@link Entities.EntityProperties-Model|Model} entity. This is
+     * the same as calling both {@link Entities.setLocalJointRotations|setLocalJointRotations} and
      * {@link Entities.setLocalJointTranslations|setLocalJointTranslations} at the same time.
      * @function Entities.setLocalJointsData
      * @param {Uuid} entityID - The ID of the entity.
      * @param {Quat[]} rotations - The local rotations to set the joints to.
      * @param {Vec3[]} translations - The local translations to set the joints to.
-     * @returns {boolean} <code>true</code> if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity 
-     *     is loaded, the model has joints, and at least one of the rotations or translations is different to the model's 
+     * @returns {boolean} <code>true</code> if the entity is a {@link Entities.EntityProperties-Model|Model} entity, the entity
+     *     is loaded, the model has joints, and at least one of the rotations or translations is different to the model's
      *     current values; otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
@@ -1546,8 +1482,8 @@ public slots:
      * @function Entities.getJointIndex
      * @param {Uuid} entityID - The ID of the entity.
      * @param {string} name - The name of the joint.
-     * @returns {number} The integer index of the joint if the entity is a {@link Entities.EntityProperties-Model|Model} 
-     *     entity, the entity is loaded, and the joint is present; otherwise <code>-1</code>. The joint indexes are in order 
+     * @returns {number} The integer index of the joint if the entity is a {@link Entities.EntityProperties-Model|Model}
+     *     entity, the entity is loaded, and the joint is present; otherwise <code>-1</code>. The joint indexes are in order
      *     per {@link Entities.getJointNames|getJointNames}.
      * @example <caption>Report the index of a model's head joint.</caption>
      * entityID = Entities.addEntity({
@@ -1571,8 +1507,8 @@ public slots:
      * Gets the names of all the joints in a {@link Entities.EntityProperties-Model|Model} entity.
      * @function Entities.getJointNames
      * @param {Uuid} entityID - The ID of the {@link Entities.EntityProperties-Model|Model} entity.
-     * @returns {string[]} The names of all the joints in the entity if it is a {@link Entities.EntityProperties-Model|Model} 
-     *     entity and is loaded, otherwise an empty array. The joint names are in order per 
+     * @returns {string[]} The names of all the joints in the entity if it is a {@link Entities.EntityProperties-Model|Model}
+     *     entity and is loaded, otherwise an empty array. The joint names are in order per
      *     {@link Entities.getJointIndex|getJointIndex}.
      * @example <caption>Report a model's joint names.</caption>
      * entityID = Entities.addEntity({
@@ -1594,12 +1530,12 @@ public slots:
 
 
     /*@jsdoc
-     * Gets the IDs of entities and avatars that are directly parented to an entity or avatar model. To get all descendants, 
+     * Gets the IDs of entities and avatars that are directly parented to an entity or avatar model. To get all descendants,
      * you can recurse on the IDs returned.
      * @function Entities.getChildrenIDs
      * @param {Uuid} parentID - The ID of the entity or avatar to get the children IDs of.
-     * @returns {Uuid[]} An array of entity and avatar IDs that are parented directly to the <code>parentID</code> 
-     *     entity or avatar. Does not include children's children, etc. The array is empty if no children can be found or 
+     * @returns {Uuid[]} An array of entity and avatar IDs that are parented directly to the <code>parentID</code>
+     *     entity or avatar. Does not include children's children, etc. The array is empty if no children can be found or
      *     <code>parentID</code> cannot be found.
      * @example <caption>Report the children of an entity.</caption>
      * function createEntity(description, position, parent) {
@@ -1625,13 +1561,13 @@ public slots:
     Q_INVOKABLE QVector<QUuid> getChildrenIDs(const QUuid& parentID);
 
     /*@jsdoc
-     * Gets the IDs of entities and avatars that are directly parented to an entity or avatar model's joint. To get all 
+     * Gets the IDs of entities and avatars that are directly parented to an entity or avatar model's joint. To get all
      * descendants, you can use {@link Entities.getChildrenIDs|getChildrenIDs} to recurse on the IDs returned.
      * @function Entities.getChildrenIDsOfJoint
      * @param {Uuid} parentID - The ID of the entity or avatar to get the children IDs of.
      * @param {number} jointIndex - Integer number of the model joint to get the children IDs of.
-     * @returns {Uuid[]} An array of entity and avatar IDs that are parented directly to the <code>parentID</code> 
-     *     entity or avatar at the <code>jointIndex</code> joint. Does not include children's children, etc. The 
+     * @returns {Uuid[]} An array of entity and avatar IDs that are parented directly to the <code>parentID</code>
+     *     entity or avatar at the <code>jointIndex</code> joint. Does not include children's children, etc. The
      *     array is empty if no children can be found or <code>parentID</code> cannot be found.
      * @example <caption>Report the children of your avatar's right hand.</caption>
      * function createEntity(description, position, parent) {
@@ -1655,7 +1591,7 @@ public slots:
      *         parentID: MyAvatar.sessionUUID,
      *         parentJointIndex: MyAvatar.getJointIndex("RightHand")
      *     });
-     * 
+     *
      *     var children = Entities.getChildrenIDsOfJoint(MyAvatar.sessionUUID, MyAvatar.getJointIndex("RightHand"));
      *     print("Children of hand: " + JSON.stringify(children));  // Only the root entity.
      * }, 50);
@@ -1667,7 +1603,7 @@ public slots:
      * @function Entities.isChildOfParent
      * @param {Uuid} childID - The ID of the child entity to test for being a child, grandchild, etc.
      * @param {Uuid} parentID - The ID of the parent entity to test for being a parent, grandparent, etc.
-     * @returns {boolean} <code>true</code> if the <code>childID</code> entity has the <code>parentID</code> entity 
+     * @returns {boolean} <code>true</code> if the <code>childID</code> entity has the <code>parentID</code> entity
      *     as a parent or grandparent etc., otherwise <code>false</code>.
      * @example <caption>Check that a grandchild entity is a child of its grandparent.</caption>
      * function createEntity(description, position, parent) {
@@ -1718,7 +1654,7 @@ public slots:
     /*@jsdoc
      * Sets the {@link Entities.EntityProperties-Web|Web} entity that has keyboard focus.
      * @function Entities.setKeyboardFocusEntity
-     * @param {Uuid} id - The ID of the {@link Entities.EntityProperties-Web|Web} entity to set keyboard focus to. Use 
+     * @param {Uuid} id - The ID of the {@link Entities.EntityProperties-Web|Web} entity to set keyboard focus to. Use
      *     <code>null</code> or {@link Uuid(0)|Uuid.NULL} to unset keyboard focus from an entity.
      */
     Q_INVOKABLE void setKeyboardFocusEntity(const QUuid& id);
@@ -1796,17 +1732,17 @@ public slots:
     Q_INVOKABLE void sendHoverLeaveEntity(const EntityItemID& id, const PointerEvent& event);
 
     /*@jsdoc
-     * Checks whether an entity wants hand controller pointer events. For example, a {@link Entities.EntityProperties-Web|Web} 
+     * Checks whether an entity wants hand controller pointer events. For example, a {@link Entities.EntityProperties-Web|Web}
      * entity does but a {@link Entities.EntityProperties-Shape|Shape} entity doesn't.
      * @function Entities.wantsHandControllerPointerEvents
      * @param {Uuid} entityID -  The ID of the entity.
-     * @returns {boolean} <code>true</code> if the entity can be found and it wants hand controller pointer events, otherwise 
+     * @returns {boolean} <code>true</code> if the entity can be found and it wants hand controller pointer events, otherwise
      *     <code>false</code>.
      */
     Q_INVOKABLE bool wantsHandControllerPointerEvents(const QUuid& id);
 
     /*@jsdoc
-     * Sends a message to a {@link Entities.EntityProperties-Web|Web} entity's HTML page. To receive the message, the web 
+     * Sends a message to a {@link Entities.EntityProperties-Web|Web} entity's HTML page. To receive the message, the web
      * page's script must connect to the <code>EventBridge</code> that is automatically provided to the script:
      * <pre class="prettyprint"><code>EventBridge.scriptEventReceived.connect(function(message) {
      *     ...
@@ -1856,12 +1792,12 @@ public slots:
      *     if (entityID === webEntity) {
      *         // Message received.
      *         print("Message received: " + message);
-     * 
+     *
      *         // Send a message back.
      *         Entities.emitScriptEvent(webEntity, message + " back");
      *     }
      * }
-     * 
+     *
      * Entities.webEventReceived.connect(onWebEventReceived);
      */
     Q_INVOKABLE void emitScriptEvent(const EntityItemID& entityID, const QVariant& message);
@@ -1879,25 +1815,7 @@ public slots:
     Q_INVOKABLE bool AABoxIntersectsCapsule(const glm::vec3& low, const glm::vec3& dimensions,
                                             const glm::vec3& start, const glm::vec3& end, float radius);
 
-    /*@jsdoc
-     * Gets the meshes in a {@link Entities.EntityProperties-Model|Model} or {@link Entities.EntityProperties-PolyVox|PolyVox} 
-     * entity.
-     * @function Entities.getMeshes
-     * @param {Uuid} entityID - The ID of the <code>Model</code> or <code>PolyVox</code> entity to get the meshes of.
-     * @param {Entities~getMeshesCallback} callback - The function to call upon completion.
-     * @deprecated This function is deprecated and will be removed. It no longer works for Model entities. Use the 
-     *     {@link Graphics} API instead.
-     */
-     /*@jsdoc
-      * Called when a {@link Entities.getMeshes} call is complete.
-      * @callback Entities~getMeshesCallback
-      * @param {MeshProxy[]} meshes - If <code>success</code> is <code>true</code>, a {@link MeshProxy} per mesh in the 
-      *     <code>Model</code> or <code>PolyVox</code> entity; otherwise <code>undefined</code>. 
-      * @param {boolean} success - <code>true</code> if the {@link Entities.getMeshes} call was successful, <code>false</code> 
-      *     otherwise. The call may be unsuccessful if the requested entity could not be found.
-      * @deprecated This function is deprecated and will be removed. It no longer works for Model entities. Use the 
-      *     {@link Graphics} API instead. 
-      */
+    // TODO: Deprecated by documentation, please review for accuracy
     // FIXME move to a renderable entity interface
     Q_INVOKABLE void getMeshes(const QUuid& entityID, const ScriptValue& callback);
 
@@ -1905,7 +1823,7 @@ public slots:
      * Gets the object to world transform, excluding scale, of an entity.
      * @function Entities.getEntityTransform
      * @param {Uuid} entityID - The ID of the entity.
-     * @returns {Mat4} The entity's object to world transform excluding scale (i.e., translation and rotation, with scale of 1) 
+     * @returns {Mat4} The entity's object to world transform excluding scale (i.e., translation and rotation, with scale of 1)
      *    if the entity can be found, otherwise a transform with zero translation and rotation and a scale of 1.
      * @example <caption>Position and rotation in an entity's world transform.</caption>
      * var position = Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 1, z: -2 }));
@@ -1933,8 +1851,8 @@ public slots:
      * Gets the object to parent transform, excluding scale, of an entity.
      * @function Entities.getEntityLocalTransform
      * @param {Uuid} entityID - The ID of the entity.
-     * @returns {Mat4} The entity's object to parent transform excluding scale (i.e., translation and rotation, with scale of 
-     *     1) if the entity can be found, otherwise a transform with zero translation and rotation and a scale of 1. If the 
+     * @returns {Mat4} The entity's object to parent transform excluding scale (i.e., translation and rotation, with scale of
+     *     1) if the entity can be found, otherwise a transform with zero translation and rotation and a scale of 1. If the
      *     entity doesn't have a parent, its world transform is returned.
      * @example <caption>Position and rotation in an entity's local transform.</caption>
      * function createEntity(position, rotation, parent) {
@@ -1970,15 +1888,15 @@ public slots:
      * @function Entities.worldToLocalPosition
      * @param {Vec3} worldPosition - The world position to convert.
      * @param {Uuid} parentID - The avatar or entity that the local coordinates are based on.
-     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If 
+     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If
      *     <code>-1</code> then no joint is used and the local coordinates are based solely on the avatar or entity.
-     * @param {boolean} [scalesWithParent= false] - <code>true</code> to scale the local position per the parent's scale, 
+     * @param {boolean} [scalesWithParent= false] - <code>true</code> to scale the local position per the parent's scale,
      *     <code>false</code> for the local position to be at world scale.
      * @returns {Vec3} The position converted to local coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      * @example <caption>Report the local coordinates of an entity parented to another.</caption>
      * var parentPosition = Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 0, z: -5 }));
      * var childPosition = Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 1, z: -5 }));
-     * 
+     *
      * var parentEntity = Entities.addEntity({
      *     type: "Box",
      *     position: parentPosition,
@@ -1993,7 +1911,7 @@ public slots:
      *     parentID: parentEntity,
      *     lifetime: 300  // Delete after 5 minutes.
      * });
-     * 
+     *
      * var localPosition = Entities.worldToLocalPosition(childPosition, parentEntity);
      * print("Local position: " + JSON.stringify(localPosition));  // 0, 1, 0.
      * localPosition = Entities.getEntityProperties(childEntity, "localPosition").localPosition;
@@ -2018,22 +1936,22 @@ public slots:
      * @function Entities.worldToLocalVelocity
      * @param {Vec3} worldVelocity - The world velocity to convert.
      * @param {Uuid} parentID - The avatar or entity that the local coordinates are based on.
-     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If 
+     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If
      *     <code>-1</code> then no joint is used and the local coordinates are based solely on the avatar or entity.
-     * @param {boolean} [scalesWithParent=false] - <code>true</code> to scale the local velocity per the parent's scale, 
+     * @param {boolean} [scalesWithParent=false] - <code>true</code> to scale the local velocity per the parent's scale,
      *     <code>false</code> for the local velocity to be at world scale.
      * @returns {Vec3} The velocity converted to local coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
     Q_INVOKABLE glm::vec3 worldToLocalVelocity(glm::vec3 worldVelocity, const QUuid& parentID,
                                                int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
-     * Converts a Euler angular velocity in world coordinates to an angular velocity in an avatar, entity, or joint's local 
+     * Converts a Euler angular velocity in world coordinates to an angular velocity in an avatar, entity, or joint's local
      * coordinates.
      * @function Entities.worldToLocalAngularVelocity
-     * @param {Vec3} worldAngularVelocity - The world Euler angular velocity to convert. (Can be in any unit, e.g., deg/s or 
+     * @param {Vec3} worldAngularVelocity - The world Euler angular velocity to convert. (Can be in any unit, e.g., deg/s or
      *     rad/s.)
      * @param {Uuid} parentID - The avatar or entity that the local coordinates are based on.
-     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If 
+     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If
      *     <code>-1</code> then no joint is used and the local coordinates are based solely on the avatar or entity.
      * @param {boolean} [scalesWithParent=false] - <em>Not used in the calculation.</em>
      * @returns {Vec3} The angular velocity converted to local coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
@@ -2046,7 +1964,7 @@ public slots:
      * @param {Vec3} worldDimensions - The world dimensions to convert.
      * @param {Uuid} parentID - The avatar or entity that the local coordinates are based on.
      * @param {number} [parentJointIndex=-1] - <em>Not used in the calculation.</em>
-     * @param {boolean} [scalesWithParent=false] - <code>true</code> to scale the local dimensions per the parent's scale, 
+     * @param {boolean} [scalesWithParent=false] - <code>true</code> to scale the local dimensions per the parent's scale,
      *     <code>false</code> for the local dimensions to be at world scale.
      * @returns {Vec3} The dimensions converted to local coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
@@ -2057,9 +1975,9 @@ public slots:
      * @function Entities.localToWorldPosition
      * @param {Vec3} localPosition - The local position to convert.
      * @param {Uuid} parentID - The avatar or entity that the local coordinates are based on.
-     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If 
+     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If
      *     <code>-1</code> then no joint is used and the local coordinates are based solely on the avatar or entity.
-     * @param {boolean} [scalesWithparent=false] - <code>true</code> if the local dimensions are scaled per the parent's scale, 
+     * @param {boolean} [scalesWithparent=false] - <code>true</code> if the local dimensions are scaled per the parent's scale,
      *     <code>false</code> if the local dimensions are at world scale.
      * @returns {Vec3} The position converted to world coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
@@ -2082,22 +2000,22 @@ public slots:
      * @function Entities.localToWorldVelocity
      * @param {Vec3} localVelocity - The local velocity to convert.
      * @param {Uuid} parentID - The avatar or entity that the local coordinates are based on.
-     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If 
+     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If
      *     <code>-1</code> then no joint is used and the local coordinates are based solely on the avatar or entity.
-     * @param {boolean} [scalesWithParent= false] - <code>true</code> if the local velocity is scaled per the parent's scale, 
+     * @param {boolean} [scalesWithParent= false] - <code>true</code> if the local velocity is scaled per the parent's scale,
      *     <code>false</code> if the local velocity is at world scale.
      * @returns {Vec3} The velocity converted to world coordinates it successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
     Q_INVOKABLE glm::vec3 localToWorldVelocity(glm::vec3 localVelocity, const QUuid& parentID,
                                                int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
-     * Converts a Euler angular velocity in an avatar, entity, or joint's local coordinate to an angular velocity in world 
+     * Converts a Euler angular velocity in an avatar, entity, or joint's local coordinate to an angular velocity in world
      * coordinates.
      * @function Entities.localToWorldAngularVelocity
-     * @param {Vec3} localAngularVelocity - The local Euler angular velocity to convert. (Can be in any unit, e.g., deg/s or 
+     * @param {Vec3} localAngularVelocity - The local Euler angular velocity to convert. (Can be in any unit, e.g., deg/s or
      * rad/s.)
      * @param {Uuid} parentID - The avatar or entity that the local coordinates are based on.
-     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If 
+     * @param {number} [parentJointIndex=-1] - The joint in the avatar or entity that the local coordinates are based on. If
      *     <code>-1</code> then no joint is used and the local coordinates are based solely on the avatar or entity.
      * @param {boolean} [scalesWithParent= false] - <em>Not used in the calculation.</em>
      * @returns {Vec3} The angular velocity converted to world coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
@@ -2110,7 +2028,7 @@ public slots:
      * @param {Vec3} localDimensions - The local dimensions to convert.
      * @param {Uuid} parentID - The avatar or entity that the local coordinates are based on.
      * @param {number} [parentJointIndex=-1] - <em>Not used in the calculation.</em>
-     * @param {boolean} [scalesWithParent= false] - <code>true</code> if the local dimensions are scaled per the parent's 
+     * @param {boolean} [scalesWithParent= false] - <code>true</code> if the local dimensions are scaled per the parent's
      *     scale, <code>false</code> if the local dimensions are at world scale.
      * @returns {Vec3} The dimensions converted to world coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
@@ -2135,7 +2053,7 @@ signals:
      * for a collision with an avatar.
      * <p>See also, {@link Entities|Entity Methods} and {@link Script.addEventHandler}.</p>
      * @function Entities.collisionWithEntity
-     * @param {Uuid} idA - The ID of one entity in the collision. For an entity script, this is the ID of the entity containing 
+     * @param {Uuid} idA - The ID of one entity in the collision. For an entity script, this is the ID of the entity containing
      *     the script.
      * @param {Uuid} idB - The ID of the other entity in the collision.
      * @param {Collision} collision - The details of the collision.
@@ -2175,7 +2093,7 @@ signals:
     /*@jsdoc
      * Triggered when your ability to change the <code>locked</code> property of entities changes.
      * @function Entities.canAdjustLocksChanged
-     * @param {boolean} canAdjustLocks - <code>true</code> if the script can change the <code>locked</code> property of an 
+     * @param {boolean} canAdjustLocks - <code>true</code> if the script can change the <code>locked</code> property of an
      *     entity, <code>false</code> if it can't.
      * @returns {Signal}
      * @example <caption>Report when your ability to change locks changes.</caption>
@@ -2198,7 +2116,7 @@ signals:
      * Triggered when your ability to rez (create) temporary entities changes. Temporary entities are entities with a finite
      * <code>lifetime</code> property value set.
      * @function Entities.canRezTmpChanged
-     * @param {boolean} canRezTmp - <code>true</code> if the script can rez (create) temporary entities, <code>false</code> if 
+     * @param {boolean} canRezTmp - <code>true</code> if the script can rez (create) temporary entities, <code>false</code> if
      *   it can't.
      * @returns {Signal}
      */
@@ -2216,12 +2134,12 @@ signals:
     /*@jsdoc
      * Triggered when your ability to get and set private user data changes.
      * @function Entities.canGetAndSetPrivateUserDataChanged
-     * @param {boolean} canGetAndSetPrivateUserData - <code>true</code> if the script can change the <code>privateUserData</code> 
+     * @param {boolean} canGetAndSetPrivateUserData - <code>true</code> if the script can change the <code>privateUserData</code>
      *     property of an entity, <code>false</code> if it can't.
      * @returns {Signal}
      */
     void canGetAndSetPrivateUserDataChanged(bool canGetAndSetPrivateUserData);
-    
+
     /*@jsdoc
      * Triggered when your ability to use avatar entities is changed.
      * @function Entities.canRezAvatarEntitiesChanged
@@ -2233,7 +2151,7 @@ signals:
 
 
     /*@jsdoc
-     * Triggered when a mouse button is clicked while the mouse cursor is on an entity, or a controller trigger is fully 
+     * Triggered when a mouse button is clicked while the mouse cursor is on an entity, or a controller trigger is fully
      * pressed while its laser is on an entity.
      * <p>See also, {@link Entities|Entity Methods} and {@link Script.addEventHandler}.</p>
      * @function Entities.mousePressOnEntity
@@ -2269,7 +2187,7 @@ signals:
     void mouseMoveOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
 
     /*@jsdoc
-     * Triggered when a mouse button is released after clicking on an entity or the controller trigger is partly or fully 
+     * Triggered when a mouse button is released after clicking on an entity or the controller trigger is partly or fully
      * released after pressing on an entity, even if the mouse pointer or controller laser has moved off the entity.
      * <p>See also, {@link Entities|Entity Methods} and {@link Script.addEventHandler}.</p>
      * @function Entities.mouseReleaseOnEntity
@@ -2310,14 +2228,14 @@ signals:
      *         print("Entity : Clicked sphere ; " + event.type);
      *     };
      * });
-     * 
+     *
      * var sphereID = Entities.addEntity({
      *     type: "Sphere",
      *     position: Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 0, z: -3 })),
      *     script: "(" + entityScript + ")",  // Could host the script on a Web server instead.
      *     lifetime: 300  // Delete after 5 minutes.
      * });
-     * 
+     *
      * Entities.clickDownOnEntity.connect(function (entityID, event) {
      *     // Signal is triggered for all entities.
      *     if (entityID === sphereID) {
@@ -2330,7 +2248,7 @@ signals:
     void clickDownOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
 
     /*@jsdoc
-     * Repeatedly triggered while a mouse button continues to be held after clicking an entity, even if the mouse cursor has 
+     * Repeatedly triggered while a mouse button continues to be held after clicking an entity, even if the mouse cursor has
      * moved off the entity. Note: Not triggered by controllers.
      * <p>See also, {@link Entities|Entity Methods} and {@link Script.addEventHandler}.</p>
      * @function Entities.holdingClickOnEntity
@@ -2341,7 +2259,7 @@ signals:
     void holdingClickOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
 
     /*@jsdoc
-     * Triggered when a mouse button is released after clicking on an entity, even if the mouse cursor has moved off the 
+     * Triggered when a mouse button is released after clicking on an entity, even if the mouse cursor has moved off the
      * entity. Note: Not triggered by controllers.
      * <p>See also, {@link Entities|Entity Methods} and {@link Script.addEventHandler}.</p>
      * @function Entities.clickReleaseOnEntity
@@ -2384,7 +2302,7 @@ signals:
 
     /*@jsdoc
      * Triggered when an avatar enters an entity.
-     * Note: At the initial loading of the script, if the avatar is already present inside the entity, it might be too late 
+     * Note: At the initial loading of the script, if the avatar is already present inside the entity, it might be too late
      * to catch this event when the script runs, so it won't trigger. The {@link Entities.preload|preload} signal can be used to handle those cases.
      * <p>See also, {@link Entities|Entity Methods} and {@link Script.addEventHandler}.</p>
      * @function Entities.enterEntity
@@ -2417,7 +2335,7 @@ signals:
 
     /*@jsdoc
      * Triggered when an entity is added to Interface's local in-memory tree of entities it knows about. This may occur when
-     * entities are loaded upon visiting a domain, when the user rotates their view so that more entities become visible, and 
+     * entities are loaded upon visiting a domain, when the user rotates their view so that more entities become visible, and
      * when any type of entity is created (e.g., by {@link Entities.addEntity|addEntity}).
      * @function Entities.addingEntity
      * @param {Uuid} entityID - The ID of the entity added.
@@ -2442,7 +2360,7 @@ signals:
     void deletingWearable(const EntityItemID& entityID);
 
     /*@jsdoc
-     * Triggered when a "wearable" entity is added to Interface's local in-memory tree of entities it knows about, for example 
+     * Triggered when a "wearable" entity is added to Interface's local in-memory tree of entities it knows about, for example
      * when adding a "wearable" to your avatar.
      * @function Entities.addingWearable
      * @param {Uuid} entityID - The ID of the "wearable" entity added.
@@ -2455,7 +2373,7 @@ signals:
     void addingWearable(const EntityItemID& entityID);
 
     /*@jsdoc
-     * Triggered when you disconnect from a domain, at which time Interface's local in-memory tree of entities that it knows 
+     * Triggered when you disconnect from a domain, at which time Interface's local in-memory tree of entities that it knows
      * about is cleared.
      * @function Entities.clearingEntities
      * @returns {Signal}
@@ -2465,13 +2383,13 @@ signals:
      * });
      */
     void clearingEntities();
-    
+
     /*@jsdoc
-     * Triggered when a script in a {@link Entities.EntityProperties-Web|Web} entity's HTML sends an event over the entity's 
+     * Triggered when a script in a {@link Entities.EntityProperties-Web|Web} entity's HTML sends an event over the entity's
      * HTML event bridge. The HTML web page can send a message by calling:
      * <pre class="prettyprint"><code>EventBridge.emitWebEvent(message);</code></pre>
      * <p>Use {@link Entities.emitScriptEvent} to send messages to the Web entity's HTML page.</p>
-     * <p>Alternatively, you can use {@link Entities.getEntityObject} to exchange messages over a Web entity's HTML event 
+     * <p>Alternatively, you can use {@link Entities.getEntityObject} to exchange messages over a Web entity's HTML event
      * bridge.</p>
      * @function Entities.webEventReceived
      * @param {Uuid} entityID - The ID of the Web entity that the message was received from.

--- a/libraries/graphics-scripting/src/graphics-scripting/Forward.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/Forward.h
@@ -89,7 +89,7 @@ namespace scriptable {
      * A material layer.
      * @typedef {object} Graphics.MaterialLayer
      * @property {Graphics.Material} material - The layer's material.
-     * @property {number} priority - The priority of the layer. If multiple materials are applied to a mesh part, only the 
+     * @property {number} priority - The priority of the layer. If multiple materials are applied to a mesh part, only the
      *     layer with the highest priority is applied, with materials of the same priority randomly assigned.
      */
     class ScriptableMaterialLayer {
@@ -117,31 +117,19 @@ namespace scriptable {
         ScriptableMeshBase& operator=(const ScriptableMeshBase& view);
         virtual ~ScriptableMeshBase();
 
-        /*@jsdoc
-         * @function GraphicsMesh.getMeshPointer
-         * @deprecated This method is deprecated and will be removed.
-         * @returns {undefined}
-         */
+        // TODO: Deprecated by documentation, please review for accuracy
         // scriptable::MeshPointer is not registered as a JavaScript type.
         Q_INVOKABLE const scriptable::MeshPointer getMeshPointer() const { return weakMesh.lock(); }
 
-        /*@jsdoc
-         * @function GraphicsMesh.getModelProviderPointer
-         * @deprecated This method is deprecated and will be removed.
-         * @returns {undefined}
-         */
+        // TODO: Deprecated by documentation, please review for accuracy
         // scriptable::ModelProviderPointer is not registered as a JavaScript type.
         Q_INVOKABLE const scriptable::ModelProviderPointer getModelProviderPointer() const { return provider.lock(); }
 
-        /*@jsdoc
-         * @function GraphicsMesh.getModelBasePointer
-         * @deprecated This method is deprecated and will be removed.
-         * @returns {undefined}
-         */
+        // TODO: Deprecated by documentation, please review for accuracy
         // scriptable::ScriptableModelBasePointer is not registered as a JavaScript type.
         Q_INVOKABLE const scriptable::ScriptableModelBasePointer getModelBasePointer() const { return model; }
     };
-    
+
     // abstract container for holding one or more references to mesh pointers
     class ScriptableModelBase : public QObject {
         Q_OBJECT

--- a/libraries/material-networking/src/material-networking/TextureCacheScriptingInterface.h
+++ b/libraries/material-networking/src/material-networking/TextureCacheScriptingInterface.h
@@ -43,7 +43,6 @@ class TextureCacheScriptingInterface : public ScriptableResourceCache, public De
      *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
-     * @borrows ResourceCache.updateTotalSize as updateTotalSize
      * @borrows ResourceCache.prefetch as prefetch
      * @borrows ResourceCache.dirty as dirty
      */
@@ -57,18 +56,14 @@ public:
      * @variation 0
      * @param {string} url - The URL of the texture to prefetch.
      * @param {TextureCache.TextureType} type - The type of the texture.
-     * @param {number} [maxNumPixels=67108864] - The maximum number of pixels to use for the image. If the texture has more 
+     * @param {number} [maxNumPixels=67108864] - The maximum number of pixels to use for the image. If the texture has more
      *     than this number it is downscaled.
      * @returns {ResourceObject} A resource object.
      */
     Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type, int maxNumPixels = ABSOLUTE_MAX_TEXTURE_NUM_PIXELS);
 
 signals:
-    /*@jsdoc
-     * @function TextureCache.spectatorCameraFramebufferReset
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void spectatorCameraFramebufferReset();
 };
 

--- a/libraries/midi/src/Midi.h
+++ b/libraries/midi/src/Midi.h
@@ -56,14 +56,7 @@ private:
     void MidiCleanup();
 
 signals:
-
-    /*@jsdoc
-     * Triggered when a connected device sends an output.
-     * @function Midi.midiNote
-     * @param {Midi.MidiMessage} message - The MIDI message.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed. Use {@link Midi.midiMessage|midiMessage} instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void midiNote(QVariantMap eventData);
 
     /*@jsdoc

--- a/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
+++ b/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
@@ -43,7 +43,6 @@ class ModelCacheScriptingInterface : public ScriptableResourceCache, public Depe
      *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
-     * @borrows ResourceCache.updateTotalSize as updateTotalSize
      * @borrows ResourceCache.prefetch as prefetch
      * @borrows ResourceCache.dirty as dirty
      */

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -71,66 +71,7 @@ const QString GET_PLACE = "/api/v1/places/%1";
  *     <em>Read-only.</em>
  */
 
-/*@jsdoc
- * The <code>AddressManager</code> API provides facilities related to your current location in the directory services.
- *
- * @namespace AddressManager
- *
- * @hifi-interface
- * @hifi-client-entity
- * @hifi-avatar
- *
- * @deprecated This API is deprecated and will be removed. Use the {@link location} or {@link Window|Window.location} APIs
- * instead.
- *
- * @property {Uuid} domainID - A UUID uniquely identifying the domain you're visiting. Is {@link Uuid(0)|Uuid.NULL} if you're not
- *     connected to the domain or are in a serverless domain.
- *     <em>Read-only.</em>
- * @property {string} hostname - The name of the domain for your current directory services address (e.g., <code>"DomainName"</code>,
- *     <code>localhost</code>, or an IP address). Is blank if you're in a serverless domain.
- *     <em>Read-only.</em>
- * @property {string} href - Your current directory services address (e.g., <code>"hifi://domainname/15,-10,26/0,0,0,1"</code>)
- *     regardless of whether or not you're connected to the domain. Starts with <code>"file:///"</code> if you're in a
- *     serverless domain.
- *     <em>Read-only.</em>
- * @property {boolean} isConnected - <code>true</code> if you're connected to the domain in your current <code>href</code>
- *     directory services address, otherwise <code>false</code>.
- * @property {string} pathname - The location and orientation in your current <code>href</code> directory services address
- *     (e.g., <code>"/15,-10,26/0,0,0,1"</code>).
- *     <em>Read-only.</em>
- * @property {string} placename - The place name in your current <code>href</code> directory services address
- *     (e.g., <code>"DomainName"</code>). Is blank if your <code>hostname</code> is an IP address.
- *     <em>Read-only.</em>
- * @property {string} protocol - The protocol of your current <code>href</code> directory services address (e.g., <code>"hifi"</code>).
- *     <em>Read-only.</em>
- *
- * @borrows location.handleLookupString as handleLookupString
- * @borrows location.goToViewpointForPath as goToViewpointForPath
- * @borrows location.goBack as goBack
- * @borrows location.goForward as goForward
- * @borrows location.goToLocalSandbox as goToLocalSandbox
- * @borrows location.goToEntry as goToEntry
- * @borrows location.goToUser as goToUser
- * @borrows location.goToLastAddress as goToLastAddress
- * @borrows location.canGoBack as canGoBack
- * @borrows location.refreshPreviousLookup as refreshPreviousLookup
- * @borrows location.storeCurrentAddress as storeCurrentAddress
- * @borrows location.copyAddress as copyAddress
- * @borrows location.copyPath as copyPath
- * @borrows location.lookupShareableNameForDomainID as lookupShareableNameForDomainID
- *
- * @borrows location.lookupResultsFinished as lookupResultsFinished
- * @borrows location.lookupResultIsOffline as lookupResultIsOffline
- * @borrows location.lookupResultIsNotFound as lookupResultIsNotFound
- * @borrows location.possibleDomainChangeRequired as possibleDomainChangeRequired
- * @borrows location.locationChangeRequired as locationChangeRequired
- * @borrows location.possibleDomainChangeRequiredViaICEForID as possibleDomainChangeRequiredViaICEForID
- * @borrows location.pathChangeRequired as pathChangeRequired
- * @borrows location.hostChanged as hostChanged
- * @borrows location.goBackPossible as goBackPossible
- * @borrows location.goForwardPossible as goForwardPossible
- */
-
+// TODO: Deprecated by documentation, please review for accuracy
 class AddressManager : public QObject, public Dependency {
     Q_OBJECT
     SINGLETON_DEPENDENCY
@@ -261,14 +202,7 @@ public slots:
      */
     void handleLookupString(const QString& lookupString, bool fromSuggestions = false);
 
-    /*@jsdoc
-     * Takes you to a position and orientation resulting from a lookup for a named path in the domain (set in the domain
-     * server's settings).
-     * @function location.goToViewpointForPath
-     * @param {string} path - The position and orientation corresponding to the named path.
-     * @param {string} namedPath - The named path that was looked up on the server.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // This function is marked as deprecated in anticipation that it will not be included in the JavaScript API if and when the
     // functions and signals that should be exposed are moved to a scripting interface class.
     //
@@ -329,11 +263,7 @@ public slots:
      */
     bool canGoBack() const;
 
-    /*@jsdoc
-     * Refreshes the current address, e.g., after connecting to a domain in order to position the user to the desired location.
-     * @function location.refreshPreviousLookup
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // This function is marked as deprecated in anticipation that it will not be included in the JavaScript API if and when the
     // functions and signals that should be exposed are moved to a scripting interface class.
     void refreshPreviousLookup();
@@ -358,12 +288,7 @@ public slots:
      */
     void copyPath();
 
-    /*@jsdoc
-     * Retrieves and remembers the place name for the given domain ID if the place name is not already known.
-     * @function location.lookupShareableNameForDomainID
-     * @param {Uuid} domainID - The UUID of the domain.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // This function is marked as deprecated in anticipation that it will not be included in the JavaScript API if and when the
     // functions and signals that should be exposed are moved to a scripting interface class.
     void lookupShareableNameForDomainID(const QUuid& domainID);

--- a/libraries/procedural/src/procedural/MaterialCacheScriptingInterface.h
+++ b/libraries/procedural/src/procedural/MaterialCacheScriptingInterface.h
@@ -42,7 +42,6 @@ class MaterialCacheScriptingInterface : public ScriptableResourceCache, public D
      *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
-     * @borrows ResourceCache.updateTotalSize as updateTotalSize
      * @borrows ResourceCache.prefetch as prefetch
      * @borrows ResourceCache.dirty as dirty
      */

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -201,11 +201,6 @@ void ScriptEngines::shutdownScripting() {
  * Information on a public script, i.e., a script that's included in the Interface installation.
  * @typedef {object} ScriptDiscoveryService.PublicScript
  * @property {string} name - The script's file name.
- * @property {string} type - <code>"script"</code> or <code>"folder"</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed. It currently always has the value,
- *     <code>"script"</code>.</p>
- * @property {ScriptDiscoveryService.PublicScript[]} [children] - Only present if <code>type == "folder"</code>.
- *     <p class="important">Deprecated: This property is deprecated and will be removed. It currently is never present.
  * @property {string} [url] - The full URL of the script &mdash; including the <code>"file:///"</code> scheme at the start.
  *     <p>Only present if <code>type == "script"</code>.</p>
  */
@@ -240,13 +235,7 @@ QVariantList ScriptEngines::getPublic() {
     return getPublicChildNodes(NULL);
 }
 
-/*@jsdoc
- * Information on a local script.
- * @typedef {object} ScriptDiscoveryService.LocalScript
- * @property {string} name - The script's file name.
- * @property {string} path - The script's path.
- * @deprecated This type is deprecated and will be removed.
- */
+// TODO: Deprecated by documentation, please review for accuracy
 QVariantList ScriptEngines::getLocal() {
     QVariantList result;
     QList<TreeNodeBase*> treeNodes = getScriptsModel().getFolderNodes(NULL);

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -165,11 +165,7 @@ public:
      */
     Q_INVOKABLE QVariantList getPublic();
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.getLocal
-     * @returns {ScriptDiscoveryService.LocalScript[]} Local scripts.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because there is no longer a notion of a "local" scripts folder where you would put your personal scripts.
     Q_INVOKABLE QVariantList getLocal();
 
@@ -254,12 +250,7 @@ signals:
      */
     void infoMessage(const QString& message, const QString& engineName);
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.errorLoadingScript
-     * @param {string} url - URL.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because never emitted.
     void errorLoadingScript(const QString& url);
 
@@ -272,65 +263,33 @@ signals:
 
 public slots:
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.onPrintedMessage
-     * @param {string} message - Message.
-     * @param {string} scriptName - Script name.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because only use is to emit a signal.
     void onPrintedMessage(const QString& message, const QString& scriptName);
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.onErrorMessage
-     * @param {string} message - Message.
-     * @param {string} scriptName - Script name.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because only use is to emit a signal.
     void onErrorMessage(const QString& message, const QString& scriptName);
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.onWarningMessage
-     * @param {string} message - Message.
-     * @param {string} scriptName - Script name.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because only use is to emit a signal.
     void onWarningMessage(const QString& message, const QString& scriptName);
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.onInfoMessage
-     * @param {string} message - Message.
-     * @param {string} scriptName - Script name.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because only use is to emit a signal.
     void onInfoMessage(const QString& message, const QString& scriptName);
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.onErrorLoadingScript
-     * @param {string} url - URL.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because only use is to emit a signal. And it isn't used.
     void onErrorLoadingScript(const QString& url);
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.onClearDebugWindow
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because only use is to emit a signal.
     void onClearDebugWindow();
 
 protected slots:
 
-    /*@jsdoc
-     * @function ScriptDiscoveryService.onScriptFinished
-     * @param {string} scriptName - Script name.
-     * @param {object} manager - Script manager.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Deprecated because it wasn't intended to be in the API.
     void onScriptFinished(const QString& fileNameString, ScriptManagerPointer manager);
 

--- a/libraries/script-engine/src/ScriptManagerScriptingInterface.h
+++ b/libraries/script-engine/src/ScriptManagerScriptingInterface.h
@@ -68,15 +68,13 @@ public:
      * Stops and unloads the current script.
      * <p><strong>Warning:</strong> If an assignment client script, the script gets restarted after stopping.</p>
      * @function Script.stop
-     * @param {boolean} [marshal=false] - Marshal.
-     *     <p class="important">Deprecated: This parameter is deprecated and will be removed.</p>
      * @example <caption>Stop a script after 5s.</caption>
      * Script.setInterval(function () {
      *     print("Hello");
      * }, 1000);
      *
      * Script.setTimeout(function () {
-     *     Script.stop(true);
+     *     Script.stop();
      * }, 5000);
      */
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -147,13 +145,7 @@ public:
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // NOTE - these are intended to be public interfaces available to scripts
 
-    /*@jsdoc
-     * @function Script.formatExecption
-     * @param {object} exception - Exception.
-     * @param {boolean} inludeExtendeDetails - Include extended details.
-     * @returns {string} String.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE QString formatException(const ScriptValue& exception, bool includeExtendedDetails) { return _manager->formatException(exception, includeExtendedDetails); }
 
     /*@jsdoc
@@ -263,11 +255,7 @@ public:
      */
     Q_INVOKABLE ScriptValue require(const QString& moduleId) { return _manager->require(moduleId); }
 
-    /*@jsdoc
-     * @function Script.resetModuleCache
-     * @param {boolean} [deleteScriptCache=false] - Delete script cache.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void resetModuleCache(bool deleteScriptCache = false) { _manager->resetModuleCache(deleteScriptCache);}
 
     /*@jsdoc
@@ -405,28 +393,13 @@ public:
      */
     Q_INVOKABLE void logBacktrace(const QString &title) { _manager->logBacktrace(title); }
 
-    /*@jsdoc
-     * @function Script.loadEntityScript
-     * @param {Uuid} entityID - Entity ID.
-     * @param {string} script - Script.
-     * @param {boolean} forceRedownload - Force re-download.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void loadEntityScript(const EntityItemID& entityID, const QString& entityScript, bool forceRedownload) { _manager->loadEntityScript(entityID, entityScript, forceRedownload); }
 
-    /*@jsdoc
-     * @function Script.unloadEntityScript
-     * @param {Uuid} entityID - Entity ID.
-     * @param {boolean} [shouldRemoveFromMap=false] - Should remove from map.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void unloadEntityScript(const EntityItemID& entityID, bool shouldRemoveFromMap = false) { _manager->unloadEntityScript(entityID, shouldRemoveFromMap); }
 
-    /*@jsdoc
-     * @function Script.unloadAllEntityScripts
-     * @param {boolean} [blockingCall=false] - Wait for completion if call moved to another thread.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void unloadAllEntityScripts(bool blockingCall = false) { _manager->unloadAllEntityScripts(blockingCall); }
 
     /*@jsdoc
@@ -441,32 +414,13 @@ public:
                                             const QStringList& params = QStringList(),
                                             const QUuid& remoteCallerID = QUuid()) { _manager->callEntityScriptMethod(entityID, methodName, params, remoteCallerID); }
 
-    /*@jsdoc
-     * Calls a method in an entity script.
-     * @function Script.callEntityScriptMethod
-     * @param {Uuid} entityID - Entity ID.
-     * @param {string} methodName - Method name.
-     * @param {PointerEvent} event - Pointer event.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const PointerEvent& event) { _manager->callEntityScriptMethod(entityID, methodName, event); }
 
-    /*@jsdoc
-     * Calls a method in an entity script.
-     * @function Script.callEntityScriptMethod
-     * @param {Uuid} entityID - Entity ID.
-     * @param {string} methodName - Method name.
-     * @param {Uuid} otherID - Other entity ID.
-     * @param {Collision} collision - Collision.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void callEntityScriptMethod(const EntityItemID& entityID, const QString& methodName, const EntityItemID& otherID, const Collision& collision) { _manager->callEntityScriptMethod(entityID, methodName, otherID, collision);}
 
-    /*@jsdoc
-     * @function Script.generateUUID
-     * @returns {Uuid} A new UUID.
-     * @deprecated This function is deprecated and will be removed. Use {@link Uuid(0).generate|Uuid.generate} instead.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE QUuid generateUUID() { return QUuid::createUuid(); }
 
     /*@jsdoc
@@ -559,20 +513,10 @@ public:
 
 signals:
 
-    /*@jsdoc
-     * @function Script.scriptLoaded
-     * @param {string} filename - File name.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void scriptLoaded(const QString& scriptFilename);
 
-    /*@jsdoc
-     * @function Script.errorLoadingScript
-     * @param {string} filename - File name.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void errorLoadingScript(const QString& scriptFilename);
 
     /*@jsdoc
@@ -651,29 +595,12 @@ signals:
      */
     void runningStateChanged();
 
-    /*@jsdoc
-     * @function Script.clearDebugWindow
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void clearDebugWindow();
 
-    /*@jsdoc
-     * @function Script.loadScript
-     * @param {string} scriptName - Script name.
-     * @param {boolean} isUserLoaded - Is user loaded.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void loadScript(const QString& scriptName, bool isUserLoaded);
 
-    /*@jsdoc
-     * @function Script.reloadScript
-     * @param {string} scriptName - Script name.
-     * @param {boolean} isUserLoaded - Is user loaded.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
     void reloadScript(const QString& scriptName, bool isUserLoaded);
 
     /*@jsdoc
@@ -683,13 +610,7 @@ signals:
      */
     void doneRunning();
 
-    /*@jsdoc
-     * @function Script.entityScriptDetailsUpdated
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-    // Emitted when an entity script is added or removed, or when the status of an entity
-    // script is updated (goes from RUNNING to ERROR_RUNNING_SCRIPT, for example)
+    // TODO: Deprecated by documentation, please review for accuracy
     void entityScriptDetailsUpdated();
 
     /*@jsdoc
@@ -734,39 +655,10 @@ signals:
     void unhandledException(const ScriptValue& exception);
 
 protected:
-    /*@jsdoc
-     * @function Script.executeOnScriptThread
-     * @param {function} function - Function.
-     * @param {ConnectionType} [type=2] - Connection type.
-     * @deprecated This function is deprecated and will be removed.
-     */
-    // V8TODO: Nothing seems to be using this, and it generates:
-    // hifi.scriptengine: Parameter  1 in method  ScriptManagerScriptingInterface :: "executeOnScriptThread"  is of type QMetaType::UnknownType
-    // so removing for now.
-    //
-    // Q_INVOKABLE void executeOnScriptThread(std::function<void()> function, const Qt::ConnectionType& type = Qt::QueuedConnection ) { _manager->executeOnScriptThread(function, type);}
-
-    /*@jsdoc
-     * @function Script._requireResolve
-     * @param {string} module - Module.
-     * @param {string} [relativeTo=""] - Relative to.
-     * @returns {string} Result.
-     * @deprecated This function is deprecated and will be removed.
-     */
-    // note: this is not meant to be called directly, but just to have QMetaObject take care of wiring it up in general;
-    //   then inside of init() we just have to do "Script.require.resolve = Script._requireResolve;"
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE QString _requireResolve(const QString& moduleId, const QString& relativeTo = QString()) { return _manager->_requireResolve(moduleId, relativeTo); }
 
-    /*@jsdoc
-     * @function Script.entityScriptContentAvailable
-     * @param {Uuid} entityID - Entity ID.
-     * @param {string} scriptOrURL - Path.
-     * @param {string} contents - Contents.
-     * @param {boolean} isURL - Is a URL.
-     * @param {boolean} success - Success.
-     * @param {string} status - Status.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void entityScriptContentAvailable(const EntityItemID& entityID, const QString& scriptOrURL, const QString& contents, bool isURL, bool success, const QString& status)
         { _manager->entityScriptContentAvailable(entityID, scriptOrURL, contents, isURL, success, status); }
 

--- a/libraries/script-engine/src/ScriptsModel.h
+++ b/libraries/script-engine/src/ScriptsModel.h
@@ -70,10 +70,10 @@ public:
 };
 
 /*@jsdoc
- * Information on the scripts that are in the default scripts directory of the Interface installation. This is provided as a 
+ * Information on the scripts that are in the default scripts directory of the Interface installation. This is provided as a
  * property of {@link ScriptDiscoveryService}.
  *
- * <p>The information provided reflects the subdirectory structure. Methods and signals are per QT's 
+ * <p>The information provided reflects the subdirectory structure. Methods and signals are per QT's
  * <a href="http://doc.qt.io/qt-5/qabstractitemmodel.html">QAbstractItemModel</a> class, with the following details:</p>
  * <ul>
  *   <li>A single column of data: <code>columnCount(index)</code> returns <code>1</code>. </li>
@@ -84,7 +84,7 @@ public:
  *       </thead>
  *       <tbody>
  *         <tr><td>Display</td><td><code>0</code></td><td>The directory or script file name.</td></tr>
- *         <tr><td>Path</td><td><code>256</code></td><td>The path and filename of the data item if it is a script, 
+ *         <tr><td>Path</td><td><code>256</code></td><td>The path and filename of the data item if it is a script,
  *         <code>undefined</code> if it is a directory.</td></tr>
  *       </tbody>
  *     </table>
@@ -103,24 +103,24 @@ public:
  * var MAX_DIRECTORY_LEVEL = 1;
  * var DISPLAY_ROLE = 0;
  * var PATH_ROLE = 256;
- * 
+ *
  * function printDirectory(parentIndex, directoryLevel, indent) {
  *     var numRows = ScriptDiscoveryService.scriptsModel.rowCount(parentIndex);
  *     for (var i = 0; i < numRows; i++) {
  *         var rowIndex = ScriptDiscoveryService.scriptsModel.index(i, 0, parentIndex);
- * 
+ *
  *         var name = ScriptDiscoveryService.scriptsModel.data(rowIndex, DISPLAY_ROLE);
  *         var hasChildren = ScriptDiscoveryService.scriptsModel.hasChildren(rowIndex);
  *         var path = hasChildren ? "" : ScriptDiscoveryService.scriptsModel.data(rowIndex, PATH_ROLE);
- * 
+ *
  *         print(indent + "- " + name + (hasChildren ? "" : " - " + path));
- * 
+ *
  *         if (hasChildren && directoryLevel < MAX_DIRECTORY_LEVEL) {
  *             printDirectory(rowIndex, directoryLevel + 1, indent + "    ");
  *         }
  *     }
  * }
- * 
+ *
  * print("Scripts:");
  * printDirectory(null, 0, "");  // null index for the root directory.
  */
@@ -158,29 +158,16 @@ public:
 
 protected slots:
 
-    /*@jsdoc
-     * @function ScriptsModel.updateScriptsLocation
-     * @param {string} newPath - New path.
-     * @deprecated This method is deprecated and will be removed from the API.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void updateScriptsLocation(const QString& newPath);
 
-    /*@jsdoc
-     * @function ScriptsModel.downloadFinished
-     * @deprecated This method is deprecated and will be removed from the API.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void downloadFinished();
 
-    /*@jsdoc
-     * @function ScriptsModel.reloadLocalFiles
-     * @deprecated This method is deprecated and will be removed from the API.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void reloadLocalFiles();
 
-    /*@jsdoc
-     * @function ScriptsModel.reloadDefaultFiles
-     * @deprecated This method is deprecated and will be removed from the API.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void reloadDefaultFiles();
 
 protected:

--- a/libraries/shared/src/PathUtils.h
+++ b/libraries/shared/src/PathUtils.h
@@ -18,20 +18,7 @@
 
 #include "DependencyManager.h"
 
-/*@jsdoc
- * The <code>Paths</code> API provides absolute paths to the scripts and resources directories.
- *
- * @namespace Paths
- *
- * @hifi-interface
- * @hifi-client-entity
- * @hifi-avatar
- *
- * @deprecated The Paths API is deprecated. Use {@link Script.resolvePath} and {@link Script.resourcesPath} instead.
- * @readonly
- * @property {string} defaultScripts - The path to the scripts directory. <em>Read-only.</em>
- * @property {string} resources - The path to the resources directory. <em>Read-only.</em>
- */
+// TODO: Deprecated by documentation, please review for accuracy
 class PathUtils : public QObject, public Dependency {
     Q_OBJECT
     SINGLETON_DEPENDENCY

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -96,7 +96,7 @@ glm::vec2 vec2FromVariant(const QVariant& object);
 * @property {number} x - X-coordinate of the vector. Synonyms: <code>r</code>, <code>red</code>.
 * @property {number} y - Y-coordinate of the vector. Synonyms: <code>g</code>, <code>green</code>.
 * @property {number} z - Z-coordinate of the vector. Synonyms: <code>b</code>, <code>blue</code>.
-* @example <caption>Vec3 values can be set in multiple ways and modified with their aliases, but still stringify in the same 
+* @example <caption>Vec3 values can be set in multiple ways and modified with their aliases, but still stringify in the same
 *     way.</caption>
 * Entities.editEntity(<id>, { position: { x: 1, y: 2, z: 3 }});                 // { x: 1, y: 2, z: 3 }
 * Entities.editEntity(<id>, { position: { r: 4, g: 5, b: 6 }});                 // { x: 4, y: 5, z: 6 }
@@ -199,7 +199,7 @@ public:
 };
 
 /*@jsdoc
- * A vector with a starting point. It is used, for example, when finding entities or avatars that lie under a mouse click or 
+ * A vector with a starting point. It is used, for example, when finding entities or avatars that lie under a mouse click or
  * intersect a laser beam.
  *
  * @typedef {object} PickRay
@@ -233,7 +233,7 @@ Q_DECLARE_METATYPE(PickRay)
  * The tip of a stylus.
  *
  * @typedef {object} StylusTip
- * @property {number} side - The hand that the stylus is attached to: <code>0</code> for left hand, <code>1</code> for the 
+ * @property {number} side - The hand that the stylus is attached to: <code>0</code> for left hand, <code>1</code> for the
  *     right hand, <code>-1</code> for invalid.
  * @property {Vec3} tipOffset - The position of the stylus tip relative to the body of the stylus.
  * @property {Vec3} position - The position of the stylus tip.
@@ -277,11 +277,11 @@ public:
 * avatars that intersect a parabolic beam.
 *
 * @typedef {object} PickParabola
-* @property {Vec3} origin - The starting position of the parabola, i.e., the initial position of a virtual projectile whose 
+* @property {Vec3} origin - The starting position of the parabola, i.e., the initial position of a virtual projectile whose
 *     trajectory defines the parabola.
-* @property {Vec3} velocity - The starting velocity of the parabola in m/s, i.e., the initial speed of a virtual projectile 
+* @property {Vec3} velocity - The starting velocity of the parabola in m/s, i.e., the initial speed of a virtual projectile
 *     whose trajectory defines the parabola.
-* @property {Vec3} acceleration - The acceleration that the parabola experiences in m/s<sup>2</sup>, i.e., the acceleration of 
+* @property {Vec3} acceleration - The acceleration that the parabola experiences in m/s<sup>2</sup>, i.e., the acceleration of
 *     a virtual projectile whose trajectory defines the parabola, both magnitude and direction.
 */
 class PickParabola : public MathPick {
@@ -365,9 +365,9 @@ public:
     /*@jsdoc
      * A volume for checking collisions in the physics simulation.
      * @typedef {object} CollisionRegion
-     * @property {Shape} shape - The collision region's shape and size. Dimensions are in world coordinates, but scale with the 
+     * @property {Shape} shape - The collision region's shape and size. Dimensions are in world coordinates, but scale with the
      *     parent if defined.
-     * @property {boolean} loaded - <code>true</code> if the <code>shape</code> has no model, or has a model and it is loaded, 
+     * @property {boolean} loaded - <code>true</code> if the <code>shape</code> has no model, or has a model and it is loaded,
      *     <code>false</code> if otherwise.
      * @property {Vec3} position - The position of the collision region, relative to the parent if defined.
      * @property {Quat} orientation - The orientation of the collision region, relative to the parent if defined.
@@ -606,26 +606,13 @@ namespace graphics {
 
 using MeshPointer = std::shared_ptr<graphics::Mesh>;
 
-/*@jsdoc
- * A mesh, such as returned by {@link Entities.getMeshes} or {@link Model} API functions.
- *
- * @class MeshProxy
- * @hideconstructor
- *
- * @hifi-interface
- * @hifi-client-entity
- * @hifi-avatar
- * @hifi-server-entity
- * @hifi-assignment-client
- *
- * @deprecated Use the {@link Graphics} API instead.
- */
+// TODO: Deprecated by documentation, please review for accuracy
 class MeshProxy : public QObject {
     Q_OBJECT
 
 public:
     virtual MeshPointer getMeshPointer() const = 0;
-    
+
     /*@jsdoc
      * Gets the number of vertices in the mesh.
      * @function MeshProxy#getNumVertices

--- a/libraries/ui/src/QmlWebWindowClass.h
+++ b/libraries/ui/src/QmlWebWindowClass.h
@@ -27,11 +27,11 @@ class ScriptEngine;
  *
  * @class OverlayWebWindow
  * @param {string|OverlayWindow.Properties} [titleOrProperties="WebWindow"] - The window's title or initial property values.
- * @param {string} [source="about:blank"] - The URL of the HTML to display. Not used unless the first parameter is the window 
+ * @param {string} [source="about:blank"] - The URL of the HTML to display. Not used unless the first parameter is the window
  *     title.
- * @param {number} [width=0] - The width of the window interior, in pixels. Not used unless the first parameter is the window 
+ * @param {number} [width=0] - The width of the window interior, in pixels. Not used unless the first parameter is the window
  *     title.
- * @param {number} [height=0] - The height of the window interior, in pixels. Not used unless the first parameter is the 
+ * @param {number} [height=0] - The height of the window interior, in pixels. Not used unless the first parameter is the
  *     window title.
  *
  * @hifi-interface
@@ -73,24 +73,6 @@ class ScriptEngine;
  */
 
 /*@jsdoc
- * @function OverlayWebWindow.clearDebugWindow
- * @deprecated This method is deprecated and will be removed.
- */
-
-/*@jsdoc
- * @function OverlayWebWindow.sendToQML
- * @param {string | object} message - Message.
- * @deprecated This method is deprecated and will be removed.
- */
-
-/*@jsdoc
- * @function OverlayWebWindow.fromQML
- * @param {object} message - Message.
- * @returns {Signal}
- * @deprecated This signal is deprecated and will be removed.
- */
-
-/*@jsdoc
  * Sends a message to the HTML page. To receive the message, the HTML page's script must connect to the <code>EventBridge</code>
  * that is automatically provided for the script:
  * <pre class="prettyprint"><code>EventBridge.scriptEventReceived.connect(function(message) {
@@ -107,11 +89,11 @@ class ScriptEngine;
  *     width: 400,
  *     height: 300
  * });
- * 
+ *
  * overlayWebWindow.webEventReceived.connect(function (message) {
  *     print("Message received: " + message);
  * });
- * 
+ *
  * Script.setTimeout(function () {
  *     overlayWebWindow.emitScriptEvent("Hello world!");
  * }, 2000);
@@ -145,7 +127,7 @@ class ScriptEngine;
  */
 
 
-// FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping 
+// FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping
 class QmlWebWindowClass : public QmlWindowClass {
     Q_OBJECT
     Q_PROPERTY(QString url READ getURL CONSTANT)

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -24,8 +24,8 @@ class ScriptEngine;
 /*@jsdoc
  * A <code>OverlayWindow</code> displays a QML window inside Interface.
  *
- * <p>The QML can optionally include a <code>WebView</code> control that embeds an HTML-based windows. (The <code>WebView</code> 
- * control is defined by a "WebView.qml" file included in the Interface install.) Alternatively, an {@link OverlayWebWindow} 
+ * <p>The QML can optionally include a <code>WebView</code> control that embeds an HTML-based windows. (The <code>WebView</code>
+ * control is defined by a "WebView.qml" file included in the Interface install.) Alternatively, an {@link OverlayWebWindow}
  * can be used for HTML-based windows.</p>
  *
  * <p>Create using <code>new OverlayWindow(...)</code>.</p>
@@ -47,7 +47,7 @@ class ScriptEngine;
  * @property {boolean} visible - <code>true</code> if the window is visible, <code>false</code> if it isn't.
  */
 
-// FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping 
+// FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping
 class QmlWindowClass : public QObject {
     Q_OBJECT
     Q_PROPERTY(glm::vec2 position READ getPosition WRITE setPosition NOTIFY positionChanged)
@@ -68,11 +68,7 @@ public:
     QmlWindowClass(bool restricted);
     ~QmlWindowClass();
 
-    /*@jsdoc
-     * @function OverlayWindow.initQml
-     * @param {OverlayWindow.Properties} properties - Properties.
-     * @deprecated This method is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // FIXME: This shouldn't be in the API. It is an internal function used in object construction.
     Q_INVOKABLE virtual void initQml(QVariantMap properties);
 
@@ -162,11 +158,7 @@ public slots:
      */
     Q_INVOKABLE void close();
 
-    /*@jsdoc
-     * @function OverlayWindow.getEventBridge
-     * @returns {object} Object.
-     * @deprecated This method is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Shouldn't be in the API: It returns the OverlayWindow object, not the even bridge.
     Q_INVOKABLE QObject* getEventBridge() { return this; };
 
@@ -180,37 +172,37 @@ public slots:
      * @param {string | object} message - The message to send to the QML.
      * @example <caption>Send and receive messages with a QML window.</caption>
      * // JavaScript file.
-     * 
+     *
      * var overlayWindow = new OverlayWindow({
      *     title: "Overlay Window",
      *     source: Script.resolvePath("OverlayWindow.qml"),
      *     width: 400,
      *     height: 300
      * });
-     * 
+     *
      * overlayWindow.fromQml.connect(function (message) {
      *     print("Message received: " + message);
      * });
-     * 
+     *
      * Script.setTimeout(function () {
      *     overlayWindow.sendToQml("Hello world!");
      * }, 2000);
-     * 
+     *
      * @example
      * // QML file, "OverlayWindow.qml".
      *
      * import QtQuick 2.5
      * import QtQuick.Controls 1.4
-     * 
+     *
      * Rectangle {
      *     width: parent.width
      *     height: parent.height
-     * 
+     *
      *     function fromScript(message) {
      *         text.text = message;
      *         sendToScript("Hello back!");
      *     }
-     * 
+     *
      *     Label{
      *         id: text
      *         anchors.centerIn : parent
@@ -221,10 +213,7 @@ public slots:
     // Scripts can use this to send a message to the QML object
     void sendToQml(const QVariant& message);
 
-    /*@jsdoc
-     * Calls a <code>clearWindow()</code> function if present in the QML.
-     * @function OverlayWindow.clearDebugWindow
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void clearDebugWindow();
 
     /*@jsdoc
@@ -239,11 +228,7 @@ public slots:
     // QmlWindow content may include WebView requiring EventBridge.
     void emitScriptEvent(const QVariant& scriptMessage);
 
-    /*@jsdoc
-     * @function OverlayWindow.emitWebEvent
-     * @param {object|string} message - The message.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void emitWebEvent(const QVariant& webMessage);
 
 signals:
@@ -302,13 +287,7 @@ signals:
     // Scripts can connect to this signal to receive messages from the QML object
     void fromQml(const QVariant& message);
 
-
-    /*@jsdoc
-     * @function OverlayWindow.scriptEventReceived
-     * @param {object} message - The message.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // QmlWindow content may include WebView requiring EventBridge.
     void scriptEventReceived(const QVariant& message);
 
@@ -323,32 +302,21 @@ signals:
 
 protected slots:
 
-    /*@jsdoc
-     * @function OverlayWindow.hasMoved
-     * @param {Vec2} position - Position.
-     * @deprecated This method is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Shouldn't be in the API: it is just connected to in order to emit a signal.
     void hasMoved(QVector2D);
 
-    /*@jsdoc
-     * @function OverlayWindow.hasClosed
-     * @deprecated This method is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Shouldn't be in the API: it is just connected to in order to emit a signal.
     void hasClosed();
 
-    /*@jsdoc
-     * @function OverlayWindow.qmlToScript
-     * @param {object} message - Message.
-     * @deprecated This method is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Shouldn't be in the API: it is just connected to in order to emit a signal.
     void qmlToScript(const QVariant& message);
 
 protected:
     static QVariantMap parseArguments(ScriptContext* context);
-    static ScriptValue internalConstructor(ScriptContext* context, ScriptEngine* engine, 
+    static ScriptValue internalConstructor(ScriptContext* context, ScriptEngine* engine,
         std::function<QmlWindowClass*(QVariantMap)> function);
 
     virtual QString qmlSource() const { return "QmlWindow.qml"; }

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -38,7 +38,7 @@ class QmlWindowClass;
 class OffscreenQmlSurface;
 
 /*@jsdoc
- * The <code>Tablet</code> API provides the facilities to work with the system or other tablet. In toolbar mode (see Developer 
+ * The <code>Tablet</code> API provides the facilities to work with the system or other tablet. In toolbar mode (see Developer
  * &gt; UI options), the tablet's menu buttons are displayed in a toolbar and other tablet content is displayed in a dialog.
  *
  * <p>See also the {@link Toolbars} API for working with toolbars.</p>
@@ -48,21 +48,6 @@ class OffscreenQmlSurface;
  * @hifi-interface
  * @hifi-client-entity
  * @hifi-avatar
- */
-/*@jsdoc
- * The <code>tabletInterface</code> API provides the facilities to work with the system or other tablet.
- *
- * @namespace tabletInterface
- *
- * @hifi-interface
- * @hifi-client-entity
- * @hifi-avatar
- *
- * @deprecated This API is deprecated and will be removed. Use {@link Tablet} instead.
- *
- * @borrows Tablet.getTablet as getTablet
- * @borrows Tablet.playSound as playSound
- * @borrows Tablet.tabletNotification as tabletNotification
  */
 class TabletScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
@@ -111,7 +96,7 @@ public:
     void preloadSounds();
 
     /*@jsdoc
-     * Plays a standard tablet sound. The sound is played locally (only the user running the script hears it) without a 
+     * Plays a standard tablet sound. The sound is played locally (only the user running the script hears it) without a
      * position.
      * @function Tablet.playSound
      * @param {Tablet.AudioEvents} sound - The tablet sound to play.
@@ -133,7 +118,7 @@ public:
 signals:
     /*@jsdoc
      * Triggered when a tablet message or dialog is displayed on the tablet that needs the user's attention.
-     * <p><strong>Note:</strong> Only triggered if the script is running in the same script engine as the script that created 
+     * <p><strong>Note:</strong> Only triggered if the script is running in the same script engine as the script that created
      * the tablet. By default, this means in scripts included as part of the default scripts.</p>
      * @function Tablet.tabletNotification
      * @returns {Signal}
@@ -154,7 +139,7 @@ protected:
 };
 
 /*@jsdoc
- * Information on the buttons in the tablet main menu (toolbar in toolbar mode) for use in QML. Has properties and functions 
+ * Information on the buttons in the tablet main menu (toolbar in toolbar mode) for use in QML. Has properties and functions
  * per <a href="http://doc.qt.io/qt-5/qabstractlistmodel.html">http://doc.qt.io/qt-5/qabstractlistmodel.html</a>.
  * @typedef {object} TabletProxy.TabletButtonListModel
  */
@@ -210,7 +195,7 @@ private:
 Q_DECLARE_METATYPE(TabletButtonsProxyModel*);
 
 /*@jsdoc
- * An instance of a tablet. In toolbar mode (see Developer &gt; UI options), the tablet's menu buttons are displayed in a 
+ * An instance of a tablet. In toolbar mode (see Developer &gt; UI options), the tablet's menu buttons are displayed in a
  * toolbar and other tablet content is displayed in a dialog.
  *
  * <p>Retrieve an existing tablet or create a new tablet using {@link Tablet.getTablet}.</p>
@@ -224,12 +209,12 @@ Q_DECLARE_METATYPE(TabletButtonsProxyModel*);
  *
  * @property {string} name - A unique name that identifies the tablet. <em>Read-only.</em>
  * @property {boolean} toolbarMode - <code>true</code> if the tablet is in toolbar mode, <code>false</code> if it isn't.
- * @property {boolean} landscape - <code>true</code> if the tablet is displayed in landscape mode, <code>false</code> if it is 
+ * @property {boolean} landscape - <code>true</code> if the tablet is displayed in landscape mode, <code>false</code> if it is
  *     displayed in portrait mode.
  *     <p>Note: This property isn't used in toolbar mode.</p>
  * @property {boolean} tabletShown - <code>true</code> if the tablet is currently displayed, <code>false</code> if it isn't.
  *     <p>Note: This property isn't used in toolbar mode.</p>
- * @property {TabletProxy.TabletButtonListModel} buttons - Information on the buttons in the tablet main menu (or toolbar in 
+ * @property {TabletProxy.TabletButtonListModel} buttons - Information on the buttons in the tablet main menu (or toolbar in
  *     toolbar mode) for use in QML. <em>Read-only.</em>
  */
 class TabletProxy : public QObject {
@@ -259,11 +244,7 @@ public:
      */
     Q_INVOKABLE void gotoMenuScreen(const QString& submenu = "");
 
-    /*@jsdoc
-     * @function TabletProxy#initialScreen
-     * @param {string} url - URL.
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void initialScreen(const QVariant& url);
 
     /*@jsdoc
@@ -279,9 +260,6 @@ public:
      * @function TabletProxy#gotoWebScreen
      * @param {string} url - The URL of the web page or app.
      * @param {string} [injectedJavaScriptUrl=""] - The URL of JavaScript to inject into the web page.
-     * @param {boolean} [loadOtherBase=false] - If <code>true</code>, the web page or app is displayed in a frame with "back" 
-     * and "close" buttons.
-     * <p class="important">Deprecated: This parameter is deprecated and will be removed.</p>
      */
     Q_INVOKABLE void gotoWebScreen(const QString& url);
     Q_INVOKABLE void gotoWebScreen(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase = false);
@@ -290,36 +268,24 @@ public:
      * Opens a QML app or dialog on the tablet.
      * @function TabletProxy#loadQMLSource
      * @param {string} path - The path of the QML app or dialog.
-     * @param {boolean} [resizable=false] - <code>true</code> to make the dialog resizable in toolbar mode, <code>false</code> 
+     * @param {boolean} [resizable=false] - <code>true</code> to make the dialog resizable in toolbar mode, <code>false</code>
      *     to have it not resizable.
      */
     Q_INVOKABLE void loadQMLSource(const QVariant& path, bool resizable = false);
 
-    /*@jsdoc
-     * @function TabletProxy#loadQMLSourceImpl
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Internal function, do not call from scripts.
     Q_INVOKABLE void loadQMLSourceImpl(const QVariant& path, bool resizable, bool localSafeContext);
 
-    /*@jsdoc
-     * @function TabletProxy#loadHTMLSourceOnTopImpl
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Internal function, do not call from scripts.
     Q_INVOKABLE void loadHTMLSourceOnTopImpl(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase, bool localSafeContext);
 
-    /*@jsdoc
-     * @function TabletProxy#returnToPreviousAppImpl
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Internal function, do not call from scripts.
     Q_INVOKABLE void returnToPreviousAppImpl(bool localSafeContext);
 
-    /*@jsdoc
-     * @function TabletProxy#loadQMLOnTopImpl
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     // Internal function, do not call from scripts.
     Q_INVOKABLE void loadQMLOnTopImpl(const QVariant& path, bool localSafeContext);
 
@@ -327,11 +293,11 @@ public:
     //        it should be initialized internally so it cannot fail
 
     /*@jsdoc
-     * Displays a QML dialog over the top of the current dialog, without closing the current dialog. Use 
+     * Displays a QML dialog over the top of the current dialog, without closing the current dialog. Use
      * {@link TabletProxy#popFromStack|popFromStack} to close the dialog.
-     * <p>If the current dialog or its ancestors contain a QML <code>StackView</code> with <code>objectName: "stack"</code> and 
-     * function <code>pushSource(path)</code>, that function is called; otherwise, 
-     * {@link TabletProxy#loadQMLSource|loadQMLSource} is called. The Create app provides an example of using a QML 
+     * <p>If the current dialog or its ancestors contain a QML <code>StackView</code> with <code>objectName: "stack"</code> and
+     * function <code>pushSource(path)</code>, that function is called; otherwise,
+     * {@link TabletProxy#loadQMLSource|loadQMLSource} is called. The Create app provides an example of using a QML
      * <code>StackView</code>.</p>
      * @function TabletProxy#pushOntoStack
      * @param {string} path - The path to the dialog's QML.
@@ -341,7 +307,7 @@ public:
     Q_INVOKABLE bool pushOntoStack(const QVariant& path);
 
     /*@jsdoc
-     * Closes a QML dialog that was displayed using {@link Tablet#pushOntoStack|pushOntoStack} with a dialog implementing a QML 
+     * Closes a QML dialog that was displayed using {@link Tablet#pushOntoStack|pushOntoStack} with a dialog implementing a QML
      * <code>StackView</code>; otherwise, no action is taken.
      * <p>If using a QML <code>StackView</code>, its <code>popSource()</code> function is called.</p>
      * @function TabletProxy#popFromStack
@@ -349,8 +315,8 @@ public:
     Q_INVOKABLE void popFromStack();
 
     /*@jsdoc
-     * Opens a QML app or dialog in addition to any current app. In tablet mode, the app or dialog is displayed over the top of 
-     * the current app; in toolbar mode, the app or dialog is opened in a new window. If in tablet mode, the app can be closed 
+     * Opens a QML app or dialog in addition to any current app. In tablet mode, the app or dialog is displayed over the top of
+     * the current app; in toolbar mode, the app or dialog is opened in a new window. If in tablet mode, the app can be closed
      * using {@link TabletProxy#returnToPreviousApp}.
      * @function TabletProxy#loadQMLOnTop
      * @param {string} path - The path to the app's QML.
@@ -359,7 +325,7 @@ public:
 
     /*@jsdoc
      * Opens a web app or page in addition to any current app. In tablet mode, the app or page is displayed over the top of the
-     * current app; in toolbar mode, the app is opened in a new window that replaces any current window open. If in tablet 
+     * current app; in toolbar mode, the app is opened in a new window that replaces any current window open. If in tablet
      * mode, the app or page can be closed using {@link TabletProxy#returnToPreviousApp}.
      * @function TabletProxy#loadWebScreenOnTop
      * @param {string} path - The URL of the web page or HTML app.
@@ -369,7 +335,7 @@ public:
     Q_INVOKABLE void loadWebScreenOnTop(const QVariant& url, const QString& injectedJavaScriptUrl);
 
     /*@jsdoc
-     * Closes the current app and returns to the previous app, if in tablet mode and the current app was loaded using 
+     * Closes the current app and returns to the previous app, if in tablet mode and the current app was loaded using
      * {@link TabletProxy#loadQMLOnTop|loadQMLOnTop} or {@link TabletProxy#loadWebScreenOnTop|loadWebScreenOnTop}.
      * @function TabletProxy#returnToPreviousApp
      */
@@ -383,7 +349,7 @@ public:
     Q_INVOKABLE bool isMessageDialogOpen();
 
     /*@jsdoc
-     * Closes any open modal, non-modal, or message dialog, opened by {@link Window.prompt}, {@link Window.promptAsync}, 
+     * Closes any open modal, non-modal, or message dialog, opened by {@link Window.prompt}, {@link Window.promptAsync},
      * {@link Window.openMessageBox}, or similar.
      * @function TabletProxy#closeDialog
      */
@@ -397,11 +363,11 @@ public:
      * @example <caption>Add a menu button.</caption>
      * var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
      * var button = tablet.addButton({ text: "TEST" });
-     * 
+     *
      * button.clicked.connect(function () {
      *     print("TEST button clicked");
      * });
-     * 
+     *
      * Script.scriptEnding.connect(function () {
      *     tablet.removeButton(button);
      * });
@@ -422,11 +388,11 @@ public:
      * <pre class="prettyprint"><code>EventBridge.scriptEventReceived.connect(function(message) {
      *     ...
      * });</code></pre>
-     * <p><strong>Warning:</strong> The <code>EventBridge</code> object is not necessarily set up immediately ready for the web 
-     * page's script to use. A simple workaround that normally works is to add a delay before calling 
-     * <code>EventBridge.scriptEventReceived.connect(...)</code>. A better solution is to periodically call 
-     * <code>EventBridge.scriptEventReceived.connect(...)</code> and then <code>EventBridge.emitWebEvent(...)</code> to send a 
-     * message to the Interface script, and have that send a message back using <code>emitScriptEvent(...)</code>; when the 
+     * <p><strong>Warning:</strong> The <code>EventBridge</code> object is not necessarily set up immediately ready for the web
+     * page's script to use. A simple workaround that normally works is to add a delay before calling
+     * <code>EventBridge.scriptEventReceived.connect(...)</code>. A better solution is to periodically call
+     * <code>EventBridge.scriptEventReceived.connect(...)</code> and then <code>EventBridge.emitWebEvent(...)</code> to send a
+     * message to the Interface script, and have that send a message back using <code>emitScriptEvent(...)</code>; when the
      * return message is received, the <codE>EventBridge</code> is ready for use.</p>
      * @function TabletProxy#emitScriptEvent
      * @param {string|object} message - The message to send to the web page.
@@ -454,7 +420,7 @@ public:
      * Sets whether the tablet is displayed in landscape or portrait mode.
      * <p>Note: The setting isn't used in toolbar mode.</p>
      * @function TabletProxy#setLandscape
-     * @param {boolean} landscape - <code>true</code> to display the tablet in landscape mode, <code>false</code> to display it 
+     * @param {boolean} landscape - <code>true</code> to display the tablet in landscape mode, <code>false</code> to display it
      *     in portrait mode.
      */
     Q_INVOKABLE void setLandscape(bool landscape) { _landscape = landscape; }
@@ -463,7 +429,7 @@ public:
      * Gets whether the tablet is displayed in landscape or portrait mode.
      * <p>Note: The setting isn't used in toolbar mode.</p>
      * @function TabletProxy#getLandscape
-     * @returns {boolean} <code>true</code> if the tablet is displayed in landscape mode, <code>false</code> if it is displayed 
+     * @returns {boolean} <code>true</code> if the tablet is displayed in landscape mode, <code>false</code> if it is displayed
      *     in portrait mode.
      */
     Q_INVOKABLE bool getLandscape() { return _landscape; }
@@ -488,7 +454,7 @@ public:
 
 signals:
     /*@jsdoc
-     * Triggered when a message from the current HTML web page displayed on the tablet is received. The HTML web page can send 
+     * Triggered when a message from the current HTML web page displayed on the tablet is received. The HTML web page can send
      * a message by calling:
      * <pre class="prettyprint"><code>EventBridge.emitWebEvent(message);</code></pre>
      * @function TabletProxy#webEventReceived
@@ -498,7 +464,7 @@ signals:
     void webEventReceived(QVariant msg);
 
     /*@jsdoc
-     * Triggered when a message from the current QML page displayed on the tablet is received. The QML page can send a message 
+     * Triggered when a message from the current QML page displayed on the tablet is received. The QML page can send a message
      * (string or object) by calling: <pre class="prettyprint"><code>sendToScript(message);</code></pre>
      * @function TabletProxy#fromQml
      * @param {string|object} message - The message received.
@@ -509,7 +475,7 @@ signals:
     /*@jsdoc
      * Triggered when the tablet's screen changes.
      * @function TabletProxy#screenChanged
-     * @param type {string} - The type of the new screen or change: <code>"Home"</code>, <code>"Menu"</code>, 
+     * @param type {string} - The type of the new screen or change: <code>"Home"</code>, <code>"Menu"</code>,
      *     <code>"QML"</code>, <code>"Web"</code>, <code>"Closed"</code>, or <code>"Unknown"</code>.
      * @param url {string} - The url of the page displayed. Only valid for Web and QML.
      * @returns {Signal}
@@ -538,24 +504,14 @@ signals:
     void toolbarModeChanged();
 
 protected slots:
-    
-    /*@jsdoc
-     * @function TabletProxy#desktopWindowClosed
-     * @deprecated This function is deprecated and will be removed.
-     */
+
+    // TODO: Deprecated by documentation, please review for accuracy
     void desktopWindowClosed();
 
-    /*@jsdoc
-     * @function TabletProxy#emitWebEvent
-     * @param {object|string} message - Message
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void emitWebEvent(const QVariant& msg);
 
-    /*@jsdoc
-     * @function TabletProxy#onTabletShown
-     * @deprecated This function is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     void onTabletShown();
 
 protected:
@@ -586,7 +542,7 @@ private:
 Q_DECLARE_METATYPE(TabletProxy*);
 
 /*@jsdoc
- * A tablet button. In toolbar mode (Developer &gt; UI &gt; Tablet Becomes Toolbar), the tablet button is displayed on the 
+ * A tablet button. In toolbar mode (Developer &gt; UI &gt; Tablet Becomes Toolbar), the tablet button is displayed on the
  * toolbar.
  *
  * <p>Create a new button using {@link TabletProxy#addButton}.</p>
@@ -599,7 +555,7 @@ Q_DECLARE_METATYPE(TabletProxy*);
  * @hifi-avatar
  *
  * @property {Uuid} uuid - The ID of the button. <em>Read-only.</em>
- * @property {TabletButtonProxy.ButtonProperties} properties - The current values of the button's properties. Only properties 
+ * @property {TabletButtonProxy.ButtonProperties} properties - The current values of the button's properties. Only properties
  *     that have been set during button creation or subsequently edited are returned. <em>Read-only.</em>
  */
 class TabletButtonProxy : public QObject {
@@ -613,17 +569,17 @@ public:
     QUuid getUuid() const { return _uuid; }
 
     /*@jsdoc
-     * Gets the current values of the button's properties. Only properties that have been set during button creation or 
+     * Gets the current values of the button's properties. Only properties that have been set during button creation or
      * subsequently edited are returned.
      * @function TabletButtonProxy#getProperties
      * @returns {TabletButtonProxy.ButtonProperties} The button properties.
      * @example <caption>Report a test button's properties.</caption>
      * var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
      * var button = tablet.addButton({ text: "TEST" });
-     * 
+     *
      * var properties = button.getProperties();
      * print("TEST button properties: " + JSON.stringify(properties));
-     * 
+     *
      * Script.scriptEnding.connect(function () {
      *     tablet.removeButton(button);
      * });
@@ -637,15 +593,15 @@ public:
      * @example <caption>Set a button's hover text after a delay.</caption>
      * var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
      * var button = tablet.addButton({ text: "TEST" });
-     * 
+     *
      * button.propertiesChanged.connect(function () {
      *     print("TEST button properties changed");
      * });
-     * 
+     *
      * Script.setTimeout(function () {
      *     button.editProperties({ text: "CHANGED" });
      * }, 2000);
-     * 
+     *
      * Script.scriptEnding.connect(function () {
      *     tablet.removeButton(button);
      * });

--- a/libraries/ui/src/ui/ToolbarScriptingInterface.h
+++ b/libraries/ui/src/ui/ToolbarScriptingInterface.h
@@ -41,7 +41,7 @@ Q_DECLARE_METATYPE(ToolbarButtonProxy*);
 
 /*@jsdoc
  * An instance of a toolbar.
- * 
+ *
  * <p>Retrieve an existing toolbar or create a new toolbar using {@link Toolbars.getToolbar}.</p>
  *
  * @class ToolbarProxy
@@ -56,28 +56,17 @@ class ToolbarProxy : public QmlWrapper {
 public:
     ToolbarProxy(QObject* qmlObject, QObject* parent = nullptr);
 
-    /*@jsdoc
-     * <em>Currently doesn't work.</em>
-     * @function ToolbarProxy#addButton
-     * @param {object} properties - Button properties
-     * @returns {object} The button added.
-     * @deprecated This method is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE ToolbarButtonProxy* addButton(const QVariant& properties);
 
-    /*@jsdoc
-     * <em>Currently doesn't work.</em>
-     * @function ToolbarProxy#removeButton
-     * @param {string} name - Button name.
-     * @deprecated This method is deprecated and will be removed.
-     */
+    // TODO: Deprecated by documentation, please review for accuracy
     Q_INVOKABLE void removeButton(const QVariant& name);
 
 
     // QmlWrapper methods.
 
     /*@jsdoc
-     * Sets the value of a toolbar property. A property is added to the toolbar if the named property doesn't already 
+     * Sets the value of a toolbar property. A property is added to the toolbar if the named property doesn't already
      * exist.
      * @function ToolbarProxy#writeProperty
      * @parm {string} propertyName - The name of the property. Toolbar properties are those in the QML implementation of the
@@ -89,7 +78,7 @@ public:
      * Sets the values of toolbar properties. A property is added to the toolbar if a named property doesn't already
      * exist.
      * @function ToolbarProxy#writeProperties
-     * @param {object} properties - The names and values of the properties to set. Toolbar properties are those in the QML 
+     * @param {object} properties - The names and values of the properties to set. Toolbar properties are those in the QML
      *     implementation of the toolbar.
      */
 
@@ -103,9 +92,9 @@ public:
     /*@jsdoc
      * Gets the values of toolbar properties.
      * @function ToolbarProxy#readProperties
-     * @param {string[]} propertyList - The names of the properties to get the values of. Toolbar properties are those in the 
+     * @param {string[]} propertyList - The names of the properties to get the values of. Toolbar properties are those in the
      *     QML implementation of the toolbar.
-     * @returns {object} The names and values of the specified properties. If the toolbar doesn't have a particular property 
+     * @returns {object} The names and values of the specified properties. If the toolbar doesn't have a particular property
      *     then the result doesn't include that property.
      */
 };
@@ -146,7 +135,7 @@ signals:
      * Toolbars.toolbarVisibleChanged.connect(function(visible, name) {
      *     print("Toolbar " + name + " visible changed to " + visible);
      * });
-     * 
+     *
      * var toolbar = Toolbars.getToolbar("com.highfidelity.interface.toolbar.system");
      * if (toolbar) {
      *     toolbar.writeProperty("visible", false);


### PR DESCRIPTION
This PR attempts to clean up the API documentation by removing the 330 instances of deprecated API's, methods, and properties present throughout.

This PR takes a naive approach by only removing the jsDoc strings so that the deprecated items no longer appear on apidocs.overte.org. This is because I don't have enough experience with either C++ or this project to confidently determine if the associated code can be removed.

To make the effort of determining this easier for others, I've included a comment in place of each of the removed jsDoc strings, that way you can easily find every replaced instance  (around 50 files in total) and determine if the deprecated code can be removed.

The comment I left behind looks like this:
```c++
// TODO: Deprecated by documentation, please review for accuracy
```

Additionally I've documented each of the 330 removed items along with their replacement (if it was present in the removed jsDoc string) in an included markdown file named `Deprecated JSDocs Removal.md`. The data in this file is formatted as a standard markdown table so that it can be easily consumed in editor or converted to CSV for automated processing. I can provide the data in other formats upon request.

I anticipate this PR is going to invite a lot of discussion and review topics, so I'm opening this as a draft until we're confident these changes should be adopted.

Additionally I will be making another pass through the codebase to document any Javascript files affected by these removals, though that will take me a bit longer to complete.