### PR TITLE
Re-enable building Oculus plugin on VS 2022

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -12,21 +12,16 @@ list(REMOVE_ITEM PLUGIN_SUBDIRS "CMakeFiles")
 
 # client-side plugins
 if (NOT SERVER_ONLY AND NOT ANDROID)
-  if (NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-    if ((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (MSVC_VERSION GREATER 1930))
-      message(WARNING "Building under ${CMAKE_CXX_COMPILER_ID}, MSVC Version ${MSVC_VERSION}. Oculus plugin unsupported, disabling.")
-    else()
-      # Check if we're building on MSVC 2022. If so, Oculus plugin fails to build.
+  if (WIN32 AND (NOT USE_GLES))
       set(DIR "oculus")
       add_subdirectory(${DIR})
       set(DIR "oculusLegacy")
       add_subdirectory(${DIR})
-    endif()
-
-    # Note: OpenVR is a Steam thing, which is different from OVR, which is an Oculus SDK component.
-    set(DIR "openvr")
-    add_subdirectory(${DIR})    
   endif()
+
+  # Note: OpenVR is a Steam thing, which is different from OVR, which is an Oculus SDK component.
+  set(DIR "openvr")
+  add_subdirectory(${DIR})
 
   set(DIR "hifiSdl2")
   add_subdirectory(${DIR})

--- a/plugins/oculus/CMakeLists.txt
+++ b/plugins/oculus/CMakeLists.txt
@@ -8,7 +8,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-if (WIN32 AND (NOT USE_GLES) AND (MSVC_VERSION LESS 1930) )
+if (WIN32 AND (NOT USE_GLES))
 
   # if we were passed an Oculus App ID for entitlement checks, send that along
   if (DEFINED ENV{OCULUS_APP_ID})


### PR DESCRIPTION
I'm not seeing any problems with building it on VS 2022, so I re-enabled it, and simplified the logic while at it.
