### PR TITLE
Prevent the chat bar from popping up when VR headset is on

### DIFF
--- a/scripts/communityScripts/chat/FloofChat.js
+++ b/scripts/communityScripts/chat/FloofChat.js
@@ -695,7 +695,7 @@ function keyPressEvent(event) {
     if (event.key === H_KEY && !event.isAutoRepeat && event.isControl) {
         toggleMainChatWindow()
     }
-    if (event.key === ENTER_KEY && !event.isAutoRepeat && !visible) {
+    if (event.key === ENTER_KEY && !event.isAutoRepeat && !visible && !HMD.active) {
         setVisible(true);
     }
     if (event.key === ESC_KEY && !event.isAutoRepeat && visible) {


### PR DESCRIPTION
This fixes https://github.com/overte-org/overte/issues/670
It's up to discussion if we should fix it this way until better fix happens, so please share your opinions.