### PR TITLE
Fix crash when starting with --display, --disable-displays or --disable-inputs

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -763,19 +763,7 @@ bool setupEssentials(int& argc, char** argv, const QCommandLineParser& parser, b
         }
     }
 
-    // Tell the plugin manager about our statically linked plugins
-    DependencyManager::set<ScriptInitializers>();
-    DependencyManager::set<PluginManager>();
-    auto pluginManager = PluginManager::getInstance();
-    pluginManager->setInputPluginProvider([] { return getInputPlugins(); });
-    pluginManager->setDisplayPluginProvider([] { return getDisplayPlugins(); });
-    pluginManager->setInputPluginSettingsPersister([](const InputPluginList& plugins) { saveInputPluginSettings(plugins); });
-    if (auto steamClient = pluginManager->getSteamClientPlugin()) {
-        steamClient->init();
-    }
-    if (auto oculusPlatform = pluginManager->getOculusPlatformPlugin()) {
-        oculusPlatform->init();
-    }
+
 
     PROFILE_SET_THREAD_NAME("Main Thread");
 
@@ -8763,6 +8751,21 @@ void Application::sendLambdaEvent(const std::function<void()>& f) {
 }
 
 void Application::initPlugins(const QCommandLineParser& parser) {
+    // Tell the plugin manager about our statically linked plugins
+    DependencyManager::set<ScriptInitializers>();
+    DependencyManager::set<PluginManager>();
+    auto pluginManager = PluginManager::getInstance();
+    pluginManager->setInputPluginProvider([] { return getInputPlugins(); });
+    pluginManager->setDisplayPluginProvider([] { return getDisplayPlugins(); });
+    pluginManager->setInputPluginSettingsPersister([](const InputPluginList& plugins) { saveInputPluginSettings(plugins); });
+    if (auto steamClient = pluginManager->getSteamClientPlugin()) {
+        steamClient->init();
+    }
+    if (auto oculusPlatform = pluginManager->getOculusPlatformPlugin()) {
+        oculusPlatform->init();
+    }
+
+
     if (parser.isSet("display")) {
         auto preferredDisplays = parser.value("display").split(',', Qt::SkipEmptyParts);
         qInfo() << "Setting prefered display plugins:" << preferredDisplays;


### PR DESCRIPTION

This happens because the PluginManager doesn't exist yet at the time when these options are handled. Fix this by moving PluginManager initialization to an earlier stage of the code.