### PR TITLE
Mouselook hotfix

### DIFF
--- a/scripts/system/controllers/mouseLook.js
+++ b/scripts/system/controllers/mouseLook.js
@@ -160,7 +160,8 @@ by rampa3 (https://github.com/rampa3) and vegaslon (https://github.com/vegaslon)
     }
 
     function mouseLookOn() {
-        Camera.captureMouse = true;
+        if (mouseLookEnabled)
+            Camera.captureMouse = true;
     }
 
     function mouseLookOff() {


### PR DESCRIPTION
Resolves #660 

Issue: My compatibility for inspect.js forced mouselook to reenable itself when returning control to the user. I did not check if the mouselook setting was enabled before forcing it into activation. 

Now it checks if the mouselook setting is enabled. 