### PR TITLE
Custom refresh rate profile

### DIFF
--- a/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
+++ b/interface/resources/qml/hifi/dialogs/graphics/GraphicsSettings.qml
@@ -347,6 +347,10 @@ Flickable {
                             text: "Real-Time"
                             refreshRatePreset: 2 // RefreshRateProfile::REALTIME
                         }
+                        ListElement {
+                            text: "Custom"
+                            refreshRatePreset: 3 // RefreshRateProfile::CUSTOM
+                        }
                     }
 
                     HifiControlsUit.ComboBox {
@@ -366,8 +370,10 @@ Flickable {
                                 refreshRateDropdown.currentIndex = 0;
                             } else if (Performance.getRefreshRateProfile() === 1) {
                                 refreshRateDropdown.currentIndex = 1;
-                            } else {
+                            } else if (Performance.getRefreshRateProfile() === 2) {
                                 refreshRateDropdown.currentIndex = 2;
+                            } else {
+                                refreshRateDropdown.currentIndex = 3;
                             }
                         }
 
@@ -378,6 +384,132 @@ Flickable {
                         onCurrentIndexChanged: {
                             Performance.setRefreshRateProfile(model.get(currentIndex).refreshRatePreset);
                             refreshRateDropdown.displayText = model.get(currentIndex).text;
+                        }
+                    }
+
+                    HifiControlsUit.SpinBox {
+                        id: refreshRateCustomFocusActive
+                        decimals: 0
+                        width: 160
+                        height: parent.height
+                        suffix: " FPS"
+                        label: "Focus Active"
+                        minimumValue: 1.0
+                        realStepSize: 1.0
+                        realValue: 60.0
+                        colorScheme: hifi.colorSchemes.dark
+
+                        Component.onCompleted: {
+                            realValue = Performance.getCustomRefreshRate(0)
+                        }
+
+                        onRealValueChanged: {
+                            Performance.setCustomRefreshRate(0, realValue);
+                        }
+                    }
+
+                    HifiControlsUit.SpinBox {
+                        id: refreshRateCustomFocusInactive
+                        decimals: 0
+                        width: 160
+                        height: parent.height
+                        suffix: " FPS"
+                        label: "Focus Inactive"
+                        minimumValue: 1.0
+                        realStepSize: 1.0
+                        realValue: 60.0
+                        colorScheme: hifi.colorSchemes.dark
+
+                        Component.onCompleted: {
+                            realValue = Performance.getCustomRefreshRate(1)
+                        }
+
+                        onRealValueChanged: {
+                            Performance.setCustomRefreshRate(1, realValue);
+                        }
+                    }
+
+                    HifiControlsUit.SpinBox {
+                        id: refreshRateCustomUnfocus
+                        decimals: 0
+                        width: 160
+                        height: parent.height
+                        suffix: " FPS"
+                        label: "Unfocus"
+                        minimumValue: 1.0
+                        realStepSize: 1.0
+                        realValue: 60.0
+                        colorScheme: hifi.colorSchemes.dark
+
+                        Component.onCompleted: {
+                            realValue = Performance.getCustomRefreshRate(2)
+                        }
+
+                        onRealValueChanged: {
+                            Performance.setCustomRefreshRate(2, realValue);
+                        }
+                    }
+
+                    HifiControlsUit.SpinBox {
+                        id: refreshRateCustomMinimized
+                        decimals: 0
+                        width: 160
+                        height: parent.height
+                        suffix: " FPS"
+                        label: "Minimized"
+                        minimumValue: 1.0
+                        realStepSize: 1.0
+                        realValue: 60.0
+                        colorScheme: hifi.colorSchemes.dark
+
+                        Component.onCompleted: {
+                            realValue = Performance.getCustomRefreshRate(3)
+                        }
+
+                        onRealValueChanged: {
+                            Performance.setCustomRefreshRate(3, realValue);
+                        }
+                    }
+
+                    HifiControlsUit.SpinBox {
+                        id: refreshRateCustomStartup
+                        decimals: 0
+                        width: 160
+                        height: parent.height
+                        suffix: " FPS"
+                        label: "Startup"
+                        minimumValue: 1.0
+                        realStepSize: 1.0
+                        realValue: 60.0
+                        colorScheme: hifi.colorSchemes.dark
+
+                        Component.onCompleted: {
+                            realValue = Performance.getCustomRefreshRate(4)
+                        }
+
+                        onRealValueChanged: {
+                            Performance.setCustomRefreshRate(4, realValue);
+                        }
+                    }
+
+                    HifiControlsUit.SpinBox {
+                        id: refreshRateCustomShutdown
+                        decimals: 0
+                        width: 160
+                        height: parent.height
+                        suffix: " FPS"
+                        label: "Shutdown"
+                        minimumValue: 1.0
+                        realStepSize: 1.0
+                        realValue: 60.0
+                        colorScheme: hifi.colorSchemes.dark
+
+                        Component.onCompleted: {
+                            realValue = Performance.getCustomRefreshRate(5)
+                        }
+
+                        onRealValueChanged: {
+                            Performance.setCustomRefreshRate(5, realValue);
                         }
                     }
                 }

--- a/interface/src/RefreshRateManager.cpp
+++ b/interface/src/RefreshRateManager.cpp
@@ -94,7 +94,8 @@ static const std::array<std::string, RefreshRateManager::UXMode::UX_NUM> UX_MODE
 static const std::map<std::string, RefreshRateManager::RefreshRateProfile> REFRESH_RATE_PROFILE_FROM_STRING =
     { { "Eco", RefreshRateManager::RefreshRateProfile::ECO },
       { "Interactive", RefreshRateManager::RefreshRateProfile::INTERACTIVE },
-      { "Realtime", RefreshRateManager::RefreshRateProfile::REALTIME } };
+      { "Realtime", RefreshRateManager::RefreshRateProfile::REALTIME },
+      { "Custom", RefreshRateManager::RefreshRateProfile::CUSTOM } };
 
 
 // Porfile regimes are:
@@ -166,6 +167,25 @@ void RefreshRateManager::setRefreshRateProfile(RefreshRateManager::RefreshRatePr
         });
         updateRefreshRateController();
     }
+}
+
+int RefreshRateManager::getCustomRefreshRate(RefreshRateRegime regime)
+{
+    Q_ASSERT(regime >= 0 && regime < RefreshRateRegime::REGIME_NUM);
+    if (regime < 0 && regime >= RefreshRateRegime::REGIME_NUM)
+        return -1;
+
+    return _customProfile[regime];
+}
+
+int RefreshRateManager::setCustomRefreshRate(RefreshRateRegime regime, int value)
+{
+    Q_ASSERT(regime >= 0 && regime < RefreshRateRegime::REGIME_NUM);
+    if (regime < 0 && regime >= RefreshRateRegime::REGIME_NUM)
+        return -1;
+
+    _customProfile[regime] = value;
+    return 0;
 }
 
 RefreshRateManager::RefreshRateProfile RefreshRateManager::getRefreshRateProfile() const {

--- a/interface/src/RefreshRateManager.h
+++ b/interface/src/RefreshRateManager.h
@@ -32,6 +32,7 @@ public:
         ECO = 0,
         INTERACTIVE,
         REALTIME,
+        CUSTOM,
         PROFILE_NUM
     };
     Q_ENUM(RefreshRateProfile)
@@ -106,6 +107,9 @@ public:
     // query the refresh rate target at the specified combination
     int queryRefreshRateTarget(RefreshRateProfile profile, RefreshRateRegime regime, UXMode uxMode) const;
 
+    int getCustomRefreshRate(RefreshRateRegime regime);
+    int setCustomRefreshRate(RefreshRateRegime regime, int value);
+
     void resetInactiveTimer();
     void toggleInactive();
 
@@ -115,6 +119,9 @@ public:
     static std::string refreshRateRegimeToString(RefreshRateRegime refreshRateRegime);
 
 private:
+    std::array<int, RefreshRateRegime::REGIME_NUM> _customProfile =
+        { { 0, 0, 0, 0, 0, 0 } };
+
     mutable int _activeRefreshRate { 20 };
     RefreshRateProfile _refreshRateProfile { RefreshRateProfile::INTERACTIVE};
     RefreshRateRegime _refreshRateRegime { RefreshRateRegime::STARTUP };

--- a/interface/src/scripting/PerformanceScriptingInterface.cpp
+++ b/interface/src/scripting/PerformanceScriptingInterface.cpp
@@ -56,12 +56,22 @@ void PerformanceScriptingInterface::setRefreshRateProfile(RefreshRateProfile ref
     emit settingsChanged();
 }
 
+void PerformanceScriptingInterface::setCustomRefreshRate(RefreshRateManager::RefreshRateRegime refreshRateRegime, int value)
+{
+    qApp->getRefreshRateManager().setCustomRefreshRate(refreshRateRegime, value);
+    emit settingsChanged();
+}
+
+int PerformanceScriptingInterface::getCustomRefreshRate(RefreshRateManager::RefreshRateRegime refreshRateRegime) const {
+    return qApp->getRefreshRateManager().getCustomRefreshRate(refreshRateRegime);
+}
+
 PerformanceScriptingInterface::RefreshRateProfile PerformanceScriptingInterface::getRefreshRateProfile() const {
     return (PerformanceScriptingInterface::RefreshRateProfile)qApp->getRefreshRateManager().getRefreshRateProfile();
 }
 
 QStringList PerformanceScriptingInterface::getRefreshRateProfileNames() const {
-    static const QStringList refreshRateProfileNames = { "ECO", "INTERACTIVE", "REALTIME" };
+    static const QStringList refreshRateProfileNames = { "ECO", "INTERACTIVE", "REALTIME", "CUSTOM" };
     return refreshRateProfileNames;
 }
 

--- a/interface/src/scripting/PerformanceScriptingInterface.h
+++ b/interface/src/scripting/PerformanceScriptingInterface.h
@@ -128,6 +128,22 @@ public slots:
     void setRefreshRateProfile(RefreshRateProfile refreshRateProfile);
 
     /*@jsdoc
+     * Sets a custom refresh rate.
+     * @function Performance.setCustomRefreshRate
+     * @param {RefreshRateRegime} refreshRateRegime - The refresh rate regime
+     * @param {int} value - The value for the regime
+     */
+    void setCustomRefreshRate(RefreshRateManager::RefreshRateRegime refreshRateRegime, int value);
+
+    /*@jsdoc
+     * Gets the value for a specific RefreshRateRegime.
+     * @function Performance.getCustomRefreshRate
+     * @param {RefreshRateRegime} - The regime to get the value from
+     * @returns {int} - The value from the specified regime
+     */
+    int getCustomRefreshRate(RefreshRateManager::RefreshRateRegime regime) const;
+
+    /*@jsdoc
      * Gets the current refresh rate profile in use.
      * @function Performance.getRefreshRateProfile
      * @returns {Performance.RefreshRateProfile} The refresh rate profile.

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -100,7 +100,8 @@ void setupPreferences() {
         QStringList refreshRateProfiles
             { QString::fromStdString(RefreshRateManager::refreshRateProfileToString(RefreshRateManager::RefreshRateProfile::ECO)),
               QString::fromStdString(RefreshRateManager::refreshRateProfileToString(RefreshRateManager::RefreshRateProfile::INTERACTIVE)),
-              QString::fromStdString(RefreshRateManager::refreshRateProfileToString(RefreshRateManager::RefreshRateProfile::REALTIME)) };
+              QString::fromStdString(RefreshRateManager::refreshRateProfileToString(RefreshRateManager::RefreshRateProfile::REALTIME)),
+              QString::fromStdString(RefreshRateManager::refreshRateProfileToString(RefreshRateManager::RefreshRateProfile::CUSTOM)) };
 
         preference->setItems(refreshRateProfiles);
         preferences->addPreference(preference);


### PR DESCRIPTION
This adds a Custom refresh rate profile with configurable refresh rate regimes.

Unfortunately it does not work yet. The SpinBoxes inside GraphicsSettings are on top of each other, and changing the values for the Custom profile through e.g. the newly introduced JS function `Performance.setCustomRefreshRate` does not actually affect the refresh rate cap in-game at all for some reason.