### PR TITLE
Fix prebuild.py code ordering to make --get-vcpkg-id and --get-vcpkg-path correctly in the repo root

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -41,7 +41,13 @@ endif()
         else:
             self.id = hifi_utils.hashFolder(self.sourcePortsPath)[:8]
         self.configFilePath = os.path.join(args.build_root, 'vcpkg.cmake')
-        self.assets_url = self.readVar('EXTERNAL_BUILD_ASSETS')
+
+        if args.get_vcpkg_id or args.get_vcpkg_path:
+            # With these arguments no assets will be downloaded, and they may be used in conditions
+            # where the _env hack doesn't work.
+            self.assets_url = "http://no_assets.invalid"
+        else:
+            self.assets_url = self.readVar('EXTERNAL_BUILD_ASSETS')
 
         # The noClean flag indicates we're doing weird dependency maintenance stuff
         # i.e. we've got an explicit checkout of vcpkg and we don't want the script to

--- a/prebuild.py
+++ b/prebuild.py
@@ -104,15 +104,29 @@ def main():
 
     args = parse_args()
 
+    if args.get_vcpkg_id or args.get_vcpkg_path:
+        # These arguments need quiet mode to avoid confusing scripts that use them.
+        args.quiet = True
+
     if not args.quiet:
         print(sys.argv)
-
-    assets_url = hifi_utils.readEnviromentVariableFromFile(args.build_root, 'EXTERNAL_BUILD_ASSETS')
 
     if args.ci_build:
         logging.basicConfig(datefmt='%H:%M:%S', format='%(asctime)s %(guid)s %(message)s', level=logging.INFO)
 
     logger.info('start')
+
+    pm = hifi_vcpkg.VcpkgRepo(args)
+
+    if args.get_vcpkg_id:
+        print(pm.id)
+        exit(0)
+
+    if args.get_vcpkg_path:
+        print(pm.path)
+        exit(0)
+
+    assets_url = hifi_utils.readEnviromentVariableFromFile(args.build_root, 'EXTERNAL_BUILD_ASSETS')
 
     # OS dependent information
     system = platform.system()
@@ -142,16 +156,6 @@ def main():
 
             else:
                 raise Exception("Internal error: System Qt not selected, but hifi_qt.py failed to return a cmake path")
-
-    pm = hifi_vcpkg.VcpkgRepo(args)
-
-    if args.get_vcpkg_id:
-        print(pm.id)
-        exit(0)
-
-    if args.get_vcpkg_path:
-        print(pm.path)
-        exit(0)
 
     if qtInstallPath is not None:
         pm.writeVar('QT_CMAKE_PREFIX_PATH', qtInstallPath)


### PR DESCRIPTION
Fixes this:

```
Traceback (most recent call last):
  File "/opt/overte-build/prebuild.py", line 214, in <module>
    main()
  File "/opt/overte-build/prebuild.py", line 110, in main
    assets_url = hifi_utils.readEnviromentVariableFromFile(args.build_root, 'EXTERNAL_BUILD_ASSETS')
  File "/opt/overte-build/hifi_utils.py", line 157, in readEnviromentVariableFromFile
    with open(os.path.join(buildRootDir, '_env', var + ".txt")) as fp:
FileNotFoundError: [Errno 2] No such file or directory: './_env/EXTERNAL_BUILD_ASSETS.txt'
```