### PR TITLE
Reorganize startup to allow more control over plugins

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1040,7 +1040,7 @@ Application::Application(
 void Application::initialize(const QCommandLineParser &parser) {
 
     //qCDebug(interfaceapp) << "Setting up essentials";
-    //setupEssentials(parser, _previousSessionCrashed);
+    setupEssentials(parser, _previousSessionCrashed);
     qCDebug(interfaceapp) << "Initializing application";
 
     _entitySimulation = std::make_shared<PhysicalEntitySimulation>();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1049,6 +1049,7 @@ void Application::initialize(const QCommandLineParser &parser) {
     _octreeProcessor = std::make_shared<OctreePacketProcessor>();
     _entityEditSender = std::make_shared<EntityEditPacketSender>();
     _graphicsEngine = std::make_shared<GraphicsEngine>();
+    _applicationOverlay = std::make_shared<ApplicationOverlay>();
 
 
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -764,14 +764,12 @@ bool setupEssentials(const QCommandLineParser& parser, bool runningMarkerExisted
         }
     }
 
-    // Tell the plugin manager about our statically linked plugins
+
 
     DependencyManager::set<ScriptInitializers>();
-    DependencyManager::set<PluginManager>();
+
+    // Tell the plugin manager about our statically linked plugins
     auto pluginManager = PluginManager::getInstance();
-    pluginManager->setInputPluginProvider([] { return getInputPlugins(); });
-    pluginManager->setDisplayPluginProvider([] { return getDisplayPlugins(); });
-    pluginManager->setInputPluginSettingsPersister([](const InputPluginList& plugins) { saveInputPluginSettings(plugins); });
     if (auto steamClient = pluginManager->getSteamClientPlugin()) {
         steamClient->init();
     }
@@ -1040,8 +1038,12 @@ Application::Application(
     DependencyManager::set<PathUtils>();
 }
 
-void Application::initializePlugins() {
-
+void Application::initializePluginManager() {
+    DependencyManager::set<PluginManager>();
+    auto pluginManager = PluginManager::getInstance();
+    pluginManager->setInputPluginProvider([] { return getInputPlugins(); });
+    pluginManager->setDisplayPluginProvider([] { return getDisplayPlugins(); });
+    pluginManager->setInputPluginSettingsPersister([](const InputPluginList& plugins) { saveInputPluginSettings(plugins); });
 }
 
 void Application::initialize(const QCommandLineParser &parser) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -725,7 +725,7 @@ extern InputPluginList getInputPlugins();
 extern void saveInputPluginSettings(const InputPluginList& plugins);
 
 bool setupEssentials(const QCommandLineParser& parser, bool runningMarkerExisted) {
-    qInstallMessageHandler(messageHandler);
+
 
 
     const int listenPort = parser.isSet("listenPort") ? parser.value("listenPort").toInt() : INVALID_PORT;
@@ -765,7 +765,7 @@ bool setupEssentials(const QCommandLineParser& parser, bool runningMarkerExisted
     }
 
     // Tell the plugin manager about our statically linked plugins
-    DependencyManager::set<PathUtils>();
+
     DependencyManager::set<ScriptInitializers>();
     DependencyManager::set<PluginManager>();
     auto pluginManager = PluginManager::getInstance();
@@ -1035,6 +1035,13 @@ Application::Application(
 
     LogHandler::getInstance().moveToThread(thread());
     LogHandler::getInstance().setupRepeatedMessageFlusher();
+    qInstallMessageHandler(messageHandler);
+
+    DependencyManager::set<PathUtils>();
+}
+
+void Application::initializePlugins() {
+
 }
 
 void Application::initialize(const QCommandLineParser &parser) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1062,14 +1062,14 @@ void Application::initializePluginManager(const QCommandLineParser& parser) {
         PluginManager::getInstance()->setPreferredDisplayPlugins(preferredDisplays);
     }
 
-    if (parser.isSet("disableDisplays")) {
-        auto disabledDisplays = parser.value("disableDisplays").split(',', Qt::SkipEmptyParts);
+    if (parser.isSet("disableDisplayPlugins")) {
+        auto disabledDisplays = parser.value("disableDisplayPlugins").split(',', Qt::SkipEmptyParts);
         qInfo() << "Disabling following display plugins:"  << disabledDisplays;
         PluginManager::getInstance()->disableDisplays(disabledDisplays);
     }
 
-    if (parser.isSet("disableInputs")) {
-        auto disabledInputs = parser.value("disableInputs").split(',', Qt::SkipEmptyParts);
+    if (parser.isSet("disableInputPlugins")) {
+        auto disabledInputs = parser.value("disableInputPlugins").split(',', Qt::SkipEmptyParts);
         qInfo() << "Disabling following input plugins:" << disabledInputs;
         PluginManager::getInstance()->disableInputs(disabledInputs);
     }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1007,9 +1007,6 @@ Application::Application(
     _logger(new FileLogger(this)),
 #endif
     _previousSessionCrashed(setupEssentials(parser, false)),
-    _entitySimulation(std::make_shared<PhysicalEntitySimulation>()),
-    _physicsEngine(std::make_shared<PhysicsEngine>(Vectors::ZERO)),
-    _entityClipboard(std::make_shared<EntityTree>()),
     _previousScriptLocation("LastScriptLocation", DESKTOP_LOCATION),
     _fieldOfView("fieldOfView", DEFAULT_FIELD_OF_VIEW_DEGREES),
     _hmdTabletScale("hmdTabletScale", DEFAULT_HMD_TABLET_SCALE_PERCENT),
@@ -1045,6 +1042,13 @@ void Application::initialize(const QCommandLineParser &parser) {
     //qCDebug(interfaceapp) << "Setting up essentials";
     //setupEssentials(parser, _previousSessionCrashed);
     qCDebug(interfaceapp) << "Initializing application";
+
+    _entitySimulation = std::make_shared<PhysicalEntitySimulation>();
+    _physicsEngine = std::make_shared<PhysicsEngine>(Vectors::ZERO);
+    _entityClipboard = std::make_shared<EntityTree>();
+
+
+
 
 
     auto steamClient = PluginManager::getInstance()->getSteamClientPlugin();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1041,6 +1041,14 @@ Application::Application(
 void Application::initializePluginManager() {
     DependencyManager::set<PluginManager>();
     auto pluginManager = PluginManager::getInstance();
+
+    qWarning() << "Input plugins: " << getInputPlugins().size();
+
+    // To avoid any confusion: the getInputPlugins and getDisplayPlugins are not the ones
+    // from PluginManager, but functions exported by input-plugins/InputPlugin.cpp and
+    // display-plugins/DisplayPlugin.cpp.
+    //
+    // These functions provide the plugin manager with static default plugins.
     pluginManager->setInputPluginProvider([] { return getInputPlugins(); });
     pluginManager->setDisplayPluginProvider([] { return getDisplayPlugins(); });
     pluginManager->setInputPluginSettingsPersister([](const InputPluginList& plugins) { saveInputPluginSettings(plugins); });

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -226,8 +226,8 @@ public:
     PerformanceManager& getPerformanceManager() { return _performanceManager; }
     RefreshRateManager& getRefreshRateManager() { return _refreshRateManager; }
 
-    size_t getRenderFrameCount() const { return _graphicsEngine.getRenderFrameCount(); }
-    float getRenderLoopRate() const { return _graphicsEngine.getRenderLoopRate(); }
+    size_t getRenderFrameCount() const { return _graphicsEngine->getRenderFrameCount(); }
+    float getRenderLoopRate() const { return _graphicsEngine->getRenderLoopRate(); }
     float getNumCollisionObjects() const;
     float getTargetRenderFrameRate() const; // frames/second
 
@@ -305,9 +305,9 @@ public:
     void setMaxOctreePacketsPerSecond(int maxOctreePPS);
     int getMaxOctreePacketsPerSecond() const;
 
-    render::ScenePointer getMain3DScene() override { return _graphicsEngine.getRenderScene(); }
-    render::EnginePointer getRenderEngine() override { return  _graphicsEngine.getRenderEngine(); }
-    gpu::ContextPointer getGPUContext() const { return _graphicsEngine.getGPUContext(); }
+    render::ScenePointer getMain3DScene() override { return _graphicsEngine->getRenderScene(); }
+    render::EnginePointer getRenderEngine() override { return  _graphicsEngine->getRenderEngine(); }
+    gpu::ContextPointer getGPUContext() const { return _graphicsEngine->getGPUContext(); }
 
     const GameWorkload& getGameWorkload() const { return _gameWorkload; }
 
@@ -769,7 +769,7 @@ private:
 
     GameWorkload _gameWorkload;
 
-    GraphicsEngine _graphicsEngine;
+    std::shared_ptr<GraphicsEngine> _graphicsEngine;
     void updateRenderArgs(float deltaTime);
 
     bool _disableLoginScreen { true };

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -209,11 +209,11 @@ public:
 
     const ConicalViewFrustums& getConicalViews() const override { return _conicalViews; }
 
-    const OctreePacketProcessor& getOctreePacketProcessor() const { return _octreeProcessor; }
+    const OctreePacketProcessor& getOctreePacketProcessor() const { return *_octreeProcessor; }
     QSharedPointer<EntityTreeRenderer> getEntities() const { return DependencyManager::get<EntityTreeRenderer>(); }
     MainWindow* getWindow() const { return _window; }
     EntityTreePointer getEntityClipboard() const { return _entityClipboard; }
-    EntityEditPacketSender* getEntityEditPacketSender() { return &_entityEditSender; }
+    std::shared_ptr<EntityEditPacketSender> getEntityEditPacketSender() { return _entityEditSender; }
 
     ivec2 getMouse() const;
 
@@ -721,8 +721,8 @@ private:
     bool _enableProcessOctreeThread;
     bool _interstitialMode { false };
 
-    OctreePacketProcessor _octreeProcessor;
-    EntityEditPacketSender _entityEditSender;
+    std::shared_ptr<OctreePacketProcessor> _octreeProcessor;
+    std::shared_ptr<EntityEditPacketSender> _entityEditSender;
 
     StDev _idleLoopStdev;
     float _idleLoopMeasuredJitter;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -217,8 +217,8 @@ public:
 
     ivec2 getMouse() const;
 
-    ApplicationOverlay& getApplicationOverlay() { return _applicationOverlay; }
-    const ApplicationOverlay& getApplicationOverlay() const { return _applicationOverlay; }
+    ApplicationOverlay& getApplicationOverlay() { return *_applicationOverlay; }
+    const ApplicationOverlay& getApplicationOverlay() const { return *_applicationOverlay; }
     CompositorHelper& getApplicationCompositor() const;
 
     Overlays& getOverlays() { return _overlays; }
@@ -775,7 +775,7 @@ private:
     bool _disableLoginScreen { true };
 
     Overlays _overlays;
-    ApplicationOverlay _applicationOverlay;
+    std::shared_ptr<ApplicationOverlay> _applicationOverlay;
     OverlayConductor _overlayConductor;
 
     DialogsManagerScriptingInterface* _dialogsManagerScriptingInterface = new DialogsManagerScriptingInterface();

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -124,7 +124,16 @@ class Application : public QApplication,
 
 public:
 
-    void initializePluginManager();
+    /**
+     * @brief Initialize the plugin manager
+     *
+     * This both does the initial startup and parses arguments. This
+     * is necessary because the plugin manager's options must be set
+     * before any usage of it is made, or they won't apply.
+     *
+     * @param parser
+     */
+    void initializePluginManager(const QCommandLineParser& parser);
 
     /**
      * @brief Initialize everything
@@ -151,8 +160,6 @@ public:
 
     virtual DisplayPluginPointer getActiveDisplayPlugin() const override;
 
-    // FIXME? Empty methods, do we still need them?
-    void configurePlugins(const QCommandLineParser& parser);
     static void shutdownPlugins();
 
     Application(

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -123,6 +123,9 @@ class Application : public QApplication,
     friend class OctreePacketProcessor;
 
 public:
+
+    void initializePlugins();
+
     /**
      * @brief Initialize everything
      *

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -123,6 +123,19 @@ class Application : public QApplication,
     friend class OctreePacketProcessor;
 
 public:
+    /**
+     * @brief Initialize everything
+     *
+     * This is a QApplication, and for Qt reasons it's desirable to create this object
+     * as early as possible. Without that some Qt functions don't work, like QCoreApplication::applicationDirPath()
+     *
+     * So we keep the constructor as minimal as possible, and do the rest of the work in
+     * this function.
+     */
+    void initialize(const QCommandLineParser &parser);
+
+    void setPreviousSessionCrashed(bool value) { _previousSessionCrashed = value; }
+
     // virtual functions required for PluginContainer
     virtual ui::Menu* getPrimaryMenu() override;
     virtual void requestReset() override { resetSensors(false); }
@@ -136,14 +149,13 @@ public:
     virtual DisplayPluginPointer getActiveDisplayPlugin() const override;
 
     // FIXME? Empty methods, do we still need them?
-    static void initPlugins(const QCommandLineParser& parser);
+    void configurePlugins(const QCommandLineParser& parser);
     static void shutdownPlugins();
 
     Application(
         int& argc, char** argv,
         const QCommandLineParser& parser,
-        QElapsedTimer& startup_time,
-        bool runningMarkerExisted
+        QElapsedTimer& startup_time
     );
     ~Application();
 
@@ -860,5 +872,7 @@ private:
     bool _crashOnShutdown { false };
 
     DiscordPresence* _discordPresence{ nullptr };
+
+    bool _profilingInitialized { false };
 };
 #endif // hifi_Application_h

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -124,7 +124,7 @@ class Application : public QApplication,
 
 public:
 
-    void initializePlugins();
+    void initializePluginManager();
 
     /**
      * @brief Initialize everything

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1035,8 +1035,8 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
         std::pair<bool, bool> zoneInteractionProperties;
         entityTree->withWriteLock([&] {
             zoneInteractionProperties = entityTreeRenderer->getZoneInteractionProperties();
-            EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
-            entityTree->updateEntityQueryAACube(shared_from_this(), packetSender, false, true);
+            std::shared_ptr<EntityEditPacketSender> packetSender = qApp->getEntityEditPacketSender();
+            entityTree->updateEntityQueryAACube(shared_from_this(), packetSender.get(), false, true);
         });
         bool isPhysicsEnabled = qApp->isPhysicsEnabled();
         bool zoneAllowsFlying = zoneInteractionProperties.first;
@@ -1729,7 +1729,7 @@ void MyAvatar::handleChangedAvatarEntityData() {
     entityTree->deleteEntitiesByID(entitiesToDelete);
 
     // ADD real entities
-    EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
+    auto packetSender = qApp->getEntityEditPacketSender();
     for (const auto& id : entitiesToAdd) {
         bool blobFailed = false;
         EntityItemProperties properties;
@@ -4231,7 +4231,7 @@ void MyAvatar::setSessionUUID(const QUuid& sessionUUID) {
             _avatarEntitiesLock.withReadLock([&] {
                 avatarEntityIDs = _packedAvatarEntityData.keys();
             });
-            EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
+            auto packetSender = qApp->getEntityEditPacketSender();
             entityTree->withWriteLock([&] {
                 for (const auto& entityID : avatarEntityIDs) {
                     auto entity = entityTree->findEntityByID(entityID);
@@ -6888,7 +6888,7 @@ void MyAvatar::sendPacket(const QUuid& entityID) const {
     if (entityTree) {
         entityTree->withWriteLock([&] {
             // force an update packet
-            EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
+            auto packetSender = qApp->getEntityEditPacketSender();
             packetSender->queueEditAvatarEntityMessage(entityTree, entityID);
         });
     }

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -378,6 +378,8 @@ int main(int argc, const char* argv[]) {
             data["configurable"] = plugin->configurable();
             data["isHandController"] = plugin->isHandController();
             data["isHeadController"] = plugin->isHeadController();
+            data["isActive"] = plugin->isActive();
+            data["isSupported"] = plugin->isSupported();
 
             inputJson[plugin->getName()] = data;
         }
@@ -389,13 +391,19 @@ int main(int argc, const char* argv[]) {
             data["isStereo"] = plugin->isStereo();
             data["targetFramerate"] = plugin->getTargetFrameRate();
             data["hasAsyncReprojection"] = plugin->hasAsyncReprojection();
+            data["isActive"] = plugin->isActive();
+            data["isSupported"] = plugin->isSupported();
 
             displayJson[plugin->getName()] = data;
         }
 
-        QJsonArray codecsArray;
+        QJsonObject codecsJson;
         for (const auto &plugin : pluginManager->getCodecPlugins()) {
-            codecsArray.append(plugin->getName());
+            QJsonObject data;
+            data["isActive"] = plugin->isActive();
+            data["isSupported"] = plugin->isSupported();
+
+            codecsJson[plugin->getName()] = data;
         }
 
         QJsonObject staticJson;
@@ -405,7 +413,7 @@ int main(int argc, const char* argv[]) {
         QJsonObject root;
         root["input"] = inputJson;
         root["display"] = displayJson;
-        root["codec"] = codecsArray;
+        root["codec"] = codecsJson;
         root["staticPlugins"] = staticJson;
 
         std::cout << QJsonDocument(root).toJson().toStdString() << "\n";

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -142,12 +142,12 @@ int main(int argc, const char* argv[]) {
         "displays"
     );
     QCommandLineOption disableDisplaysOption(
-        "disableDisplays",
+        "disableDisplayPlugins",
         "Displays to disable. Valid options include \"OpenVR (Vive)\" and \"Oculus Rift\"",
         "string"
     );
     QCommandLineOption disableInputsOption(
-        "disableInputs",
+        "disableInputPlugins",
         "Inputs to disable. Valid options include \"OpenVR (Vive)\" and \"Oculus Rift\"",
         "string"
     );

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -370,6 +370,17 @@ int main(int argc, const char* argv[]) {
     if (parser.isSet(getPluginsOption)) {
         auto pluginManager = PluginManager::getInstance();
 
+        QJsonObject pluginsJson;
+        for (const auto &plugin : pluginManager->getPluginInfo()) {
+            QJsonObject data;
+            data["data"] = plugin.metaData;
+            data["loaded"] = plugin.loaded;
+            data["disabled"] = plugin.disabled;
+            data["filteredOut"] = plugin.filteredOut;
+            data["wrongVersion"] = plugin.wrongVersion;
+            pluginsJson[plugin.name] = data;
+        }
+
         QJsonObject inputJson;
         for (const auto &plugin : pluginManager->getInputPlugins()) {
             QJsonObject data;
@@ -406,15 +417,16 @@ int main(int argc, const char* argv[]) {
             codecsJson[plugin->getName()] = data;
         }
 
-        QJsonObject staticJson;
-        staticJson["steamAvailable"] = (pluginManager->getSteamClientPlugin() != nullptr);
-        staticJson["oculusAvailable"] = (pluginManager->getOculusPlatformPlugin() != nullptr);
+        QJsonObject platformsJson;
+        platformsJson["steamAvailable"] = (pluginManager->getSteamClientPlugin() != nullptr);
+        platformsJson["oculusAvailable"] = (pluginManager->getOculusPlatformPlugin() != nullptr);
 
         QJsonObject root;
-        root["input"] = inputJson;
-        root["display"] = displayJson;
-        root["codec"] = codecsJson;
-        root["staticPlugins"] = staticJson;
+        root["plugins"] = pluginsJson;
+        root["inputs"] = inputJson;
+        root["displays"] = displayJson;
+        root["codecs"] = codecsJson;
+        root["platforms"] = platformsJson;
 
         std::cout << QJsonDocument(root).toJson().toStdString() << "\n";
 

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -407,8 +407,8 @@ int main(int argc, const char* argv[]) {
         }
 
         QJsonObject staticJson;
-        staticJson["steamAvailable"] = (pluginManager->getSteamClientPlugin() == nullptr);
-        staticJson["oculusAvailable"] = (pluginManager->getOculusPlatformPlugin() == nullptr);
+        staticJson["steamAvailable"] = (pluginManager->getSteamClientPlugin() != nullptr);
+        staticJson["oculusAvailable"] = (pluginManager->getOculusPlatformPlugin() != nullptr);
 
         QJsonObject root;
         root["input"] = inputJson;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -142,12 +142,12 @@ int main(int argc, const char* argv[]) {
         "displays"
     );
     QCommandLineOption disableDisplaysOption(
-        "disable-displays",
+        "disableDisplays",
         "Displays to disable. Valid options include \"OpenVR (Vive)\" and \"Oculus Rift\"",
         "string"
     );
     QCommandLineOption disableInputsOption(
-        "disable-inputs",
+        "disableInputs",
         "Inputs to disable. Valid options include \"OpenVR (Vive)\" and \"Oculus Rift\"",
         "string"
     );
@@ -365,7 +365,7 @@ int main(int argc, const char* argv[]) {
         }
     }
 
-    app.initializePluginManager();
+    app.initializePluginManager(parser);
 
     if (parser.isSet(getPluginsOption)) {
         auto pluginManager = PluginManager::getInstance();
@@ -648,7 +648,7 @@ int main(int argc, const char* argv[]) {
     // Oculus initialization MUST PRECEDE OpenGL context creation.
     // The nature of the Application constructor means this has to be either here,
     // or in the main window ctor, before GL startup.
-    app.configurePlugins(parser);
+    //app.configurePlugins(parser);
 
 #ifdef Q_OS_WIN
     // If we're running in steam mode, we need to do an explicit check to ensure we're up to the required min spec

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -272,14 +272,6 @@ DisplayPluginList PluginManager::getAllDisplayPlugins() {
     return _displayPlugins;
 }
 
-void PluginManager::disableDisplayPlugin(const QString& name) {
-    auto it = std::remove_if(_displayPlugins.begin(), _displayPlugins.end(), [&](const DisplayPluginPointer& plugin){
-        return plugin->getName() == name;
-    });
-    _displayPlugins.erase(it, _displayPlugins.end());
-}
-
-
 const InputPluginList& PluginManager::getInputPlugins() {
     static std::once_flag once;
     static auto deviceAddedCallback = [&](QString deviceName) {

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -77,7 +77,8 @@ bool isDisabled(QJsonObject metaData) {
     auto name = getPluginNameFromMetaData(metaData);
     auto iid = getPluginIIDFromMetaData(metaData);
 
-    if (iid == DisplayProvider_iid) {
+    qDebug() << "Name = " << name << "; iid =" << iid;
+    if (iid == DisplayProvider_iid || iid == SteamClientProvider_iid || iid == OculusPlatformProvider_iid) {
         return disabledDisplays.contains(name);
     } else if (iid == InputProvider_iid) {
         return disabledInputs.contains(name);

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -108,15 +108,6 @@ public:
     void setPreferredDisplayPlugins(const QStringList& displays);
 
     /**
-     * @brief Disable a display plugin.
-     *
-     * This removes the plugin from the plugins list.
-     * The plugin is not deinitialized, and events are not disconnected.
-     * @param name
-     */
-    void disableDisplayPlugin(const QString& name);
-
-    /**
      * @brief Disable a list of displays
      *
      * This adds the display to a list of displays not to be used.

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -18,6 +18,22 @@
 class QPluginLoader;
 using PluginManagerPointer = QSharedPointer<PluginManager>;
 
+/**
+ * @brief Manages loadable plugins
+ *
+ * The current implementation does initialization only once, as soon as it's needed.
+ * Once things are initialized the configuration is made permanent.
+ *
+ * Both loadable and statically modules are supported. Static modules have to be provided
+ * with setDisplayPluginProvider, setInputPluginProvider and setCodecPluginProvider.
+ *
+ * @warning Users of the PluginManager must take care to do any configuration very early
+ * on, because changes become impossible once initialization is done. Plugins can't be
+ * added or removed once that happens.
+ *
+ * Initialization is performed in the getDisplayPlugins, getInputPlugins and getCodecPlugins
+ * functions.
+ */
 class PluginManager : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
     Q_OBJECT
@@ -25,33 +41,186 @@ class PluginManager : public QObject, public Dependency {
 public:
     static PluginManagerPointer getInstance();
 
+    /**
+     * @brief Get the list of display plugins
+     *
+     * @note Calling this function will perform initialization and
+     * connects events to all the known the plugins on the first call.
+     *
+     * @return const DisplayPluginList&
+     */
     const DisplayPluginList& getDisplayPlugins();
+
+    /**
+     * @brief Get the list of input plugins
+     *
+     * @note Calling this function will perform initialization and
+     * connects events to all the known the plugins on the first call.
+     *
+     * @return const InputPluginList&
+     */
     const InputPluginList& getInputPlugins();
+
+    /**
+     * @brief Get the list of audio codec plugins
+     *
+     * @note Calling this function will perform initialization and
+     * connects events to all the known the plugins on the first call.
+     *
+     * @return const CodecPluginList&
+     */
     const CodecPluginList& getCodecPlugins();
+
+    /**
+     * @brief Get the pointer to the Steam client plugin
+     *
+     * This may return a null pointer if Steam support isn't built in.
+     *
+     * @return const SteamClientPluginPointer
+     */
     const SteamClientPluginPointer getSteamClientPlugin();
+
+    /**
+     * @brief Get the pointer to the Oculus Platform Plugin
+     *
+     * This may return a null pointer if Oculus support isn't built in.
+     *
+     * @return const OculusPlatformPluginPointer
+     */
     const OculusPlatformPluginPointer getOculusPlatformPlugin();
 
+    /**
+     * @brief Returns the list of preferred display plugins
+     *
+     * The preferred display plugins are set by setPreferredDisplayPlugins.
+     *
+     * @return DisplayPluginList
+     */
     DisplayPluginList getPreferredDisplayPlugins();
+
+    /**
+     * @brief Sets the list of preferred display plugins
+     *
+     * @note This must be called early, before any call to getPreferredDisplayPlugins.
+     *
+     * @param displays
+     */
     void setPreferredDisplayPlugins(const QStringList& displays);
 
+    /**
+     * @brief Disable a display plugin.
+     *
+     * This removes the plugin from the plugins list.
+     * The plugin is not deinitialized, and events are not disconnected.
+     * @param name
+     */
     void disableDisplayPlugin(const QString& name);
+
+    /**
+     * @brief Disable a list of displays
+     *
+     * This adds the display to a list of displays not to be used.
+     *
+     * @param displays
+     */
     void disableDisplays(const QStringList& displays);
+
+    /**
+     * @brief Disable a list of inputs
+     *
+     * This adds the input to a list of inputs not to be used.
+     * @param inputs
+     */
     void disableInputs(const QStringList& inputs);
+
+    /**
+     * @brief Save the settings
+     *
+     */
     void saveSettings();
+
+    /**
+     * @brief Set the container for plugins
+     *
+     * This will be passed to all active plugins on initialization.
+     *
+     * @param container
+     */
     void setContainer(PluginContainer* container) { _container = container; }
 
     int instantiate();
     void shutdown();
 
-    // Application that have statically linked plugins can expose them to the plugin manager with these function
+
+    /**
+     * @brief Provide a list of statically linked plugins.
+     *
+     * This is used to provide a list of statically linked plugins to the plugin manager.
+     *
+     * @note This must be called very early on, and only works once. Once the plugin manager
+     * builds its internal list of plugins, the final list becomes set in stone.
+     *
+     * @param provider A std::function that returns a list of display plugins
+     */
     void setDisplayPluginProvider(const DisplayPluginProvider& provider);
+
+    /**
+     * @brief Provide a list of statically linked plugins.
+     *
+     * This is used to provide a list of statically linked plugins to the plugin manager.
+     *
+     * @note This must be called very early on, and only works once. Once the plugin manager
+     * builds its internal list of plugins, the final list becomes set in stone.
+     *
+     * @param provider A std::function that returns a list of input plugins
+     */
     void setInputPluginProvider(const InputPluginProvider& provider);
+
+    /**
+     * @brief Provide a list of statically linked plugins.
+     *
+     * This is used to provide a list of statically linked plugins to the plugin manager.
+     *
+     * @note This must be called very early on, and only works once. Once the plugin manager
+     * builds its internal list of plugins, the final list becomes set in stone.
+     *
+     * @param provider A std::function that returns a list of codec plugins
+     */
     void setCodecPluginProvider(const CodecPluginProvider& provider);
+
+    /**
+     * @brief Set the input plugin persister
+     *
+     * @param persister A std::function that saves input plugin settings
+     */
     void setInputPluginSettingsPersister(const InputPluginSettingsPersister& persister);
+
+    /**
+     * @brief Get the list of running input devices
+     *
+     * @return QStringList List of input devices in running state
+     */
     QStringList getRunningInputDeviceNames() const;
 
     using PluginFilter = std::function<bool(const QJsonObject&)>;
+
+    /**
+     * @brief Set the plugin filter that determines whether a plugin will be used or not
+     *
+     * @note This must be called very early on. Once the plugin manager
+     * builds its internal list of plugins, the final list becomes set in stone.
+     *
+     * As of writing, this is used in the audio mixer.
+     *
+     * @param pluginFilter
+     */
     void setPluginFilter(PluginFilter pluginFilter) { _pluginFilter = pluginFilter; }
+
+    /**
+     * @brief Get a list of all the display plugins
+     *
+     * @return DisplayPluginList List of display plugins
+     */
     Q_INVOKABLE DisplayPluginList getAllDisplayPlugins();
 
     bool getEnableOculusPluginSetting() { return _enableOculusPluginSetting.get(); }
@@ -59,7 +228,7 @@ public:
 
 signals:
     void inputDeviceRunningChanged(const QString& pluginName, bool isRunning, const QStringList& runningDevices);
-    
+
 private:
     PluginManager() = default;
 

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -12,6 +12,8 @@
 
 #include <DependencyManager.h>
 #include <SettingHandle.h>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include "Forward.h"
 
@@ -39,6 +41,49 @@ class PluginManager : public QObject, public Dependency {
     Q_OBJECT
 
 public:
+
+    /**
+     * @brief Information about known plugins
+     *
+     */
+    struct PluginInfo {
+        /**
+         * @brief Plugin metadata
+        */
+        QJsonObject metaData;
+
+        /**
+         * @brief Filename
+         *
+         */
+        QString name;
+
+        /**
+         * @brief Whether the plugin has been disabled
+         *
+         */
+        bool disabled = false;
+
+        /**
+         * @brief Whether the plugin has been filtered out by a filter
+         *
+         */
+        bool filteredOut = false;
+
+        /**
+         * @brief Whether the plugin has been not loaded because it's the wrong version
+         *
+         */
+        bool wrongVersion = false;
+
+        /**
+         * @brief Whether the plugin has been loaded successfully
+         *
+         */
+        bool loaded = false;
+    };
+
+
     static PluginManagerPointer getInstance();
 
     /**
@@ -216,6 +261,15 @@ public:
 
     bool getEnableOculusPluginSetting() { return _enableOculusPluginSetting.get(); }
     void setEnableOculusPluginSetting(bool value);
+
+    /**
+     * @brief Returns information about known plugins
+     *
+     * This is a function for informative/debugging purposes.
+     *
+     * @return std::vector<PluginInfo>
+     */
+    std::vector<PluginInfo> getPluginInfo() const;
 
 signals:
     void inputDeviceRunningChanged(const QString& pluginName, bool isRunning, const QStringList& runningDevices);


### PR DESCRIPTION
Initial effort to reorganize the startup code, and improvements to plugin functionality.
    
This is intended to make things like plugin initialization more sane, and make Qt happier. Qt wants QApplication to start as soon as possible, but our code's attempt to load the entire world in the Application constructor doesn't quite mesh with this.
    
This will create Application much earlier, and do as little as possible in the constructor, moving almost all initialization to a later init function. A later stage would be to split the giant mess of init code into more digestible sections that run in some sort of logical order.

This separates out plugin initialization, and allows to disable Oculus/etc initialization via commandline parameters.

It also adds an option to dump plugin info in Json, which could be used by a launcher to allow users to make choices about plugins before startup.

Changes:
* Rearranged a lot of code (it may be simpler to view commit by commit, because a fair amount just changed location)
* Fixed shutdown code to handle an early shutdown correctly. This with the above means now interface can start, output the plugin list and shutdown much faster, which is good for the launcher idea.
* `--disable-displays` has been renamed to `--disableDisplayPlugins`.
* `--disable-inputs` has been renamed to `--disableInputPlugins`.
* Both of those now actually work, when before they were unable to because they were called at the wrong time.
* Oculus and Steam now count as displays and can be disabled via `--disableDisplayPlugins`.
* Added a whole lot of documentation, including clarifications on how to deal with the PluginManager properly.
* Removed an obsolete unused function
* Dump a whole lot of info with `--getPlugins`, which is intended to be used by a frontend.

--getPlugins returns the following on Linux:
```
{
    "codecs": {
        "opus": {
            "isActive": false,
            "isSupported": true
        },
        "pcm": {
            "isActive": false,
            "isSupported": true
        },
        "zlib": {
            "isActive": false,
            "isSupported": true
        }
    },
    "displays": {
        "3D TV - Interleaved": {
            "hasAsyncReprojection": false,
            "isActive": false,
            "isHmd": false,
            "isStereo": true,
            "isSupported": true,
            "targetFramerate": 1
        },
        "3D TV - Side by Side Stereo": {
            "hasAsyncReprojection": false,
            "isActive": false,
            "isHmd": false,
            "isStereo": true,
            "isSupported": true,
            "targetFramerate": 1
        },
        "Desktop": {
            "hasAsyncReprojection": false,
            "isActive": false,
            "isHmd": false,
            "isStereo": false,
            "isSupported": true,
            "targetFramerate": 60
        }
    },
    "inputs": {
        "Keyboard/Mouse": {
            "configurable": false,
            "deviceName": "",
            "isActive": false,
            "isHandController": false,
            "isHeadController": false,
            "isSupported": true,
            "subdeviceNames": [
                "Keyboard/Mouse"
            ]
        },
        "SDL2": {
            "configurable": false,
            "deviceName": "",
            "isActive": false,
            "isHandController": false,
            "isHeadController": false,
            "isSupported": true,
            "subdeviceNames": [
            ]
        },
        "Touchscreen": {
            "configurable": false,
            "deviceName": "",
            "isActive": false,
            "isHandController": false,
            "isHeadController": false,
            "isSupported": true,
            "subdeviceNames": [
                "Touchscreen"
            ]
        }
    },
    "platforms": {
        "oculusAvailable": false,
        "steamAvailable": false
    },
    "plugins": {
        "libhifiSdl2.so": {
            "data": {
                "IID": "com.highfidelity.plugins.input",
                "MetaData": {
                    "name": "SDL2",
                    "version": 1
                },
                "archreq": 2,
                "className": "SDL2Provider",
                "debug": false,
                "version": 331520
            },
            "disabled": false,
            "filteredOut": false,
            "loaded": true,
            "wrongVersion": false
        },
        "libopenvr.so": {
            "data": {
                "IID": "com.highfidelity.plugins.input",
                "MetaData": {
                    "name": "OpenVR (Vive)",
                    "version": 1
                },
                "archreq": 2,
                "className": "OpenVrProvider",
                "debug": false,
                "version": 331520
            },
            "disabled": false,
            "filteredOut": false,
            "loaded": true,
            "wrongVersion": false
        },
        "libopusCodec.so": {
            "data": {
                "IID": "com.highfidelity.plugins.codec",
                "MetaData": {
                    "name": "Opus Codec",
                    "version": 1
                },
                "archreq": 2,
                "className": "AthenaOpusCodecProvider",
                "debug": false,
                "version": 331520
            },
            "disabled": false,
            "filteredOut": false,
            "loaded": true,
            "wrongVersion": false
        },
        "libpcmCodec.so": {
            "data": {
                "IID": "com.highfidelity.plugins.codec",
                "MetaData": {
                    "name": "PCM Codec",
                    "version": 1
                },
                "archreq": 2,
                "className": "PCMCodecProvider",
                "debug": false,
                "version": 331520
            },
            "disabled": false,
            "filteredOut": false,
            "loaded": true,
            "wrongVersion": false
        },
        "libsteamClient.so": {
            "data": {
                "IID": "com.highfidelity.plugins.steamclient",
                "MetaData": {
                    "name": "Steam Client",
                    "version": 1
                },
                "archreq": 2,
                "className": "SteamAPIProvider",
                "debug": false,
                "version": 331520
            },
            "disabled": true,
            "filteredOut": false,
            "loaded": false,
            "wrongVersion": false
        }
    }
}

```

Turns out that `--disable-displays` and "--disable-inputs" act upon plugin loading, so they've been renamed for clarity. Static plugins can't be disabled, so eg, it's impossible to disable the standard monitor output. That's built-in. The right thing to pass them is what appears in the JSON under plugins -> (name) -> data -> MetaData -> name. So for instance, to disable the Steam plugin, run with `--disableDisplayPlugins "Steam Client"`. 


# Testing

* Needs testing on Windows
* In particular, try to disable Oculus on Windows and see if it works
* Startup process has been changed considerably, make sure the expected basic functionality still works.
