### PR TITLE
mouseLook.js CapsLock adjustment 

### DIFF
--- a/scripts/system/controllers/mouseLook.js
+++ b/scripts/system/controllers/mouseLook.js
@@ -41,7 +41,7 @@ by rampa3 (https://github.com/rampa3) and vegaslon (https://github.com/vegaslon)
 
     function onKeyPressEvent(event) {
         if (!hmd){
-            if (event.text === 'm') {
+            if (event.text.toLowerCase() === 'm') {
                 if (!keysOnOverlay) {
                     if (mouseLookEnabled) {
                         if (!Camera.getCaptureMouse()){


### PR DESCRIPTION
This makes the mouseLook.js script accept both "m" and "M" to toggle mouse look.

Addresses #622