### PR TITLE
Discord Rich Presence v2

### DIFF
--- a/interface/src/DiscordRichPresence.cpp
+++ b/interface/src/DiscordRichPresence.cpp
@@ -11,15 +11,15 @@
 //
 
 #include <QtCore/QString>
-#include <QtCore/QDebug>
 #include <QtCore/QDateTime>
 #include <QtCore/QLoggingCategory>
-#include <QtCore/QObject>
 
 #include "discord_rpc.h"
 #include "DiscordRichPresence.h"
 #include "DependencyManager.h"
 #include "AddressManager.h"
+#include "scripting/HMDScriptingInterface.h"
+#include "Application.h"
 #include "EntityTreeRenderer.h"
 
 #define DISCORD_APPLICATION_CLIENT_ID "1168082546270163014"
@@ -31,10 +31,18 @@ DiscordPresence::DiscordPresence()
 {
     DiscordEventHandlers handlers;
     Discord_Initialize(DISCORD_APPLICATION_CLIENT_ID, &handlers, 1, STEAM_APPLICATION_ID);
+    discordPresence.largeImageKey = "header";
+    discordPresence.smallImageKey = "";
+    discordPresence.smallImageText = "";
     const int64_t startEpoch = QDateTime::currentSecsSinceEpoch();
     discordPresence.startTimestamp = startEpoch;
+
     auto addressManager = DependencyManager::get<AddressManager>();
     connect(addressManager.data(), &AddressManager::hostChanged, this, &DiscordPresence::domainChanged);
+
+    auto hMDScriptingInterface = DependencyManager::get<HMDScriptingInterface>();
+    DiscordPresence::vrChanged(hMDScriptingInterface->isHMDMode()); // we don't receive the initial signal, so we ask for the current state
+    connect(hMDScriptingInterface.data(), &HMDScriptingInterface::displayModeChanged, this, &DiscordPresence::vrChanged);
 }
 
 void DiscordPresence::shutdown()
@@ -46,34 +54,33 @@ void DiscordPresence::domainChanged()
 {
     const auto addressManager = DependencyManager::get<AddressManager>();
     if (!addressManager) return;
-    const auto entityTreeRenderer = DependencyManager::get<EntityTreeRenderer>();
-    if (!entityTreeRenderer) return;
 
-    // only continue if domain id changed or is serverless
-    bool isServerless = false;
-    const auto tree = entityTreeRenderer->getTree();
-    if (tree) isServerless = tree->isServerlessMode();
-    QString domainID = addressManager->getDomainID();
-    if (currentDomainID == domainID && !isServerless) return;
-    currentDomainID = domainID;
-
-    // get data
     QString state;
     // TODO: switch to getPlaceName once https://github.com/overte-org/overte/issues/684 is fixed
     const QString worldName = addressManager->getHost();
-    qCDebug(discord_rich_presence) << "Discord log hostName: " + worldName;
-    if (isServerless) {
-        state = "In a serverless world";
-    } else {
+    if (worldName != "") {
         state = ("In " + worldName);
+        qCDebug(discord_rich_presence) << "Discord log hostName: " + worldName;
+    } else {
+        state = "";
+        qCDebug(discord_rich_presence) << "Discord log: in unknown place";
     }
 
-    // create Discord presence payload
     QByteArray state_data = state.toUtf8();
     discordPresence.state = state_data.constData();
-    discordPresence.largeImageKey = "header";
-    discordPresence.smallImageKey = "logo";
 
-    // update activity
+    Discord_UpdatePresence(&discordPresence);
+}
+
+void DiscordPresence::vrChanged(bool isHMDMode = false)
+{
+    if (isHMDMode) {
+        discordPresence.smallImageKey = "hmd";
+        discordPresence.smallImageText = "in VR";
+    } else {
+        discordPresence.smallImageKey = "desktop";
+        discordPresence.smallImageText = "in desktop mode";
+    }
+    qCDebug(discord_rich_presence) << "Discord log HMDMode: " + QString::number(isHMDMode);
     Discord_UpdatePresence(&discordPresence);
 }

--- a/interface/src/DiscordRichPresence.h
+++ b/interface/src/DiscordRichPresence.h
@@ -23,10 +23,11 @@ class DiscordPresence : public QObject {
     Q_OBJECT
 public:
     DiscordPresence();
-    void shutdown();
+    static void shutdown();
 
 public slots:
     void domainChanged();
+    void vrChanged(bool isHMDMode);
 
 private:
     QString currentDomainID;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -500,6 +500,7 @@ int main(int argc, const char* argv[]) {
             socket.close();
 
             qDebug() << "Interface instance appears to be running, exiting";
+            qDebug() << "Start with --allowMultipleInstances to allow running multiple instances at once.";
 
             return EXIT_SUCCESS;
         }


### PR DESCRIPTION
This PR reports VR mode versus desktop mode to Discord Rich Presence.
It also changes the behaviour when a worlds name is unknown. Before it would try to show “Private” or “Serverless” world, but this code was buggy. I changed it to just not display anything if the name is unknown.

I had trouble with memory safety, which should be fixed, but I would like whoever reviews this to specifically have an eye on memory safety and share whatever nitpicks there might be.