### PR TITLE
Add a way to get VCPKG path and hash ID

### DIFF
--- a/hifi_qt.py
+++ b/hifi_qt.py
@@ -81,7 +81,9 @@ endif()
 
             qt_found = True
             system_qt = True
-            #print("Using system Qt")
+
+            if not self.args.quiet:
+                print("Using system Qt")
 
         elif os.getenv('OVERTE_QT_PATH', "") != "":
             # 2. Using an user-provided directory.
@@ -92,7 +94,9 @@ endif()
             self.cmakePath = os.path.join(self.fullPath, 'lib', 'cmake')
 
             qt_found = True
-            #print("Using Qt from " + self.fullPath)
+
+            if not self.args.quiet:
+                print("Using Qt from " + self.fullPath)
 
         else:
             # 3. Using a pre-built Qt.
@@ -135,7 +139,8 @@ endif()
             self.lockFile = os.path.join(lockDir, lockName)
 
         if qt_found:
-            #print("Found pre-built Qt5")
+            if not self.args.quiet:
+                print("Found pre-built Qt5")
             return
 
         if 'Windows' == system:

--- a/hifi_qt.py
+++ b/hifi_qt.py
@@ -81,7 +81,7 @@ endif()
 
             qt_found = True
             system_qt = True
-            print("Using system Qt")
+            #print("Using system Qt")
 
         elif os.getenv('OVERTE_QT_PATH', "") != "":
             # 2. Using an user-provided directory.
@@ -92,7 +92,7 @@ endif()
             self.cmakePath = os.path.join(self.fullPath, 'lib', 'cmake')
 
             qt_found = True
-            print("Using Qt from " + self.fullPath)
+            #print("Using Qt from " + self.fullPath)
 
         else:
             # 3. Using a pre-built Qt.
@@ -135,7 +135,7 @@ endif()
             self.lockFile = os.path.join(lockDir, lockName)
 
         if qt_found:
-            print("Found pre-built Qt5")
+            #print("Found pre-built Qt5")
             return
 
         if 'Windows' == system:
@@ -147,8 +147,8 @@ endif()
             cpu_architecture = platform.machine()
 
             if 'x86_64' == cpu_architecture:
-                # `major_version()` can return blank string on rolling release distros like arch 
-                # The `or 0` conditional assignment prevents the int parsing error from hiding the useful Qt package error 
+                # `major_version()` can return blank string on rolling release distros like arch
+                # The `or 0` conditional assignment prevents the int parsing error from hiding the useful Qt package error
                 u_major = int( distro.major_version() or '0' )
                 if distro.id() == 'ubuntu' or distro.id() == 'linuxmint':
                     if (distro.id() == 'ubuntu' and u_major == 20) or distro.id() == 'linuxmint' and u_major == 20:

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -71,7 +71,7 @@ endif()
                 os.makedirs(self.basePath)
             self.path = os.path.join(self.basePath, self.id)
 
-        print("Using vcpkg path {}".format(self.path))
+        #print("Using vcpkg path {}".format(self.path))
         lockDir, lockName = os.path.split(self.path)
         lockName += '.lock'
         if not os.path.isdir(lockDir):

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -71,7 +71,8 @@ endif()
                 os.makedirs(self.basePath)
             self.path = os.path.join(self.basePath, self.id)
 
-        #print("Using vcpkg path {}".format(self.path))
+        if not self.args.quiet:
+            print("Using vcpkg path {}".format(self.path))
         lockDir, lockName = os.path.split(self.path)
         lockName += '.lock'
         if not os.path.isdir(lockDir):

--- a/prebuild.py
+++ b/prebuild.py
@@ -103,6 +103,10 @@ def main():
             del os.environ[var]
 
     args = parse_args()
+
+    if not args.quiet:
+        print(sys.argv)
+
     assets_url = hifi_utils.readEnviromentVariableFromFile(args.build_root, 'EXTERNAL_BUILD_ASSETS')
 
     if args.ci_build:
@@ -205,7 +209,7 @@ def main():
 
     logger.info('end')
 
-#print(sys.argv)
+
 try:
     main()
 except hifi_utils.SilentFatalError as fatal_ex:

--- a/prebuild.py
+++ b/prebuild.py
@@ -85,6 +85,7 @@ def parse_args():
     parser.add_argument('--ci-build', action='store_true', default=os.getenv('CI_BUILD') is not None)
     parser.add_argument('--get-vcpkg-id', action='store_true', help='Get the VCPKG ID, the hash path of the full VCPKG path')
     parser.add_argument('--get-vcpkg-path', action='store_true', help='Get the full VCPKG path, ID included.')
+    parser.add_argument('--quiet', action='store_true', default=False, help='Quiet mode with less output')
 
     if True:
         args = parser.parse_args()
@@ -132,8 +133,9 @@ def main():
                     qt.writeConfig()
         else:
             if (os.environ["OVERTE_USE_SYSTEM_QT"]):
-                #print("System Qt selected")
-                None
+                if not args.quiet:
+                    print("System Qt selected")
+
             else:
                 raise Exception("Internal error: System Qt not selected, but hifi_qt.py failed to return a cmake path")
 


### PR DESCRIPTION
This makes a simple change that aids in packaging, Docker container creation and similar:

```
$ python ./prebuild.py --get-vcpkg-id --build-root . --quiet
77b4e5f4

$python ./prebuild.py --get-vcpkg-path --build-root . --quiet
/home/dale/overte-files/vcpkg/77b4e5f4
```

The `--build-root .` is a requirement of the previously existing code. The value used doesn't matter for `--get-vcpkg-id` and `--get-vcpkg-path`.

A few status messages were commented out to make this more usable in a script. If they're wanted we could add a verbose or quiet mode to choose whether they show up.


