### PR TITLE
Fix loading avatars from Dropbox due to URLs containing parameters

### DIFF
--- a/libraries/model-serializers/src/FSTReader.cpp
+++ b/libraries/model-serializers/src/FSTReader.cpp
@@ -20,6 +20,9 @@
 #include <NetworkingConstants.h>
 #include <SharedUtil.h>
 
+
+const QStringList SINGLE_VALUE_PROPERTIES{"name", "filename", "texdir", "script", "comment"};
+
 hifi::VariantMultiHash FSTReader::parseMapping(QIODevice* device) {
     hifi::VariantMultiHash properties;
 
@@ -32,9 +35,25 @@ hifi::VariantMultiHash FSTReader::parseMapping(QIODevice* device) {
         if (sections.size() < 2) {
             continue;
         }
+
+        // We can have URLs like:
+        // filename = https://www.dropbox.com/scl/fi/xxx/avatar.fbx?rlkey=xxx&dl=1\n
+        // These confuse the parser due to the presence of = in the URL.
+        //
+        // SINGLE_VALUE_PROPERTIES contains a list of things that may be URLs or contain an =
+        // for some other reason, and that we know for sure contain only a single value after
+        // the first =.
+        //
+        // Really though, we should just use JSON instead.
         QByteArray name = sections.at(0).trimmed();
-        if (sections.size() == 2) {
-            properties.insert(name, sections.at(1).trimmed());
+        bool isSingleValue = SINGLE_VALUE_PROPERTIES.contains(name);
+
+        if (sections.size() == 2 || isSingleValue) {
+            // As per the above, we can have '=' signs inside of URLs, so instead of
+            // using the split string, just use everything after the first '='.
+
+            QString value = line.mid(line.indexOf("=")+1).trimmed();
+            properties.insert(name, value);
         } else if (sections.size() == 3) {
             QVariantHash heading = properties.value(name).toHash();
             heading.insert(sections.at(1).trimmed(), sections.at(2).trimmed());


### PR DESCRIPTION
Fixes the FST parser, which chokes on `=` characters in URLs.

With this avatars hosted on Dropbox should load correctly.

Here's an URL to test with: https://www.dropbox.com/scl/fi/9tcraie3picd576o4kcpi/avatar-dropbox-good-dl3.fst?rlkey=o03ebkw7l19bzpvvw7qrg6cow&dl=1

For it to work, you must use the download link, with the `dl=1` at the end. The actual FST has to contain a full URL for the model, also with the download link:

```
filename = https://www.dropbox.com/scl/fi/jalud26irtex49jujp2ea/DaleFoxShapes.fbx?rlkey=xxigk6fww60ynzta82aqs5qbx&dl=1
```

Note that the "rlkey" and the URL don't match in these two. Dropbox URLs are random and can't be used with the "texdir" and similar relative paths. Full paths must be used everywhere.



Closes #633 