### PR TITLE
Fix the display of Notifications

### DIFF
--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -45,8 +45,8 @@
     
     //HMD NOTIFICATION PANEL PROPERTIES
     var HMD_UI_SCALE_FACTOR = 1.0; //This define the size of all the notification system in HMD.
-    var hmdPanelLocalPosition = {"x": 0.4, "y": 0.25, "z": -1.5};
-    var hmdPanelLocalRotation = Quat.fromVec3Degrees({"x": 0, "y": -5, "z": 0});
+    var hmdPanelLocalPosition = {"x": 0.3, "y": 0.25, "z": -1.5};
+    var hmdPanelLocalRotation = Quat.fromVec3Degrees({"x": 0, "y": -3, "z": 0});
     var mainHMDnotificationContainerID = Uuid.NULL;
     var CAMERA_MATRIX_INDEX = -7;
     


### PR DESCRIPTION
This PR addresses the following things:
- In **HMD**, the notification are now synch with the helmet, you can't miss any notification now. the rendering is more stable this way. (Addressing Issue #826)

- in **Desktop**, it is using _**Window API**_ instead of **_Controller API_** to obtain the window size to know where to display should be. (_Controller_ is not always on synch with desktop size.  _Window_ is always accurate for Desktop.)

- In Desktop, now the windows width is recomputed so it supports now window resizing. (Maybe addressing Issue #470 (assuming that "Announcements" are"Notifications", ))