### PR TITLE
Fixes for Oculus VR plugin

### DIFF
--- a/cmake/externals/LibOVR/CMakeLists.txt
+++ b/cmake/externals/LibOVR/CMakeLists.txt
@@ -15,11 +15,16 @@ string(TOUPPER ${EXTERNAL_NAME} EXTERNAL_NAME_UPPER)
 
 if (WIN32)
 
+  # Note the -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+  # It's important that we pass our build type down to other builds we make, especially on Windows.
+  # On Windows, debug libraries get a 'd' suffix, eg, LibOVRd.lib. This means that a mismatch of build
+  # types means we'll generate a LibOVRd.lib and the rest of the system will look for LibOVR.lib, or
+  # viceversa.
   ExternalProject_Add(
     ${EXTERNAL_NAME}
     URL "${EXTERNAL_BUILD_ASSETS}/dependencies/ovr_sdk_win_1.35.0.zip"
     URL_MD5 1e3e8b2101387af07ff9c841d0ea285e
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/LibOVRCMakeLists.txt" <SOURCE_DIR>/CMakeLists.txt
     LOG_DOWNLOAD 1
     DOWNLOAD_EXTRACT_TIMESTAMP 1

--- a/cmake/externals/LibOVR/CMakeLists.txt
+++ b/cmake/externals/LibOVR/CMakeLists.txt
@@ -25,6 +25,7 @@ if (WIN32)
     DOWNLOAD_EXTRACT_TIMESTAMP 1
     BUILD_BYPRODUCTS
       "project/Lib/LibOVR.lib"
+      "project/Lib/LibOVRd.lib"
   )
 
   ExternalProject_Get_Property(${EXTERNAL_NAME} SOURCE_DIR)

--- a/cmake/externals/LibOVR/CMakeLists.txt
+++ b/cmake/externals/LibOVR/CMakeLists.txt
@@ -23,6 +23,8 @@ if (WIN32)
     PATCH_COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/LibOVRCMakeLists.txt" <SOURCE_DIR>/CMakeLists.txt
     LOG_DOWNLOAD 1
     DOWNLOAD_EXTRACT_TIMESTAMP 1
+    BUILD_BYPRODUCTS
+      "project/Lib/LibOVR.lib"
   )
 
   ExternalProject_Get_Property(${EXTERNAL_NAME} SOURCE_DIR)

--- a/cmake/externals/LibOVR/LibOVRCMakeLists.txt
+++ b/cmake/externals/LibOVR/LibOVRCMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.20)
 project(LibOVR)
+
+message(STATUS "Building LibOVR for ${CMAKE_BUILD_TYPE} configuration")
 
 include_directories(LibOVR/Include LibOVR/Src)
 file(GLOB HEADER_FILES LibOVR/Include/*.h)

--- a/cmake/externals/LibOVRPlatform/CMakeLists.txt
+++ b/cmake/externals/LibOVRPlatform/CMakeLists.txt
@@ -16,6 +16,8 @@ if (WIN32)
     INSTALL_COMMAND ""
     LOG_DOWNLOAD 1
     DOWNLOAD_EXTRACT_TIMESTAMP 1
+    BUILD_BYPRODUCTS
+    "project/src/LibOVRPlatform/Windows/LibOVRPlatform64_1.lib"
   )
 
   ExternalProject_Get_Property(${EXTERNAL_NAME} SOURCE_DIR)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -13,17 +13,18 @@ list(REMOVE_ITEM PLUGIN_SUBDIRS "CMakeFiles")
 # client-side plugins
 if (NOT SERVER_ONLY AND NOT ANDROID)
   if (NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-    if (NOT ((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (MSVC_VERSION LESS 1930)))
+    if ((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (MSVC_VERSION GREATER 1930))
+      message(WARNING "Building under ${CMAKE_CXX_COMPILER_ID}, MSVC Version ${MSVC_VERSION}. Oculus plugin unsupported, disabling.")
+    else()
       # Check if we're building on MSVC 2022. If so, Oculus plugin fails to build.
       set(DIR "oculus")
       add_subdirectory(${DIR})
-      set(DIR "openvr")
-      add_subdirectory(${DIR})
       set(DIR "oculusLegacy")
       add_subdirectory(${DIR})
-    else()
-      message(WARNING "Building under ${CMAKE_CXX_COMPILER_ID}, MSVC Version ${MSVC_VERSION}. Oculus plugin unsupported, disabling.")
     endif()
+    
+    set(DIR "openvr")
+    add_subdirectory(${DIR})    
   endif()
 
   set(DIR "hifiSdl2")

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,7 +22,8 @@ if (NOT SERVER_ONLY AND NOT ANDROID)
       set(DIR "oculusLegacy")
       add_subdirectory(${DIR})
     endif()
-    
+
+    # Note: OpenVR is a Steam thing, which is different from OVR, which is an Oculus SDK component.
     set(DIR "openvr")
     add_subdirectory(${DIR})    
   endif()


### PR DESCRIPTION
This is still not quite right at least on Ninja, but testing and help would be appreciated.

On Ninja this fails with:

`LINK : fatal error LNK1104: cannot open file 'ext\vc14\LibOVR\project\Lib\LibOVR.lib'`

And indeed I don't see where this is supposed to come from.

The [.zip](https://build-deps.overte.org/dependencies/ovr_sdk_win_1.35.0.zip) has:

    ./LibOVR/Lib/Windows/Win32/Release/VS2013/LibOVR.lib
    ./LibOVR/Lib/Windows/Win32/Release/VS2015/LibOVR.lib
    ./LibOVR/Lib/Windows/Win32/Release/VS2017/LibOVR.lib
    ./LibOVR/Lib/Windows/x64/Release/VS2013/LibOVR.lib
    ./LibOVR/Lib/Windows/x64/Release/VS2015/LibOVR.lib
    ./LibOVR/Lib/Windows/x64/Release/VS2017/LibOVR.lib

None of that matches the path. I suppose it's probably VS2017, but this had to work somehow before.


## Mystery solved!

The .lib libraries from the .zip are not actually used. Instead, the source found in the .zip is built and generates `Lib\LibOVR.lib'
