### PR TITLE
Remove deprecated methods/properties in PickScriptingInterface

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2404,7 +2404,7 @@ Application::Application(
 
     // Setup the mouse ray pick and related operators
     {
-        auto mouseRayPick = std::make_shared<RayPick>(Vectors::ZERO, Vectors::UP, PickFilter(PickScriptingInterface::getPickEntities() | PickScriptingInterface::getPickLocalEntities()), 0.0f, true);
+        auto mouseRayPick = std::make_shared<RayPick>(Vectors::ZERO, Vectors::UP, PickFilter(PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES)), 0.0f, true);
         mouseRayPick->parentTransform = std::make_shared<MouseTransformNode>();
         mouseRayPick->setJointState(PickQuery::JOINT_STATE_MOUSE);
         auto mouseRayPickID = DependencyManager::get<PickManager>()->addPick(PickQuery::Ray, mouseRayPick);

--- a/interface/src/LoginStateManager.cpp
+++ b/interface/src/LoginStateManager.cpp
@@ -159,7 +159,7 @@ void LoginStateManager::setUp() {
     const unsigned int leftHand = 0;
     QVariantMap leftPointerPropertiesMap {
         { "joint", "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND" },
-        { "filter", PickScriptingInterface::getPickLocalEntities() },
+        { "filter", PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES) },
         { "triggers", leftPointerTriggerProperties },
         { "posOffset", vec3toVariant(grabPointSphereOffsetLeft + malletOffset) },
         { "hover", true },
@@ -189,7 +189,7 @@ void LoginStateManager::setUp() {
     rightPointerTriggerProperties = QList<QVariant>({rtClick1, rtClick2});
     QVariantMap rightPointerPropertiesMap{
         { "joint", "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND" },
-        { "filter", PickScriptingInterface::getPickLocalEntities() },
+        { "filter", PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES) },
         { "triggers", rightPointerTriggerProperties },
         { "posOffset", vec3toVariant(grabPointSphereOffsetRight + malletOffset) },
         { "hover", true },
@@ -215,10 +215,10 @@ void LoginStateManager::update(const QString& dominantHand, const QUuid& loginEn
         _dominantHand = dominantHand;
     }
     auto pointers = DependencyManager::get<PointerScriptingInterface>();
-    auto raypicks = DependencyManager::get<RayPickScriptingInterface>();
-    if (pointers && raypicks) {
-        const auto rightObjectID = raypicks->getPrevRayPickResult(_rightLoginPointerID)["objectID"].toUuid();
-        const auto leftObjectID = raypicks->getPrevRayPickResult(_leftLoginPointerID)["objectID"].toUuid();
+    auto picks = DependencyManager::get<PickScriptingInterface>();
+    if (pointers && picks) {
+        const auto rightObjectID = picks->getPrevPickResult(_rightLoginPointerID)["objectID"].toUuid();
+        const auto leftObjectID = picks->getPrevPickResult(_leftLoginPointerID)["objectID"].toUuid();
         const QString leftMode = (leftObjectID.isNull() || leftObjectID != loginEntityID) ? "" : "full";
         const QString rightMode = (rightObjectID.isNull() || rightObjectID != loginEntityID) ? "" : "full";
         pointers->setRenderState(_leftLoginPointerID, leftMode);

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -89,7 +89,7 @@ unsigned int PickScriptingInterface::createPick(const PickQuery::PickType type, 
 
 PickFilter getPickFilter(unsigned int filter) {
     // FIXME: Picks always intersect visible and collidable things right now
-    filter = filter | (PickScriptingInterface::getPickIncludeVisible() | PickScriptingInterface::getPickIncludeCollidable());
+    filter = filter | (PickFilter::FlagBit::VISIBLE | PickFilter::FlagBit::COLLIDABLE);
     return PickFilter(filter);
 }
 
@@ -97,21 +97,21 @@ PickFilter getPickFilter(unsigned int filter) {
  * The properties of a ray pick.
  *
  * @typedef {object} Picks.RayPickProperties
- * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should 
+ * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should
  *     start disabled. Disabled picks do not update their pick results.
- * @property {FilterFlags} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property 
+ * @property {FilterFlags} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property
  *     values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
- * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code> 
+ * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
  *     means no maximum.
  * @property {Uuid} [parentID] - The ID of the parent: an avatar, an entity, or another pick.
- * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint. 
+ * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint.
  *     A value of <code>0</code> means no joint.
  *     <p><em>Used only if <code>parentID</code> is specified.</em></p>
- * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to 
- *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not 
+ * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not
  *     parented to anything.
  *     <p><em>Used only if <code>parentID</code> is not specified.</em></p>
- * @property {Vec3} [position=Vec3.ZERO] - The offset of the ray origin from its parent if parented, otherwise the ray origin 
+ * @property {Vec3} [position=Vec3.ZERO] - The offset of the ray origin from its parent if parented, otherwise the ray origin
  *     in world coordinates.
  * @property {Vec3} [posOffset] - Synonym for <code>position</code>.
  * @property {Vec3} [direction] - The offset of the ray direction from its parent's y-axis if parented, otherwise the ray
@@ -119,12 +119,12 @@ PickFilter getPickFilter(unsigned int filter) {
  *     <p><strong>Default Value:</strong> <code>Vec3.UP</code> direction if <code>joint</code> is specified, otherwise
  *     <code>-Vec3.UP</code>.</p>
  * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
- * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
+ * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the
  *     default <code>direction</code> value.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or
  *     {@link Picks.getPickScriptParameters}. A ray pick's type is {@link PickType.Ray}.
- * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale 
- *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and 
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale
+ *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and
  *     is used to scale the pointer which owns this pick, if any.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMap& propMap) {
@@ -183,7 +183,7 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMa
  * The properties of a stylus pick.
  *
  * @typedef {object} Picks.StylusPickProperties
- * @property {number} [hand=-1] <code>0</code> for the left hand, <code>1</code> for the right hand, invalid (<code>-1</code>) 
+ * @property {number} [hand=-1] <code>0</code> for the left hand, <code>1</code> for the right hand, invalid (<code>-1</code>)
  *     otherwise.
  * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should
  *     start disabled. Disabled picks do not update their pick results.
@@ -192,9 +192,9 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMa
  *     <p><strong>Note:</strong> Stylus picks do not intersect avatars or the HUD.</p>
  * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
  *     means no maximum.
- * @property {Vec3} [tipOffset=0,0.095,0] - The position of the stylus tip relative to the hand position at default avatar 
+ * @property {Vec3} [tipOffset=0,0.095,0] - The position of the stylus tip relative to the hand position at default avatar
  *     scale.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or
  *     {@link Picks.getPickScriptParameters}. A stylus pick's type is {@link PickType.Stylus}.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVariantMap& propMap) {
@@ -229,37 +229,37 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVarian
     return std::make_shared<StylusPick>(side, filter, maxDistance, enabled, tipOffset);
 }
 
-// NOTE: Laser pointer still uses scaleWithAvatar. Until scaleWithAvatar is also deprecated for pointers, scaleWithAvatar 
+// NOTE: Laser pointer still uses scaleWithAvatar. Until scaleWithAvatar is also deprecated for pointers, scaleWithAvatar
 // should not be removed from the pick API.
 /*@jsdoc
  * The properties of a parabola pick.
  *
  * @typedef {object} Picks.ParabolaPickProperties
- * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should 
+ * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should
  *     start disabled. Disabled picks do not update their pick results.
- * @property {number} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property 
+ * @property {number} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property
  *     values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
- * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code> 
+ * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
  *     means no maximum.
  * @property {Uuid} [parentID] - The ID of the parent: an avatar, an entity, or another pick.
  * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint.
  *     A value of <code>0</code> means no joint.
  *     <p><em>Used only if <code>parentID</code> is specified.</em></p>
- * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to 
- *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not 
+ * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not
  *     parented to anything.
  *     <p><em>Used only if <code>parentID</code> is not specified.</em></p>
- * @property {Vec3} [position=Vec3.ZERO] - The offset of the parabola origin from its parent if parented, otherwise the 
+ * @property {Vec3} [position=Vec3.ZERO] - The offset of the parabola origin from its parent if parented, otherwise the
  *     parabola origin in world coordinates.
  * @property {Vec3} [posOffset] - Synonym for <code>position</code>.
- * @property {Vec3} [direction] - The offset of the parabola direction from its parent's y-axis if parented, otherwise the 
+ * @property {Vec3} [direction] - The offset of the parabola direction from its parent's y-axis if parented, otherwise the
  *     parabola direction in world coordinates.
  *     <p><strong>Default Value:</strong> <code>Vec3.UP</code> direction if <code>joint</code> is specified, otherwise
  *     <code>Vec3.FRONT</code>.</p>
  * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
- * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
+ * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the
  *     default <code>direction</code> value.
- * @property {number} [speed=1] - The initial speed of the parabola in m/s, i.e., the initial speed of a virtual projectile 
+ * @property {number} [speed=1] - The initial speed of the parabola in m/s, i.e., the initial speed of a virtual projectile
  *     whose trajectory defines the parabola.
  * @property {Vec3} [accelerationAxis=-Vec3.UP] - The acceleration of the parabola in m/s<sup>2</sup>, i.e., the acceleration
  *     of a virtual projectile whose trajectory defines the parabola, both magnitude and direction.
@@ -271,10 +271,10 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVarian
  *     with the avatar or other parent.
  * @property {boolean} [scaleWithAvatar=true] - Synonym for <code>scalewithParent</code>.
  *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or
  *     {@link Picks.getPickScriptParameters}. A parabola pick's type is {@link PickType.Parabola}.
- * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale 
- *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and 
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale
+ *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and
  *     is used to rescale the pick and the pointer which owns this pick, if any.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVariantMap& propMap) {
@@ -361,10 +361,10 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVari
  *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not
  *     parented to anything.
  *     <p><em>Used only if <code>parentID</code> is not specified.</em></p>
- * @property {boolean} [scaleWithParent=true] - <code>true</code> to scale the pick's dimensions and threshold according to the 
+ * @property {boolean} [scaleWithParent=true] - <code>true</code> to scale the pick's dimensions and threshold according to the
  *     scale of the parent.
  *
- * @property {Shape} shape - The collision region's shape and size. Dimensions are in world coordinates but scale with the 
+ * @property {Shape} shape - The collision region's shape and size. Dimensions are in world coordinates but scale with the
  *     parent if defined.
  * @property {Vec3} position - The position of the collision region, relative to the parent if defined.
  * @property {Quat} orientation - The orientation of the collision region, relative to the parent if defined.
@@ -372,10 +372,10 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVari
  *     the collision region. The depth is in world coordinates but scales with the parent if defined.
  * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
  *     masks overlap with the region's collision group are considered to be colliding with the region.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or
  *     {@link Picks.getPickScriptParameters}. A collision pick's type is {@link PickType.Collision}.
- * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale 
- *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and 
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale
+ *     (usually an avatar or an entity). Its value is the original scale of the parent at the moment the pick was created, and
  *     is used to rescale the pick, and/or the pointer which owns this pick, if any.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildCollisionPick(const QVariantMap& propMap) {

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -36,10 +36,10 @@ class ScriptValue;
  * @property {FilterFlags} PICK_HUD - Include the HUD surface when intersecting in HMD mode. <em>Read-only.</em>
  *
  * @property {FilterFlags} PICK_ENTITIES - Include domain and avatar entities when intersecting. <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>PICK_DOMAIN_ENTITIES | 
+ *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>PICK_DOMAIN_ENTITIES |
  *     PICK_AVATAR_ENTITIES</code> instead.</p>
  * @property {FilterFlags} PICK_OVERLAYS - Include local entities when intersecting. <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>PICK_LOCAL_ENTITIES</code> 
+ *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>PICK_LOCAL_ENTITIES</code>
  *     instead.</p>
  *
  * @property {FilterFlags} PICK_INCLUDE_VISIBLE - Include visible objects when intersecting. <em>Read-only.</em>
@@ -53,20 +53,20 @@ class ScriptValue;
  * @property {FilterFlags} PICK_PRECISE - Pick against exact meshes. <em>Read-only.</em>
  * @property {FilterFlags} PICK_COARSE - Pick against coarse meshes. <em>Read-only.</em>
  *
- * @property {FilterFlags} PICK_ALL_INTERSECTIONS - If set, returns all intersections instead of just the closest. 
+ * @property {FilterFlags} PICK_ALL_INTERSECTIONS - If set, returns all intersections instead of just the closest.
  *     <em>Read-only.</em>
  *     <p><strong>Warning:</strong> Not yet implemented.</p>
  *
- * @property {FilterFlags} PICK_BYPASS_IGNORE - Allows pick to intersect entities even when their 
+ * @property {FilterFlags} PICK_BYPASS_IGNORE - Allows pick to intersect entities even when their
  *     <code>ignorePickIntersection</code> property value is <code>true</code>. For debug purposes.
  *     <em>Read-only.</em>
  *
  * @property {IntersectionType} INTERSECTED_NONE - Intersected nothing. <em>Read-only.</em>
  * @property {IntersectionType} INTERSECTED_ENTITY - Intersected an entity. <em>Read-only.</em>
  * @property {IntersectionType} INTERSECTED_LOCAL_ENTITY - Intersected a local entity. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_OVERLAY - Intersected a local entity. (3D overlays no longer exist.) 
+ * @property {IntersectionType} INTERSECTED_OVERLAY - Intersected a local entity. (3D overlays no longer exist.)
  *     <em>Read-only.</em>
- *     <p class="important">Deprecated: This property is deprecated and will be removed. Use 
+ *     <p class="important">Deprecated: This property is deprecated and will be removed. Use
  *     <code>INTERSECTED_LOCAL_ENTITY</code> instead.</p>
  * @property {IntersectionType} INTERSECTED_AVATAR - Intersected an avatar. <em>Read-only.</em>
  * @property {IntersectionType} INTERSECTED_HUD - Intersected the HUD surface. <em>Read-only.</em>
@@ -76,34 +76,9 @@ class ScriptValue;
 
 class PickScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
-    Q_PROPERTY(unsigned int PICK_ENTITIES READ getPickEntities CONSTANT)
-    Q_PROPERTY(unsigned int PICK_OVERLAYS READ getPickOverlays CONSTANT)
-
-    Q_PROPERTY(unsigned int PICK_DOMAIN_ENTITIES READ getPickDomainEntities CONSTANT)
-    Q_PROPERTY(unsigned int PICK_AVATAR_ENTITIES READ getPickAvatarEntities CONSTANT)
-    Q_PROPERTY(unsigned int PICK_LOCAL_ENTITIES READ getPickLocalEntities CONSTANT)
-    Q_PROPERTY(unsigned int PICK_AVATARS READ getPickAvatars CONSTANT)
-    Q_PROPERTY(unsigned int PICK_HUD READ getPickHud CONSTANT)
-
-    Q_PROPERTY(unsigned int PICK_INCLUDE_VISIBLE READ getPickIncludeVisible CONSTANT)
-    Q_PROPERTY(unsigned int PICK_INCLUDE_INVISIBLE READ getPickIncludeInvisible CONSTANT)
-
-    Q_PROPERTY(unsigned int PICK_INCLUDE_COLLIDABLE READ getPickIncludeCollidable CONSTANT)
-    Q_PROPERTY(unsigned int PICK_INCLUDE_NONCOLLIDABLE READ getPickIncludeNoncollidable CONSTANT)
-
-    Q_PROPERTY(unsigned int PICK_PRECISE READ getPickPrecise CONSTANT)
-    Q_PROPERTY(unsigned int PICK_COARSE READ getPickCoarse CONSTANT)
-
-    Q_PROPERTY(unsigned int PICK_ALL_INTERSECTIONS READ getPickAllIntersections CONSTANT)
 
     Q_PROPERTY(unsigned int PICK_BYPASS_IGNORE READ getPickBypassIgnore CONSTANT)
 
-    Q_PROPERTY(unsigned int INTERSECTED_NONE READ getIntersectedNone CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_ENTITY READ getIntersectedEntity CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_LOCAL_ENTITY READ getIntersectedLocalEntity CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_OVERLAY READ getIntersectedOverlay CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_AVATAR READ getIntersectedAvatar CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_HUD READ getIntersectedHud CONSTANT)
     Q_PROPERTY(unsigned int perFrameTimeBudget READ getPerFrameTimeBudget WRITE setPerFrameTimeBudget)
     SINGLETON_DEPENDENCY
 
@@ -112,14 +87,14 @@ public:
     void registerProperties(ScriptEngine* engine);
 
     /*@jsdoc
-     * Creates a new pick. Different {@link PickType}s use different properties, and within one PickType the properties you 
-     * choose can lead to a wide range of behaviors. For example, with <code>PickType.Ray</code>, the properties could 
+     * Creates a new pick. Different {@link PickType}s use different properties, and within one PickType the properties you
+     * choose can lead to a wide range of behaviors. For example, with <code>PickType.Ray</code>, the properties could
      * configure a mouse ray pick, an avatar head ray pick, or a joint ray pick.
-     * <p><strong>Warning:</strong> Picks created using this method currently always intersect at least visible and collidable 
+     * <p><strong>Warning:</strong> Picks created using this method currently always intersect at least visible and collidable
      * things but this may not always be the case.</p>
      * @function Picks.createPick
      * @param {PickType} type - The type of picking to use.
-     * @param {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} 
+     * @param {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties}
      *     properties - Properties of the pick, per the pick <code>type</code>.
      * @returns {number} The ID of the pick created. <code>0</code> if invalid.
      */
@@ -165,12 +140,12 @@ public:
     Q_INVOKABLE QVariantMap getPickProperties(unsigned int uid) const;
 
     /*@jsdoc
-     * Gets the parameters that were passed in to {@link Picks.createPick} to create the pick, if the pick was created through 
+     * Gets the parameters that were passed in to {@link Picks.createPick} to create the pick, if the pick was created through
      * a script. Note that these properties do not reflect the current state of the pick.
      * See {@link Picks.getPickProperties}.
      * @function Picks.getPickScriptParameters
      * @param {number} id - The ID of the pick.
-     * @returns {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} 
+     * @returns {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties}
      *     Script-provided properties, per the pick <code>type</code>.
      */
     Q_INVOKABLE QVariantMap getPickScriptParameters(unsigned int uid) const;
@@ -183,9 +158,9 @@ public:
     Q_INVOKABLE QVector<unsigned int> getPicks() const;
 
     /*@jsdoc
-     * Gets the most recent result from a pick. A pick continues to be updated ready to return a result, as long as it is 
+     * Gets the most recent result from a pick. A pick continues to be updated ready to return a result, as long as it is
      * enabled.
-     * <p><strong>Note:</strong> Stylus picks only intersect with objects in their include list, set using 
+     * <p><strong>Note:</strong> Stylus picks only intersect with objects in their include list, set using
      * {@link Picks.setIncludeItems|setIncludeItems}.</p>
      * @function Picks.getPrevPickResult
      * @param {number} id - The ID of the pick.
@@ -195,7 +170,7 @@ public:
      * var HIGHLIGHT_LIST_NAME = "highlightEntitiesExampleList";
      * var HIGHLIGHT_LIST_TYPE = "entity";
      * Selection.enableListHighlight(HIGHLIGHT_LIST_NAME, {});
-     * 
+     *
      * // Ray pick.
      * var PICK_FILTER = Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES
      *         | Picks.PICK_INCLUDE_COLLIDABLE | Picks.PICK_INCLUDE_NONCOLLIDABLE;
@@ -204,7 +179,7 @@ public:
      *     filter: PICK_FILTER,
      *     joint: HMD.active ? "Avatar" : "Mouse"
      * });
-     * 
+     *
      * // Highlight intersected entity.
      * var highlightedEntityID = null;
      * Script.update.connect(function () {
@@ -224,7 +199,7 @@ public:
      *         }
      *     }
      * });
-     * 
+     *
      * // Clean up.
      * Script.scriptEnding.connect(function () {
      *     if (highlightedEntityID) {
@@ -235,7 +210,7 @@ public:
     Q_INVOKABLE QVariantMap getPrevPickResult(unsigned int uid);
 
     /*@jsdoc
-     * Sets whether or not a pick should use precision picking, i.e., whether it should pick against precise meshes or coarse 
+     * Sets whether or not a pick should use precision picking, i.e., whether it should pick against precise meshes or coarse
      * meshes.
      * This has the same effect as using the <code>PICK_PRECISE</code> or <code>PICK_COARSE</code> filter flags.
      * @function Picks.setPrecisionPicking
@@ -254,7 +229,7 @@ public:
     Q_INVOKABLE void setIgnoreItems(unsigned int uid, const ScriptValue& ignoreItems);
 
     /*@jsdoc
-     * Sets a list of entity and avatar IDs that a pick should include during intersection, instead of intersecting with 
+     * Sets a list of entity and avatar IDs that a pick should include during intersection, instead of intersecting with
      * everything.
      * <p><strong>Note:</strong> Stylus picks only intersect with items in their include list.</p>
      * @function Picks.setIncludeItems
@@ -264,8 +239,8 @@ public:
     Q_INVOKABLE void setIncludeItems(unsigned int uid, const ScriptValue& includeItems);
 
     /*@jsdoc
-     * Checks if a pick is associated with the left hand: a ray or parabola pick with <code>joint</code> property set to 
-     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with 
+     * Checks if a pick is associated with the left hand: a ray or parabola pick with <code>joint</code> property set to
+     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with
      * <code>hand</code> property set to <code>0</code>.
      * @function Picks.isLeftHand
      * @param {number} id - The ID of the pick.
@@ -275,7 +250,7 @@ public:
 
     /*@jsdoc
      * Checks if a pick is associated with the right hand: a ray or parabola pick with <code>joint</code> property set to
-     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with 
+     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with
      * <code>hand</code> property set to <code>1</code>.
      * @function Picks.isRightHand
      * @param {number} id - The ID of the pick.
@@ -284,7 +259,7 @@ public:
     Q_INVOKABLE bool isRightHand(unsigned int uid);
 
     /*@jsdoc
-     * Checks if a pick is associated with the system mouse: a ray or parabola pick with <code>joint</code> property set to 
+     * Checks if a pick is associated with the system mouse: a ray or parabola pick with <code>joint</code> property set to
      * <code>"Mouse"</code>.
      * @function Picks.isMouse
      * @param {number} id - The ID of the pick.
@@ -296,170 +271,7 @@ public:
     void setPerFrameTimeBudget(unsigned int numUsecs);
 
 public slots:
-
     static constexpr unsigned int getPickBypassIgnore() { return PickFilter::getBitMask(PickFilter::FlagBit::PICK_BYPASS_IGNORE); }
-
-    /*@jsdoc
-     * @function Picks.PICK_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_DOMAIN_ENTITIES | 
-     *     Picks.PICK_AVATAR_ENTITIES</code> properties expression instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickEntities() { return PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES); }
-
-    /*@jsdoc
-     * @function Picks.PICK_OVERLAYS
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_LOCAL_ENTITIES</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickOverlays() { return PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES); }
-
-
-    /*@jsdoc
-     * @function Picks.PICK_DOMAIN_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_DOMAIN_ENTITIES</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickDomainEntities() { return PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES); }
-
-    /*@jsdoc
-     * @function Picks.PICK_AVATAR_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_AVATAR_ENTITIES</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickAvatarEntities() { return PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES); }
-
-    /*@jsdoc
-     * @function Picks.PICK_LOCAL_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_LOCAL_ENTITIES</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickLocalEntities() { return PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES); }
-
-    /*@jsdoc
-     * @function Picks.PICK_AVATARS
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_AVATARS</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickAvatars() { return PickFilter::getBitMask(PickFilter::FlagBit::AVATARS); }
-
-    /*@jsdoc
-     * @function Picks.PICK_HUD
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_HUD</code> property instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickHud() { return PickFilter::getBitMask(PickFilter::FlagBit::HUD); }
-
-
-    /*@jsdoc
-     * @function Picks.PICK_INCLUDE_VISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_VISIBLE</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickIncludeVisible() { return PickFilter::getBitMask(PickFilter::FlagBit::VISIBLE); }
-
-    /*@jsdoc
-     * @function Picks.PICK_INCLUDE_INVISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_INVISIBLE</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickIncludeInvisible() { return PickFilter::getBitMask(PickFilter::FlagBit::INVISIBLE); }
-
-
-    /*@jsdoc
-     * @function Picks.PICK_INCLUDE_COLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_COLLIDABLE</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickIncludeCollidable() { return PickFilter::getBitMask(PickFilter::FlagBit::COLLIDABLE); }
-
-    /*@jsdoc
-     * @function Picks.PICK_INCLUDE_NONCOLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_NONCOLLIDABLE</code> 
-     *     property instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickIncludeNoncollidable() { return PickFilter::getBitMask(PickFilter::FlagBit::NONCOLLIDABLE); }
-
-
-    /*@jsdoc
-     * @function Picks.PICK_PRECISE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_PRECISE</code> property instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickPrecise() { return PickFilter::getBitMask(PickFilter::FlagBit::PRECISE); }
-
-    /*@jsdoc
-     * @function Picks.PICK_COARSE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_COARSE</code> property instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickCoarse() { return PickFilter::getBitMask(PickFilter::FlagBit::COARSE); }
-
-
-    /*@jsdoc
-     * @function Picks.PICK_ALL_INTERSECTIONS
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_ALL_INTERSECTIONS</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getPickAllIntersections() { return PickFilter::getBitMask(PickFilter::FlagBit::PICK_ALL_INTERSECTIONS); }
-
-    /*@jsdoc
-     * @function Picks.INTERSECTED_NONE
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_NONE</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getIntersectedNone() { return IntersectionType::NONE; }
-
-    /*@jsdoc
-     * @function Picks.INTERSECTED_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_ENTITY</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getIntersectedEntity() { return IntersectionType::ENTITY; }
-
-    /*@jsdoc
-     * @function Picks.INTERSECTED_LOCAL_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_LOCAL_ENTITY</code> 
-     *     property instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getIntersectedLocalEntity() { return IntersectionType::LOCAL_ENTITY; }
-
-    /*@jsdoc
-     * @function Picks.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_LOCAL_ENTITY</code> 
-     *     property instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getIntersectedOverlay() { return getIntersectedLocalEntity(); }
-
-    /*@jsdoc
-     * @function Picks.INTERSECTED_AVATAR
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_AVATAR</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getIntersectedAvatar() { return IntersectionType::AVATAR; }
-
-    /*@jsdoc
-     * @function Picks.INTERSECTED_HUD
-     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_HUD</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static constexpr unsigned int getIntersectedHud() { return IntersectionType::HUD; }
 
 protected:
     static std::shared_ptr<PickQuery> buildRayPick(const QVariantMap& properties);

--- a/interface/src/raypick/RayPickScriptingInterface.h
+++ b/interface/src/raypick/RayPickScriptingInterface.h
@@ -32,39 +32,9 @@ class ScriptValue;
  * @hifi-interface
  * @hifi-client-entity
  * @hifi-avatar
- *
- * @property {FilterFlags} PICK_ENTITIES - Include domain and avatar entities when intersecting. 
- *     <em>Read-only.</em>
- * @property {FilterFlags} PICK_OVERLAYS - Include local entities when intersecting. <em>Read-only.</em>
- * @property {FilterFlags} PICK_AVATARS - Include avatars when intersecting. <em>Read-only.</em>
- * @property {FilterFlags} PICK_HUD - Include the HUD surface when intersecting in HMD mode. <em>Read-only.</em>
- * @property {FilterFlags} PICK_PRECISE - Pick against exact meshes. <em>Read-only.</em>
- * @property {FilterFlags} PICK_INCLUDE_INVISIBLE - Include invisible objects when intersecting. <em>Read-only.</em>
- * @property {FilterFlags} PICK_INCLUDE_NONCOLLIDABLE - Include non-collidable objects when intersecting. <em>Read-only.</em>
- * @property {FilterFlags} PICK_ALL_INTERSECTIONS - Return all intersections instead of just the closest. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_NONE - Intersected nothing with the given filter flags. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_ENTITY - Intersected an entity. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_LOCAL_ENTITY - Intersected a local entity. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_OVERLAY - Intersected an entity (3D Overlays no longer exist). <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_AVATAR - Intersected an avatar. <em>Read-only.</em>
- * @property {IntersectionType} INTERSECTED_HUD - Intersected the HUD surface. <em>Read-only.</em>
  */
 class RayPickScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
-    Q_PROPERTY(unsigned int PICK_ENTITIES READ getPickEntities CONSTANT)
-    Q_PROPERTY(unsigned int PICK_OVERLAYS READ getPickOverlays CONSTANT)
-    Q_PROPERTY(unsigned int PICK_AVATARS READ getPickAvatars CONSTANT)
-    Q_PROPERTY(unsigned int PICK_HUD READ getPickHud CONSTANT)
-    Q_PROPERTY(unsigned int PICK_COARSE READ getPickCoarse CONSTANT)
-    Q_PROPERTY(unsigned int PICK_INCLUDE_INVISIBLE READ getPickIncludeInvisible CONSTANT)
-    Q_PROPERTY(unsigned int PICK_INCLUDE_NONCOLLIDABLE READ getPickIncludeNoncollidable CONSTANT)
-    Q_PROPERTY(unsigned int PICK_ALL_INTERSECTIONS READ getPickAllIntersections CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_NONE READ getIntersectedNone CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_ENTITY READ getIntersectedEntity CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_LOCAL_ENTITY READ getIntersectedLocalEntity CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_OVERLAY READ getIntersectedOverlay CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_AVATAR READ getIntersectedAvatar CONSTANT)
-    Q_PROPERTY(unsigned int INTERSECTED_HUD READ getIntersectedHud CONSTANT)
     SINGLETON_DEPENDENCY
 
 public:
@@ -101,7 +71,7 @@ public:
     Q_INVOKABLE void removeRayPick(unsigned int uid);
 
     /*@jsdoc
-     * Gets the most recent pick result from a ray pick. A ray pick continues to be updated ready to return a result, as long 
+     * Gets the most recent pick result from a ray pick. A ray pick continues to be updated ready to return a result, as long
      * as it is enabled.
      * @function RayPick.getPrevRayPickResult
      * @param {number} id - The ID of the ray pick.
@@ -111,7 +81,7 @@ public:
 
 
     /*@jsdoc
-     * Sets whether or not a ray pick should use precision picking, i.e., whether it should pick against precise meshes or 
+     * Sets whether or not a ray pick should use precision picking, i.e., whether it should pick against precise meshes or
      * coarse meshes.
      * @function RayPick.setPrecisionPicking
      * @param {number} id - The ID of the ray pick.
@@ -128,7 +98,7 @@ public:
     Q_INVOKABLE void setIgnoreItems(unsigned int uid, const ScriptValue& ignoreEntities);
 
     /*@jsdoc
-     * Sets a list of entity and avatar IDs that a ray pick should include during intersection, instead of intersecting with 
+     * Sets a list of entity and avatar IDs that a ray pick should include during intersection, instead of intersecting with
      * everything.
      * @function RayPick.setIncludeItems
      * @param {number} id - The ID of the ray pick.
@@ -139,7 +109,7 @@ public:
 
     /*@jsdoc
      * Checks if a pick is associated with the left hand: a ray or parabola pick with <code>joint</code> property set to
-     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with 
+     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with
      * <code>hand</code> property set to <code>0</code>.
      * @function RayPick.isLeftHand
      * @param {number} id - The ID of the ray pick.
@@ -149,7 +119,7 @@ public:
 
     /*@jsdoc
      * Checks if a pick is associated with the right hand: a ray or parabola pick with <code>joint</code> property set to
-     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with 
+     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with
      * <code>hand</code> property set to <code>1</code>.
      * @function RayPick.isRightHand
      * @param {number} id - The ID of the ray pick.
@@ -158,122 +128,13 @@ public:
     Q_INVOKABLE bool isRightHand(unsigned int uid);
 
     /*@jsdoc
-     * Checks if a pick is associated with the system mouse: a ray or parabola pick with <code>joint</code> property set to 
+     * Checks if a pick is associated with the system mouse: a ray or parabola pick with <code>joint</code> property set to
      * <code>"Mouse"</code>.
      * @function RayPick.isMouse
      * @param {number} id - The ID of the ray pick.
      * @returns {boolean} <code>true</code> if the pick is associated with the system mouse, <code>false</code> if it isn't.
      */
     Q_INVOKABLE bool isMouse(unsigned int uid);
-
-public slots:
-
-    /*@jsdoc
-     * @function RayPick.PICK_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the <code>Raypick.PICK_ENTITIES</code> property instead.
-     * @returns {number}
-     */
-    static unsigned int getPickEntities() { return PickScriptingInterface::getPickEntities(); }
-
-    /*@jsdoc
-     * @function RayPick.PICK_OVERLAYS
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_OVERLAYS</code> property instead.
-     * @returns {number}
-     */
-    static unsigned int getPickOverlays() { return PickScriptingInterface::getPickOverlays(); }
-
-    /*@jsdoc
-     * @function RayPick.PICK_AVATARS
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_AVATARS</code> property instead.
-     * @returns {number}
-     */
-    static unsigned int getPickAvatars() { return PickScriptingInterface::getPickAvatars(); }
-
-    /*@jsdoc
-     * @function RayPick.PICK_HUD
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_HUD</code> property instead.
-     * @returns {number}
-     */
-    static unsigned int getPickHud() { return PickScriptingInterface::getPickHud(); }
-
-    /*@jsdoc
-     * @function RayPick.PICK_COARSE
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_COARSE</code> property instead.
-     * @returns {number}
-     */
-    static unsigned int getPickCoarse() { return PickScriptingInterface::getPickCoarse(); }
-
-    /*@jsdoc
-     * @function RayPick.PICK_INCLUDE_INVISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_INCLUDE_INVISIBLE</code> 
-     *     property instead.
-     * @returns {number}
-     */
-    static unsigned int getPickIncludeInvisible() { return PickScriptingInterface::getPickIncludeInvisible(); }
-
-    /*@jsdoc
-     * @function RayPick.PICK_INCLUDE_NONCOLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_INCLUDE_NONCOLLIDABLE</code> 
-     *     property instead.
-     * @returns {number}
-     */
-    static unsigned int getPickIncludeNoncollidable() { return PickScriptingInterface::getPickIncludeNoncollidable(); }
-
-    /*@jsdoc
-     * @function RayPick.PICK_ALL_INTERSECTIONS
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_ALL_INTERSECTIONS</code> 
-     *     property instead.
-     * @returns {number}
-     */
-    static unsigned int getPickAllIntersections() { return PickScriptingInterface::getPickAllIntersections(); }
-
-    /*@jsdoc
-     * @function RayPick.INTERSECTED_NONE
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_NONE</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static unsigned int getIntersectedNone() { return PickScriptingInterface::getIntersectedNone(); }
-
-    /*@jsdoc
-     * @function RayPick.INTERSECTED_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_ENTITY</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static unsigned int getIntersectedEntity() { return PickScriptingInterface::getIntersectedEntity(); }
-
-    /*@jsdoc
-     * @function RayPick.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_LOCAL_ENTITY</code> 
-     *     property instead.
-     * @returns {number}
-     */
-    static unsigned int getIntersectedLocalEntity() { return PickScriptingInterface::getIntersectedLocalEntity(); }
-
-    /*@jsdoc
-     * @function RayPick.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_OVERLAY</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static unsigned int getIntersectedOverlay() { return PickScriptingInterface::getIntersectedOverlay(); }
-
-    /*@jsdoc
-     * @function RayPick.INTERSECTED_AVATAR
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_AVATAR</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static unsigned int getIntersectedAvatar() { return PickScriptingInterface::getIntersectedAvatar(); }
-
-    /*@jsdoc
-     * @function RayPick.INTERSECTED_HUD
-     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_HUD</code> property 
-     *     instead.
-     * @returns {number}
-     */
-    static unsigned int getIntersectedHud() { return PickScriptingInterface::getIntersectedHud(); }
 };
 
 #endif // hifi_RayPickScriptingInterface_h

--- a/interface/src/ui/Keyboard.cpp
+++ b/interface/src/ui/Keyboard.cpp
@@ -271,14 +271,14 @@ void Keyboard::createKeyboard() {
 
     QVariantMap leftStylusProperties {
         { "hand", LEFT_HAND_CONTROLLER_INDEX },
-        { "filter", PickScriptingInterface::getPickLocalEntities() },
+        { "filter", PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES) },
         { "model", modelProperties },
         { "tipOffset", vec3toVariant(MALLET_TIP_OFFSET) }
     };
 
     QVariantMap rightStylusProperties {
         { "hand", RIGHT_HAND_CONTROLLER_INDEX },
-        { "filter", PickScriptingInterface::getPickLocalEntities() },
+        { "filter", PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES) },
         { "model", modelProperties },
         { "tipOffset", vec3toVariant(MALLET_TIP_OFFSET) }
     };


### PR DESCRIPTION
This is a continuation of the work I started in #606, where I'm now removing both the C++ and their associated jsDocs for deprecated code.

This PR addresses the PickScriptingInterface, which is also depended on by the deprecated RayPickScriptingInterface.

I still need to do analysis to determine the impact of this change on existing system and community scripts, hence the draft status