### PR TITLE
Fix setting external port and IP address for manual networking modes

### DIFF
--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -601,7 +601,7 @@ $(document).ready(function(){
     form += '<label class="control-label">' + label + '</label>';
     form += ' <a id="edit-network-address-port" class="domain-loading-hide" href="#">Edit</a>';
     form += '<input type="text" class="domain-loading-hide form-control" disabled></input>';
-    form += '<div class="domain-loading-hide help-block">This defines how nodes will connect to your domain. You can read more about automatic networking <a href="">here</a>.</div>';
+    form += '<div class="domain-loading-hide help-block">This defines how nodes will connect to your domain. Since the displayed setting is read back from directory server, it takes some time to update after being edited. You can read more about automatic networking <a href="">here</a>.</div>';
     form += '</div>';
 
     form = $(form);
@@ -664,7 +664,13 @@ $(document).ready(function(){
                 success: function(xhr) {
                   console.log(xhr, parseJSONResponse(xhr));
                   dialog.modal('hide');
-                  reloadDomainInfo();
+                  reloadDomainInfo(); // TODO: this one doesn't work since directory server still has old data
+                  setTimeout(function() {
+                    reloadDomainInfo();
+                  }, 16000);
+                  setTimeout(function() {
+                    reloadDomainInfo();
+                  }, 64000);
                 },
                 error:function(xhr) {
                   var data = parseJSONResponse(xhr);

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1570,12 +1570,19 @@ void DomainServer::performIPAddressPortUpdate(const SockAddr& newPublicSockAddr)
     const QString& publicSocketAddress = newPublicSockAddr.getAddress().toString();
     const int publicSocketPort = newPublicSockAddr.getPort();
 
-    sendHeartbeatToMetaverse(publicSocketAddress, publicSocketPort);
+    if (_automaticNetworkingSetting == IP_ONLY_AUTOMATIC_NETWORKING_VALUE) {
+        sendHeartbeatToMetaverse(publicSocketAddress, 0);
+    } else {
+        // Full automatic networking, update both port and IP address
+        sendHeartbeatToMetaverse(publicSocketAddress, publicSocketPort);
+    }
 
     QJsonObject rootObject;
     QJsonObject domainServerObject;
     domainServerObject.insert(PUBLIC_SOCKET_ADDRESS_KEY, publicSocketAddress);
-    domainServerObject.insert(PUBLIC_SOCKET_PORT_KEY, publicSocketPort);
+    if (_automaticNetworkingSetting == FULL_AUTOMATIC_NETWORKING_VALUE) {
+        domainServerObject.insert(PUBLIC_SOCKET_PORT_KEY, publicSocketPort);
+    }
     rootObject.insert(DOMAIN_SERVER_SETTINGS_KEY, domainServerObject);
     QJsonDocument doc(rootObject);
     qDebug() << "DomainServer::performIPAddressPortUpdate: " << doc;

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -73,9 +73,9 @@ Q_LOGGING_CATEGORY(domain_server_auth, "overte.domain_server.auth")
 
 const QString ACCESS_TOKEN_KEY_PATH = "metaverse.access_token";
 const QString DomainServer::REPLACEMENT_FILE_EXTENSION = ".replace";
+const QString& DOMAIN_SERVER_SETTINGS_KEY = "domain_server";
 const QString PUBLIC_SOCKET_ADDRESS_KEY = "network_address";
 const QString PUBLIC_SOCKET_PORT_KEY = "network_port";
-const QString DOMAIN_UPDATE_AUTOMATIC_NETWORKING_KEY = "automatic_networking";
 const int MIN_PORT = 1;
 const int MAX_PORT = 65535;
 
@@ -1567,7 +1567,6 @@ QJsonObject jsonForDomainSocketUpdate(const SockAddr& socket) {
 }
 
 void DomainServer::performIPAddressPortUpdate(const SockAddr& newPublicSockAddr) {
-    const QString& DOMAIN_SERVER_SETTINGS_KEY = "domain_server";
     const QString& publicSocketAddress = newPublicSockAddr.getAddress().toString();
     const int publicSocketPort = newPublicSockAddr.getPort();
 
@@ -1579,6 +1578,7 @@ void DomainServer::performIPAddressPortUpdate(const SockAddr& newPublicSockAddr)
     domainServerObject.insert(PUBLIC_SOCKET_PORT_KEY, publicSocketPort);
     rootObject.insert(DOMAIN_SERVER_SETTINGS_KEY, domainServerObject);
     QJsonDocument doc(rootObject);
+    qDebug() << "DomainServer::performIPAddressPortUpdate: " << doc;
     _settingsManager.recurseJSONObjectAndOverwriteSettings(rootObject, DomainSettings);
 }
 
@@ -2487,6 +2487,16 @@ bool DomainServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
                 return true;
             }
             auto domainID = domainSetting.toString();
+            qDebug() << connection->parseUrlEncodedForm();
+            auto parsed = connection->parseUrlEncodedForm();
+            if (parsed.contains(PUBLIC_SOCKET_PORT_KEY) || parsed.contains(PUBLIC_SOCKET_ADDRESS_KEY)) {
+                QJsonObject domainServerObject;
+                domainServerObject.insert(PUBLIC_SOCKET_PORT_KEY, parsed[PUBLIC_SOCKET_PORT_KEY]);
+                domainServerObject.insert(PUBLIC_SOCKET_ADDRESS_KEY, parsed[PUBLIC_SOCKET_ADDRESS_KEY]);
+                QJsonObject rootObject;
+                rootObject.insert(DOMAIN_SERVER_SETTINGS_KEY, domainServerObject);
+                _settingsManager.recurseJSONObjectAndOverwriteSettings(rootObject, DomainSettings);
+            }
             return forwardMetaverseAPIRequest(connection, url, "/api/v1/domains/" + domainID, "domain",
                                               { }, { "network_address", "network_port", "label" });
         }  else if (url.path() == URI_API_PLACES) {


### PR DESCRIPTION
Earlier it was impossible to set port in "IP only" mode - it was never updated and changing randomly on every restart. For mode with manually setting both IP address and port it didn't change on every restart but was still impossible to set.