### PR TITLE
Fix the doppleganger position in the tutorial

### DIFF
--- a/interface/resources/serverless/Scripts/activator-doppleganger.js
+++ b/interface/resources/serverless/Scripts/activator-doppleganger.js
@@ -64,7 +64,7 @@
 
     function startDopplegangerShow(entityID) {
         var properties = Entities.getEntityProperties(entityID, ["position", "rotation"]);
-        var avatarPosition = MyAvatar.position;
+        var avatarPosition = MyAvatar.feetPosition;
         var drawPosition = {
             "x": properties.position.x,
             "y": avatarPosition.y,


### PR DESCRIPTION
This try to fix the doppleganger position in the Avatar Viewer in the tutorial.

No test has been done. (sorry I don't build.)


![image](https://github.com/overte-org/overte/assets/60075796/2bfdaf67-523a-4043-94f0-e96a78f18577)

