### PR TITLE
Fix for custom graphics setting

### DIFF
--- a/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
+++ b/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
@@ -126,9 +126,9 @@ Flickable {
                     fontSize: 16
                     leftPadding: 0
                     text: "Custom"
-                    checked: Performance.getPerformancePreset() === PerformanceEnums.UNKNOWN
+                    checked: Performance.getPerformancePreset() === PerformanceEnums.CUSTOM
                     onClicked: {
-                        Performance.setPerformancePreset(PerformanceEnums.UNKNOWN);
+                        Performance.setPerformancePreset(PerformanceEnums.CUSTOM);
                     }
                 }
             }

--- a/interface/src/PerformanceManager.cpp
+++ b/interface/src/PerformanceManager.cpp
@@ -30,7 +30,7 @@ PerformanceManager::PerformanceManager()
 
 void PerformanceManager::setupPerformancePresetSettings(bool evaluatePlatformTier) {
     if (evaluatePlatformTier || (getPerformancePreset() == UNKNOWN)) {
-        // If evaluatePlatformTier, evalute the Platform Tier and assign the matching Performance profile by default.
+        // If evaluatePlatformTier, evaluate the Platform Tier and assign the matching Performance profile by default.
         // A bunch of Performance, Simulation and Render settings will be set to a matching default value from this
 
         // Here is the mapping between platformTier and performance profile
@@ -39,7 +39,8 @@ void PerformanceManager::setupPerformancePresetSettings(bool evaluatePlatformTie
             PerformanceManager::PerformancePreset::LOW_POWER,  // platform::Profiler::LOW_POWER
             PerformanceManager::PerformancePreset::LOW,        // platform::Profiler::LOW
             PerformanceManager::PerformancePreset::MID,        // platform::Profiler::MID
-            PerformanceManager::PerformancePreset::HIGH        // platform::Profiler::HIGH
+            PerformanceManager::PerformancePreset::HIGH,       // platform::Profiler::HIGH
+            PerformanceManager::PerformancePreset::CUSTOM      // platform::Profiler::CUSTOM
         } };
 
         // What is our profile?
@@ -134,6 +135,8 @@ void PerformanceManager::applyPerformancePreset(PerformanceManager::PerformanceP
             DependencyManager::get<LODManager>()->setWorldDetailQuality(WORLD_DETAIL_LOW);
 
             break;
+        case PerformancePreset::CUSTOM:
+            // Intentionally unbroken.
         case PerformancePreset::UNKNOWN:
 	    // Intentionally unbroken.
         default:

--- a/interface/src/PerformanceManager.h
+++ b/interface/src/PerformanceManager.h
@@ -25,9 +25,10 @@ public:
         LOW,
         MID,
         HIGH,
+        CUSTOM,
         PROFILE_COUNT
     };
-    static bool isValidPerformancePreset(int value) { return (value >= PerformancePreset::UNKNOWN && value <= PerformancePreset::HIGH); }
+    static bool isValidPerformancePreset(int value) { return (value >= PerformancePreset::UNKNOWN && value <= PerformancePreset::CUSTOM); }
 
     PerformanceManager();
     ~PerformanceManager() = default;

--- a/interface/src/scripting/PerformanceScriptingInterface.h
+++ b/interface/src/scripting/PerformanceScriptingInterface.h
@@ -63,6 +63,7 @@ public:
         LOW = PerformanceManager::PerformancePreset::LOW,
         MID = PerformanceManager::PerformancePreset::MID,
         HIGH = PerformanceManager::PerformancePreset::HIGH,
+        CUSTOM = PerformanceManager::PerformancePreset::CUSTOM
     };
     Q_ENUM(PerformancePreset)
 

--- a/libraries/platform/src/platform/Profiler.h
+++ b/libraries/platform/src/platform/Profiler.h
@@ -23,6 +23,7 @@ public:
         LOW,
         MID,
         HIGH,
+        CUSTOM, // Never used, added for consistency with performance presets
 
         NumTiers, // not a valid Tier
     };


### PR DESCRIPTION
Custom graphics setting was using the same enum value as unknown setting, causing graphics setting resets.