### PR TITLE
:bug: Fixed build on Windows

### DIFF
--- a/libraries/script-engine/src/ScriptMessage.h
+++ b/libraries/script-engine/src/ScriptMessage.h
@@ -20,6 +20,9 @@
 #include <QJsonObject>
 #include "EntityItemID.h"
 
+// SEVERITY_ERROR is defined as a macro in winerror.h
+#undef SEVERITY_ERROR
+
 class ScriptMessage {
 public:
     enum class ScriptType {


### PR DESCRIPTION
SEVERITY_ERROR is defined as a macro in winerror.h, so it has to be undefined to get it to build on windows