### PR TITLE
Corrected refresh rate values in wizard.

### DIFF
--- a/interface/resources/serverless/Scripts/Wizard.qml
+++ b/interface/resources/serverless/Scripts/Wizard.qml
@@ -318,22 +318,22 @@ Rectangle {
             text:
               "<font size=\"4\" color=\"#ff9900\"><b>Not Smooth (20 Hz)</b></font>\n" +
               "<font color=\"white\">Conserve Power</font>"
-            onClicked: wizard.refreshRateProfile = 1
-            checked: wizard.refreshRateProfile === 1
+            onClicked: wizard.refreshRateProfile = 0
+            checked: wizard.refreshRateProfile === 0
         }
         RadioButton {
             text:
               "<font size=\"4\" color=\"#ffff00\"><b>Smooth (30 Hz)</b></font>\n" +
               "<font color=\"white\">Use Average Resources</font>"
-            onClicked: wizard.refreshRateProfile = 2
-            checked: wizard.refreshRateProfile === 2
+            onClicked: wizard.refreshRateProfile = 1
+            checked: wizard.refreshRateProfile === 1
         }
         RadioButton {
             text:
               "<font size=\"4\" color=\"#00ba1c\"><b>Very Smooth (60 Hz)</b></font>\n" +
               "<font color=\"white\">Use Maximum Resources - </font><font color=\"#00ba1c\"><i>Recommended</i></font>"
-            onClicked: wizard.refreshRateProfile = 3
-            checked: wizard.refreshRateProfile === 3
+            onClicked: wizard.refreshRateProfile = 2
+            checked: wizard.refreshRateProfile === 2
         }
       }
     }


### PR DESCRIPTION
I made mistake in the `Wiazrd.qml`, the possible values of RefreshRateProfile are "0, 1, 2", and not "1, 2, 3".

https://apidocs.overte.org/Performance.html#.RefreshRateProfile

This PR fixes the problem someone described on the chat couple days ago. Without this change, the "Complete" button is not working, if the highest refresh rate is selected.

