### PR TITLE
Call somethingChangedNotification() from setLocalJointXXXX

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -903,6 +903,7 @@ bool RenderableModelEntityItem::setLocalJointRotation(int index, const glm::quat
                 jointData.rotationDirty = true;
                 result = true;
                 _needsJointSimulation = true;
+                somethingChangedNotification();
             }
         }
     });
@@ -922,6 +923,7 @@ bool RenderableModelEntityItem::setLocalJointTranslation(int index, const glm::v
                 jointData.translationDirty = true;
                 result = true;
                 _needsJointSimulation = true;
+                somethingChangedNotification();
             }
         }
     });


### PR DESCRIPTION
Fix for https://github.com/overte-org/overte/issues/650

Test:
- Create a model entity: `let entity = Entities.addEntity({type: "Model", position: MyAvatar.position, modelURL: MyAvatar.skeletonModelURL})`
- Rotate one of the joints (second argument, joint index, will depend on your avatar model): `Entities.setLocalJointRotation(entity, 5, Quat.fromPitchYawRollRadians(0.0, 0.0, Math.PI / 2));`