### PR TITLE
Fix OpenEXR on Windows

### DIFF
--- a/cmake/macros/TargetOpenEXR.cmake
+++ b/cmake/macros/TargetOpenEXR.cmake
@@ -79,5 +79,11 @@ macro(TARGET_OPENEXR)
         select_library_configurations(OPENEXR)
         target_link_libraries(${TARGET_NAME} ${OPENEXR_LIBRARY})
         target_include_directories(${TARGET_NAME} PUBLIC "${VCPKG_INSTALL_ROOT}/include/Imath")
+
+        # This prevents:
+        # LNK2001	unresolved external symbol imath_half_to_float_table
+        #
+        # Apparently something changed in newer versions.
+        target_compile_definitions(${TARGET_NAME} PUBLIC IMATH_HALF_NO_LOOKUP_TABLE)
     endif()
 endmacro()


### PR DESCRIPTION
Prevents:
`LNK2001	unresolved external symbol imath_half_to_float_table`

For some reason this only happens on Windows.
This is as per https://github.com/AcademySoftwareFoundation/openexr/issues/1442
Docs: https://github.com/AcademySoftwareFoundation/Imath/blob/490be7e74e713b119895547a9d78a616ed479ceb/website/classes/half_conversion.rst#L50

