### PR TITLE
Disable Neuron by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,7 @@ if (BUILD_CLIENT)
   endif()
 
   option(USE_SIXENSE "Build Interface with sixense library/plugin" OFF)
+  option(USE_NEURON "Build Interface with Neuron library/plugin" OFF)
 endif()
 
 if (BUILD_CLIENT OR BUILD_SERVER)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -31,8 +31,12 @@ if (NOT SERVER_ONLY AND NOT ANDROID)
 
   set(DIR "hifiSpacemouse")
   add_subdirectory(${DIR})
-  set(DIR "hifiNeuron")
-  add_subdirectory(${DIR})
+
+  if (USE_NEURON)
+    set(DIR "hifiNeuron")
+    add_subdirectory(${DIR})
+  endif()
+
   set(DIR "hifiKinect")
   add_subdirectory(${DIR})
 


### PR DESCRIPTION
Helps with Windows builds.

Creates an option to enable it if needed.