### PR TITLE
Added a JS function to clean up orphaned entities

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -2525,6 +2525,10 @@ const EntityPropertyInfo EntityScriptingInterface::getPropertyInfo(const QString
     return propertyInfo;
 }
 
+int EntityScriptingInterface::removeOrphanedEntities() {
+    return _entityTree->removeOrphanedEntities();
+};
+
 glm::vec3 EntityScriptingInterface::worldToLocalPosition(glm::vec3 worldPosition, const QUuid& parentID,
                                                          int parentJointIndex, bool scalesWithParent) {
     bool success;

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -2129,6 +2129,15 @@ public slots:
      */
     Q_INVOKABLE const EntityPropertyInfo getPropertyInfo(const QString& propertyName) const;
 
+    /*@jsdoc
+     * Removes entities with parent UUID of an entity that doesn't exits.
+     * Entities are sometimes orphaned when entity server crashes during entity deletion.
+     * This function should be run server-side.
+     * @function Entities.removeOrphanedEntities
+     * @returns {number} Number of entities that were removed.
+     */
+    Q_INVOKABLE const int removeOrphanedEntities() const;
+
 signals:
     /*@jsdoc
      * Triggered on the client that is the physics simulation owner during the collision of two entities. Note: Isn't triggered

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -171,6 +171,7 @@ public:
     void debugDumpMap();
     virtual void dumpTree() override;
     virtual void pruneTree() override;
+    int removeOrphanedEntities();
 
     static QByteArray remapActionDataIDs(QByteArray actionData, QHash<EntityItemID, EntityItemID>& map);
 


### PR DESCRIPTION
This allows removing orphaned entities that cannot be removed by other means and persist even in JSON files in backups. It's not tested yet.