### PR TITLE
Support opaque (and black) particles

### DIFF
--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -21,23 +21,35 @@ using namespace render::entities;
 
 static uint8_t CUSTOM_PIPELINE_NUMBER = 0;
 static gpu::Stream::FormatPointer _vertexFormat;
-static std::weak_ptr<gpu::Pipeline> _texturedPipeline;
+static std::map<std::tuple<bool, bool>, gpu::PipelinePointer> _pipelines;
 
 static ShapePipelinePointer shapePipelineFactory(const ShapePlumber& plumber, const ShapeKey& key, RenderArgs* args) {
-    auto texturedPipeline = _texturedPipeline.lock();
-    if (!texturedPipeline) {
-        auto state = std::make_shared<gpu::State>();
-        state->setCullMode(gpu::State::CULL_BACK);
-        state->setDepthTest(true, false, gpu::LESS_EQUAL);
-        state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE,
-            gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
-        PrepareStencil::testMask(*state);
+    // FIXME: custom pipelines like this don't handle shadows or renderLayers correctly
 
-        auto program = gpu::Shader::createProgram(shader::entities_renderer::program::textured_particle);
-        _texturedPipeline = texturedPipeline = gpu::Pipeline::create(program, state);
+    if (_pipelines.empty()) {
+        for (size_t i = 0; i < 4; i++) {
+            bool transparent = (i % 2 == 0);
+            bool wireframe = (i / 2) == 0;
+
+            auto state = std::make_shared<gpu::State>();
+            state->setCullMode(gpu::State::CULL_BACK);
+
+            if (wireframe) {
+                state->setFillMode(gpu::State::FILL_LINE);
+            }
+
+            state->setDepthTest(true, !transparent, gpu::LESS_EQUAL);
+            state->setBlendFunction(transparent, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE,
+                gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
+            transparent ? PrepareStencil::testMask(*state) : PrepareStencil::testMaskDrawShape(*state);
+
+            auto program = gpu::Shader::createProgram(transparent ? shader::entities_renderer::program::textured_particle_translucent :
+                shader::entities_renderer::program::textured_particle);
+            _pipelines[std::make_tuple(transparent, wireframe)] = gpu::Pipeline::create(program, state);
+        }
     }
 
-    return std::make_shared<render::ShapePipeline>(texturedPipeline, nullptr, nullptr, nullptr);
+    return std::make_shared<render::ShapePipeline>(_pipelines[std::make_tuple(key.isTranslucent(), key.isWireframe())], nullptr, nullptr, nullptr);
 }
 
 struct GpuParticle {
@@ -138,26 +150,25 @@ void ParticleEffectEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEn
     _uniformBuffer.edit<ParticleUniforms>() = particleUniforms;
 }
 
-ItemKey ParticleEffectEntityRenderer::getKey() {
-    // FIXME: implement isTransparent() for particles and an opaque pipeline
-    auto builder = ItemKey::Builder::transparentShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
-
-    if (!_visible) {
-        builder.withInvisible();
-    }
-
-    if (_cullWithParent) {
-        builder.withSubMetaCulled();
-    }
-
-    return builder.build();
+bool ParticleEffectEntityRenderer::isTransparent() const {
+    bool particleTransparent = _particleProperties.getColorStart().a < 1.0f || _particleProperties.getColorMiddle().a < 1.0f ||
+                               _particleProperties.getColorFinish().a < 1.0f || _particleProperties.getColorSpread().a > 0.0f ||
+                               _pulseProperties.getAlphaMode() != PulseMode::NONE || (_textureLoaded && _networkTexture && _networkTexture->getGPUTexture() &&
+                                   _networkTexture->getGPUTexture()->getUsage().isAlpha() && !_networkTexture->getGPUTexture()->getUsage().isAlphaMask());
+    return particleTransparent || Parent::isTransparent();
 }
 
 ShapeKey ParticleEffectEntityRenderer::getShapeKey() {
-    auto builder = ShapeKey::Builder().withCustom(CUSTOM_PIPELINE_NUMBER).withTranslucent();
+    auto builder = ShapeKey::Builder().withCustom(CUSTOM_PIPELINE_NUMBER);
+
+    if (isTransparent()) {
+        builder.withTranslucent();
+    }
+
     if (_primitiveMode == PrimitiveMode::LINES) {
         builder.withWireframe();
     }
+
     return builder.build();
 }
 

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.h
@@ -28,7 +28,7 @@ protected:
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) override;
 
-    virtual ItemKey getKey() override;
+    bool isTransparent() const override;
     virtual ShapeKey getShapeKey() override;
     virtual Item::Bound getBound(RenderArgs* args) override;
     virtual void doRender(RenderArgs* args) override;

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
@@ -203,7 +203,6 @@ public:
     }
 
 protected:
-    virtual ItemKey getKey() override;
     virtual ShapeKey getShapeKey() override;
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;

--- a/libraries/entities-renderer/src/entities-renderer/textured_particle.slp
+++ b/libraries/entities-renderer/src/entities-renderer/textured_particle.slp
@@ -1,0 +1,1 @@
+DEFINES translucent:f

--- a/libraries/entities-renderer/src/entities-renderer/textured_particle.slp
+++ b/libraries/entities-renderer/src/entities-renderer/textured_particle.slp
@@ -1,1 +1,1 @@
-DEFINES translucent:f
+DEFINES translucent:f/forward:f

--- a/libraries/entities-renderer/src/entities-renderer/textured_particle.slp
+++ b/libraries/entities-renderer/src/entities-renderer/textured_particle.slp
@@ -1,1 +1,1 @@
-DEFINES translucent:f/forward:f
+DEFINES (translucent:f forward:f)/shadow:f

--- a/libraries/entities-renderer/src/textured_particle.slf
+++ b/libraries/entities-renderer/src/textured_particle.slf
@@ -15,23 +15,34 @@ LAYOUT(binding=0) uniform sampler2D colorMap;
 layout(location=0) in vec4 varColor;
 layout(location=1) in vec2 varTexcoord;
 
-<@if not HIFI_USE_FORWARD@>
-    <@include DeferredBufferWrite.slh@>
-<@else@>
+<@if HIFI_USE_FORWARD or HIFI_USE_SHADOW@>
     layout(location=0) out vec4 _fragColor0;
+<@else@>
+    <@include DeferredBufferWrite.slh@>
 <@endif@>
 
 void main(void) {
     vec4 albedo = texture(colorMap, varTexcoord.xy) * varColor;
 
-<@if not HIFI_USE_FORWARD@>
+<@if HIFI_USE_FORWARD or HIFI_USE_SHADOW@>
+    <@if not HIFI_USE_TRANSLUCENT@>
+        // to reduce texel flickering for floating point error we discard when alpha is "almost one"
+        if (albedo.a < 0.999999) {
+            discard;
+        }
+    <@endif@>
+
+<@if HIFI_USE_FORWARD@>
+    _fragColor0 = albedo;
+<@else@>
+    _fragColor0 = vec4(1.0);
+<@endif@>
+<@else@>
     vec3 NORMAL = vec3(1.0, 0.0, 0.0);
     <@if not HIFI_USE_TRANSLUCENT@>
         packDeferredFragmentUnlit(NORMAL, albedo.a, albedo.rgb);
     <@else@>
         packDeferredFragmentTranslucent(NORMAL, albedo.a, albedo.rgb, DEFAULT_ROUGHNESS);
     <@endif@>
-<@else@>
-    _fragColor0 = albedo;
 <@endif@>
 }

--- a/libraries/entities-renderer/src/textured_particle.slf
+++ b/libraries/entities-renderer/src/textured_particle.slf
@@ -15,17 +15,23 @@ LAYOUT(binding=0) uniform sampler2D colorMap;
 layout(location=0) in vec4 varColor;
 layout(location=1) in vec2 varTexcoord;
 
-layout(location=0) out vec4 outFragColor;
+<@if not HIFI_USE_FORWARD@>
+    <@include DeferredBufferWrite.slh@>
+<@else@>
+    layout(location=0) out vec4 _fragColor0;
+<@endif@>
 
 void main(void) {
     vec4 albedo = texture(colorMap, varTexcoord.xy) * varColor;
 
+<@if not HIFI_USE_FORWARD@>
+    vec3 NORMAL = vec3(1.0, 0.0, 0.0);
     <@if not HIFI_USE_TRANSLUCENT@>
-        // to reduce texel flickering for floating point error we discard when alpha is "almost one"
-        if (albedo.a < 0.999999) {
-            discard;
-        }
+        packDeferredFragmentUnlit(NORMAL, albedo.a, albedo.rgb);
+    <@else@>
+        packDeferredFragmentTranslucent(NORMAL, albedo.a, albedo.rgb, DEFAULT_ROUGHNESS);
     <@endif@>
-
-    outFragColor = albedo;
+<@else@>
+    _fragColor0 = albedo;
+<@endif@>
 }

--- a/libraries/entities-renderer/src/textured_particle.slf
+++ b/libraries/entities-renderer/src/textured_particle.slf
@@ -18,5 +18,14 @@ layout(location=1) in vec2 varTexcoord;
 layout(location=0) out vec4 outFragColor;
 
 void main(void) {
-    outFragColor = texture(colorMap, varTexcoord.xy) * varColor;
+    vec4 albedo = texture(colorMap, varTexcoord.xy) * varColor;
+
+    <@if not HIFI_USE_TRANSLUCENT@>
+        // to reduce texel flickering for floating point error we discard when alpha is "almost one"
+        if (albedo.a < 0.999999) {
+            discard;
+        }
+    <@endif@>
+
+    outFragColor = albedo;
 }

--- a/libraries/render-utils/src/RenderCommonTask.cpp
+++ b/libraries/render-utils/src/RenderCommonTask.cpp
@@ -85,6 +85,8 @@ void DrawLayered3D::run(const RenderContextPointer& renderContext, const Inputs&
     }
 
     if (!inItems.empty()) {
+        auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
+
         // Render the items
         gpu::doInBatch("DrawLayered3D::main", args->_context, [&](gpu::Batch& batch) {
             args->_batch = &batch;
@@ -108,11 +110,20 @@ void DrawLayered3D::run(const RenderContextPointer& renderContext, const Inputs&
                 batch.setUniformBuffer(graphics::slot::buffer::Buffer::HazeParams, haze->getHazeParametersBuffer());
             }
 
+            // Set the light
+            deferredLightingEffect->setupKeyLightBatch(args, batch);
+
+            auto renderMethod = args->_renderMethod;
+            args->_renderMethod = Args::RenderMethod::FORWARD;
             if (_opaquePass) {
                 renderStateSortShapes(renderContext, _shapePlumber, inItems, _maxDrawn);
             } else {
                 renderShapes(renderContext, _shapePlumber, inItems, _maxDrawn);
             }
+
+            deferredLightingEffect->unsetLocalLightsBatch(batch);
+
+            args->_renderMethod = renderMethod;
             args->_batch = nullptr;
         });
     }

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -60,8 +60,8 @@ ShapeKey::Filter::Builder::Builder() {
 }
 
 void ShapePlumber::addPipelineHelper(const Filter& filter, ShapeKey key, int bit, const PipelinePointer& pipeline) const {
-    // Iterate over all keys
-    if (bit < (int)ShapeKey::FlagBit::NUM_FLAGS) {
+    // Iterate over all non-custom keys
+    if (bit < (int)ShapeKey::FlagBit::NUM_NON_CUSTOM - 1) {
         addPipelineHelper(filter, key, bit + 1, pipeline);
         if (!filter._mask[bit]) {
             // Toggle bits set as insignificant in filter._mask 

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -54,6 +54,7 @@ public:
         CUSTOM_7,
 
         NUM_FLAGS, // Not a valid flag
+        NUM_NON_CUSTOM = INVALID,
 
         CUSTOM_MASK = (0xFF << CUSTOM_0),
 
@@ -112,7 +113,7 @@ public:
         Builder& withOwnPipeline() { _flags.set(OWN_PIPELINE); return (*this); }
         Builder& invalidate() { _flags.set(INVALID); return (*this); }
 
-        Builder& withCustom(uint8_t custom) {  _flags &= (~CUSTOM_MASK); _flags |= (custom << CUSTOM_0); return (*this); }
+        Builder& withCustom(uint8_t custom) { _flags &= (~CUSTOM_MASK); _flags |= (custom << CUSTOM_0); return (*this); }
         
         static const ShapeKey ownPipeline() { return Builder().withOwnPipeline(); }
         static const ShapeKey invalid() { return Builder().invalidate(); }


### PR DESCRIPTION
Closes #833 

Particles can render opaque if their texture has no alpha or is detected as "alpha mask" (e.g. https://pngimg.com/d/grass_PNG4922.png).  If any of their alpha properties (start, middle, finish) are < 1, or their alpha spread is > 0, or they have alpha pulsing, they'll go back to transparent (+ additive blending).  At a later date, we could support overriding the automatic detection via material entities.

![Screenshot 2024-03-01 130300](https://github.com/overte-org/overte/assets/53453710/61bbf556-604a-487b-a1a0-1c981fcf0b0b)