### PR TITLE
Switch to self-hosted Linux amd64 GitHub Actions Runner

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -33,7 +33,7 @@ jobs:
           - os: debian-11
             image: docker.io/overte/overte-server-build:0.1.3-debian-11-amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: linux_amd64
 
           - os: debian-11
             image: docker.io/overte/overte-server-build:0.1.3-debian-11-aarch64
@@ -43,7 +43,7 @@ jobs:
           - os: debian-12
             image: docker.io/overte/overte-server-build:0.1.3-debian-12-amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: linux_amd64
 
           - os: debian-12
             image: docker.io/overte/overte-server-build:0.1.3-debian-12-aarch64
@@ -53,17 +53,17 @@ jobs:
           - os: ubuntu-18.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-18.04-amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: linux_amd64
 
           - os: ubuntu-20.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-20.04-amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: linux_amd64
 
           - os: ubuntu-22.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-22.04-amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: linux_amd64
 
           - os: ubuntu-22.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-22.04-aarch64
@@ -73,7 +73,7 @@ jobs:
           - os: fedora-37
             image: docker.io/overte/overte-server-build:0.1.3-fedora-37-amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: linux_amd64
 
           - os: fedora-37
             image: docker.io/overte/overte-server-build:0.1.3-fedora-37-aarch64
@@ -83,7 +83,7 @@ jobs:
           - os: fedora-38
             image: docker.io/overte/overte-server-build:0.1.3-fedora-38-amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: linux_amd64
 
           - os: fedora-38
             image: docker.io/overte/overte-server-build:0.1.3-fedora-38-aarch64
@@ -93,7 +93,7 @@ jobs:
           - os: rockylinux-9
             image: docker.io/overte/overte-server-build:0.1.3-rockylinux-9-amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: linux_amd64
 
       fail-fast: false
 
@@ -102,7 +102,7 @@ jobs:
 
     steps:
     - name: Clear Working Directories
-      if: contains(matrix.runner, 'linux_aarch64')
+      if: contains(matrix.runner, 'linux_aarch64') || contains(matrix.runner, 'linux_amd64')
       shell: bash
       run: |
         rm -rf ./*
@@ -296,7 +296,7 @@ jobs:
       run: python3 $GITHUB_WORKSPACE/tools/ci-scripts/upload.py
 
     - name: Clear Working Directories
-      if: contains(matrix.runner, 'linux_aarch64')
+      if: contains(matrix.runner, 'linux_aarch64') || contains(matrix.runner, 'linux_amd64')
       shell: bash
       run: |
         rm -rf ./*

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -50,11 +50,6 @@ jobs:
             arch: aarch64
             runner: linux_aarch64
 
-          - os: ubuntu-18.04
-            image: docker.io/overte/overte-server-build:0.1.3-ubuntu-18.04-amd64
-            arch: amd64
-            runner: linux_amd64
-
           - os: ubuntu-20.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-20.04-amd64
             arch: amd64

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -45,9 +45,9 @@ jobs:
             build_type: full
           #- os: macOS-10.15
           #  build_type: full
-          - os: ubuntu-20.04
-            build_type: full
-            apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion3 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-github python3-distro
+          #- os: ubuntu-20.04
+          #  build_type: full
+          #  apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion3 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-github python3-distro
       fail-fast: false
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -57,7 +57,7 @@ jobs:
               runner: linux_amd64
               arch: amd64
               build_type: full
-              apt-dependencies: pkg-config libxext-dev libdouble-conversion-dev # add missing dependencies to docker image when convenient
+              apt-dependencies: pkg-config libxext-dev libdouble-conversion-dev libpcre2-16-0 # add missing dependencies to docker image when convenient
               image: docker.io/overte/overte-full-build:0.1.1-ubuntu-20.04-amd64
             # Android builds are currently failing
             #- os: ubuntu-18.04

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -57,7 +57,7 @@ jobs:
               runner: linux_amd64
               arch: amd64
               build_type: full
-              apt-dependencies: pkg-config # add missing dependencies to docker image when convenient
+              apt-dependencies: pkg-config libxext-dev # add missing dependencies to docker image when convenient
               image: docker.io/overte/overte-full-build:0.1.1-ubuntu-20.04-amd64
             # Android builds are currently failing
             #- os: ubuntu-18.04

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -57,7 +57,7 @@ jobs:
               runner: linux_amd64
               arch: amd64
               build_type: full
-              apt-dependencies: pkg-config libxext-dev libdouble-conversion-dev libpcre2-16-0 # add missing dependencies to docker image when convenient
+              apt-dependencies: pkg-config libxext-dev libdouble-conversion-dev libpcre2-16-0 libpulse0 libharfbuzz-dev libnss3 libnspr4 libxdamage1 libasound2 # add missing dependencies to docker image when convenient
               image: docker.io/overte/overte-full-build:0.1.1-ubuntu-20.04-amd64
             # Android builds are currently failing
             #- os: ubuntu-18.04

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -57,7 +57,7 @@ jobs:
               runner: linux_amd64
               arch: amd64
               build_type: full
-              apt-dependencies: pkg-config libxext-dev # add missing dependencies to docker image when convenient
+              apt-dependencies: pkg-config libxext-dev libdouble-conversion-dev # add missing dependencies to docker image when convenient
               image: docker.io/overte/overte-full-build:0.1.1-ubuntu-20.04-amd64
             # Android builds are currently failing
             #- os: ubuntu-18.04

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -54,10 +54,10 @@ jobs:
             #- os: macOS-10.15
             #  build_type: full
             - os: Ubuntu 20.04
-              runner: ubuntu-20.04
+              runner: linux_amd64
               arch: amd64
               build_type: full
-              apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion3 libpulse0 libsnappy1v5 libwebpdemux2 libwebpmux3 python3-distro
+              image: docker.io/overte/overte-full-build:0.1.1-ubuntu-20.04-amd64
             # Android builds are currently failing
             #- os: ubuntu-18.04
             #  build_type: android
@@ -157,7 +157,7 @@ jobs:
         fi
 
     - name: Clear Working Directories
-      if: contains(matrix.runner, 'linux_aarch64')
+      if: contains(matrix.runner, 'linux_aarch64') || contains(matrix.runner, 'linux_amd64')
       shell: bash
       run: |
         rm -rf ./*
@@ -341,7 +341,7 @@ jobs:
         if-no-files-found: error
 
     - name: Clear Working Directories
-      if: contains(matrix.runner, 'linux_aarch64')
+      if: contains(matrix.runner, 'linux_aarch64') || contains(matrix.runner, 'linux_amd64')
       shell: bash
       run: |
         rm -rf ./*

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -57,6 +57,7 @@ jobs:
               runner: linux_amd64
               arch: amd64
               build_type: full
+              apt-dependencies: pkg-config # add missing dependencies to docker image when convenient
               image: docker.io/overte/overte-full-build:0.1.1-ubuntu-20.04-amd64
             # Android builds are currently failing
             #- os: ubuntu-18.04

--- a/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-20.04
+++ b/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-20.04
@@ -1,0 +1,38 @@
+# Copyright 2022-2023 Overte e.V.
+# SPDX-License-Identifier: Apache-2.0
+
+# Docker file for building Overte
+# Example build: docker build -t overte/overte-full-build:0.1.1-ubuntu-20.04 -f Dockerfile_build_ubuntu-20.04 .
+FROM ubuntu:20.04
+LABEL maintainer="Julian Groß (julian.gro@overte.org)"
+LABEL description="Development image for full Overte builds"
+
+# Don't use any frontend when installing packages during the creation of this container
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN echo UTC >/etc/timezone
+# Installing via dependency causes interactive hang:
+RUN apt-get update && apt-get -y install tzdata
+
+# Install Overte domain-server and assignment-client build dependencies
+RUN apt-get -y install curl ninja-build git cmake g++ libssl-dev python3-distutils python3-distro mesa-common-dev libgl1-mesa-dev libsystemd-dev
+# Install server-console build dependencies
+RUN apt-get -y install npm
+
+# Install tools for package creation
+RUN apt-get -y install sudo chrpath binutils dh-make
+
+# Install locales package
+RUN apt-get -y install locales
+# Uncomment en_US.UTF-8 for inclusion in generation
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
+# Generate locale
+RUN locale-gen
+
+# Export env vars
+RUN echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc
+RUN echo "export LANG=en_US.UTF-8" >> ~/.bashrc
+RUN echo "export LANGUAGE=en_US.UTF-8" >> ~/.bashrc
+
+# Install tools needed for our Github Actions Workflow
+Run apt-get -y install python3-boto3 python3-github zip


### PR DESCRIPTION
We require more disk space (and potentially more RAM) than the GitHub hosted Runners provide.