### PR TITLE
Remove debug print with URL from ModelLoader

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelLoader.cpp
+++ b/libraries/model-networking/src/model-networking/ModelLoader.cpp
@@ -20,6 +20,5 @@ hfm::Model::Pointer ModelLoader::load(const hifi::ByteArray& data, const hifi::V
     if (!serializer) {
         return hfm::Model::Pointer();
     }
-    qDebug() << "ModelLoader::load: " << url;
     return serializer->read(data, mapping, url);
 }


### PR DESCRIPTION
It was accidentally left there