### PR TITLE
Clean up GeometryCache and remove _glColor4f

### DIFF
--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -337,7 +337,7 @@ void MaterialEntityRenderer::doRender(RenderArgs* args) {
         }
 
         // Draw!
-        auto compactColor = 0xFFFFFFFF;
+        const uint32_t compactColor = 0xFFFFFFFF;
         _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
         DependencyManager::get<GeometryCache>()->renderShape(batch, GeometryCache::Shape::Sphere, _colorBuffer);
     } else {
@@ -347,7 +347,7 @@ void MaterialEntityRenderer::doRender(RenderArgs* args) {
         proceduralDrawMaterial->prepare(batch, transform.getTranslation(), transform.getScale(),
                                         transform.getRotation(), _created, ProceduralProgramKey(outColor.a < 1.0f));
 
-        auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+        const uint32_t compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
         _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
         if (render::ShapeKey(args->_globalShapeKey).isWireframe() || _primitiveMode == PrimitiveMode::LINES) {
             DependencyManager::get<GeometryCache>()->renderWireShape(batch, GeometryCache::Shape::Sphere, _colorBuffer);

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
@@ -67,6 +67,7 @@ private:
     std::shared_ptr<NetworkMaterial> _appliedMaterial;
     std::string _currentMaterialName;
 
+    gpu::BufferPointer _colorBuffer { std::make_shared<gpu::Buffer>() };
 };
 
 } } 

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -131,7 +131,7 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
             procedural->prepare(batch, transform.getTranslation(), transform.getScale(), transform.getRotation(), _created, ProceduralProgramKey(outColor.a < 1.0f));
         });
 
-        auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+        const uint32_t compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
         _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
         if (wireframe) {
             geometryCache->renderWireShape(batch, geometryShape, _colorBuffer);
@@ -151,7 +151,7 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
                 geometryCache->renderSolidShapeInstance(args, batch, geometryShape, outColor, pipeline);
             }
         } else {
-            auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+            const uint32_t compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
             _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
             if (wireframe) {
                 geometryCache->renderWireShape(batch, geometryShape, _colorBuffer);
@@ -164,7 +164,7 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
             args->_details._materialSwitches++;
         }
 
-        auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+        const uint32_t compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
         _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
         geometryCache->renderShape(batch, geometryShape, _colorBuffer);
     }

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -131,10 +131,12 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
             procedural->prepare(batch, transform.getTranslation(), transform.getScale(), transform.getRotation(), _created, ProceduralProgramKey(outColor.a < 1.0f));
         });
 
+        auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+        _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
         if (wireframe) {
-            geometryCache->renderWireShape(batch, geometryShape, outColor);
+            geometryCache->renderWireShape(batch, geometryShape, _colorBuffer);
         } else {
-            geometryCache->renderShape(batch, geometryShape, outColor);
+            geometryCache->renderShape(batch, geometryShape, _colorBuffer);
         }
     } else if (pipelineType == Pipeline::SIMPLE) {
         // FIXME, support instanced multi-shape rendering using multidraw indirect
@@ -149,10 +151,12 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
                 geometryCache->renderSolidShapeInstance(args, batch, geometryShape, outColor, pipeline);
             }
         } else {
+            auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+            _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
             if (wireframe) {
-                geometryCache->renderWireShape(batch, geometryShape, outColor);
+                geometryCache->renderWireShape(batch, geometryShape, _colorBuffer);
             } else {
-                geometryCache->renderShape(batch, geometryShape, outColor);
+                geometryCache->renderShape(batch, geometryShape, _colorBuffer);
             }
         }
     } else {
@@ -160,7 +164,9 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
             args->_details._materialSwitches++;
         }
 
-        geometryCache->renderShape(batch, geometryShape);
+        auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+        _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
+        geometryCache->renderShape(batch, geometryShape, _colorBuffer);
     }
 
     const auto triCount = geometryCache->getShapeTriangleCount(geometryShape);

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.h
@@ -42,6 +42,8 @@ private:
     std::shared_ptr<graphics::ProceduralMaterial> _material { std::make_shared<graphics::ProceduralMaterial>() };
     glm::vec3 _color { NAN };
     float _alpha { NAN };
+
+    gpu::BufferPointer _colorBuffer { std::make_shared<gpu::Buffer>() };
 };
 
 } } 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
@@ -100,8 +100,6 @@ GLBackend::CommandCall GLBackend::_commandCalls[Batch::NUM_COMMANDS] =
     (&::gpu::gl::GLBackend::do_glUniformMatrix3fv),
     (&::gpu::gl::GLBackend::do_glUniformMatrix4fv),
 
-    (&::gpu::gl::GLBackend::do_glColor4f),
-
     (&::gpu::gl::GLBackend::do_pushProfileRange),
     (&::gpu::gl::GLBackend::do_popProfileRange),
 };
@@ -835,22 +833,6 @@ void GLBackend::do_glUniformMatrix4fv(const Batch& batch, size_t paramOffset) {
         batch._params[paramOffset + 2]._uint,
         batch._params[paramOffset + 1]._uint,
         (const GLfloat*)batch.readData(batch._params[paramOffset + 0]._uint));
-    (void)CHECK_GL_ERROR();
-}
-
-void GLBackend::do_glColor4f(const Batch& batch, size_t paramOffset) {
-
-    glm::vec4 newColor(
-        batch._params[paramOffset + 3]._float,
-        batch._params[paramOffset + 2]._float,
-        batch._params[paramOffset + 1]._float,
-        batch._params[paramOffset + 0]._float);
-
-    if (_input._colorAttribute != newColor) {
-        _input._colorAttribute = newColor;
-        glVertexAttrib4fv(gpu::Stream::COLOR, &_input._colorAttribute.r);
-        _input._hasColorAttribute = true;
-    }
     (void)CHECK_GL_ERROR();
 }
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -241,8 +241,6 @@ public:
     virtual void do_glUniformMatrix3fv(const Batch& batch, size_t paramOffset) final;
     virtual void do_glUniformMatrix4fv(const Batch& batch, size_t paramOffset) final;
 
-    virtual void do_glColor4f(const Batch& batch, size_t paramOffset) final;
-
     // The State setters called by the GLState::Commands when a new state is assigned
     virtual void do_setStateFillMode(int32 mode) final;
     virtual void do_setStateCullMode(int32 mode) final;
@@ -350,8 +348,6 @@ protected:
     struct InputStageState {
         bool _invalidFormat { true };
         bool _lastUpdateStereoState { false };
-        bool _hasColorAttribute { false };
-        bool _hadColorAttribute { false };
         FormatReference _format { GPU_REFERENCE_INIT_VALUE };
         std::string _formatKey;
 
@@ -367,8 +363,6 @@ protected:
         std::array<Offset, MAX_NUM_INPUT_BUFFERS> _bufferOffsets;
         std::array<Offset, MAX_NUM_INPUT_BUFFERS> _bufferStrides;
         std::array<GLuint, MAX_NUM_INPUT_BUFFERS> _bufferVBOs;
-
-        glm::vec4 _colorAttribute { 1.0f };
 
         BufferReference _indexBuffer;
         Offset _indexBufferOffset { 0 };

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendInput.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendInput.cpp
@@ -103,9 +103,6 @@ void GLBackend::resetInputStage() {
     reset(_input._format);
     _input._formatKey.clear();
     _input._invalidFormat = false;
-    _input._hasColorAttribute = false;
-    _input._hadColorAttribute = false;
-    _input._colorAttribute = vec4(1.0f);
     _input._attributeActivation.reset();
 
     for (uint32_t i = 0; i < _input._buffers.size(); i++) {
@@ -163,8 +160,6 @@ void GLBackend::updateInput() {
 #endif
     _input._lastUpdateStereoState = isStereoNow;
 
-    bool hasColorAttribute = _input._hasColorAttribute;
-
     if (_input._invalidFormat) {
         InputStageState::ActivationCache newActivation;
 
@@ -193,8 +188,6 @@ void GLBackend::updateInput() {
                     GLboolean isNormalized = attrib._element.isNormalized();
 
                     GLenum perLocationSize = attrib._element.getLocationSize();
-
-                    hasColorAttribute |= slot == Stream::COLOR;
 
                     for (GLuint locNum = 0; locNum < locationCount; ++locNum) {
                         GLuint attriNum = (GLuint)(slot + locNum);
@@ -226,12 +219,6 @@ void GLBackend::updateInput() {
                 glVertexBindingDivisor(bufferChannelNum, frequency);
 #endif
             }
-
-            if (!hasColorAttribute && _input._hadColorAttribute) {
-                // The previous input stage had a color attribute but this one doesn't, so reset the color to pure white.
-                _input._colorAttribute = glm::vec4(1.0f);
-                glVertexAttrib4fv(Stream::COLOR, &_input._colorAttribute.r);
-            }
         }
 
         // Manage Activation what was and what is expected now
@@ -252,9 +239,6 @@ void GLBackend::updateInput() {
         _input._invalidFormat = false;
         _stats._ISNumFormatChanges++;
     }
-
-    _input._hadColorAttribute = hasColorAttribute;
-    _input._hasColorAttribute = false;
 
     if (_input._invalidBuffers.any()) {
         auto vbo = _input._bufferVBOs.data();

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendInput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendInput.cpp
@@ -33,8 +33,6 @@ void GL41Backend::updateInput() {
 #endif
     _input._lastUpdateStereoState = isStereoNow;
 
-    bool hasColorAttribute = _input._hasColorAttribute;
-
     if (_input._invalidFormat || _input._invalidBuffers.any()) {
 
         auto format = acquire(_input._format);
@@ -110,8 +108,6 @@ void GL41Backend::updateInput() {
                             uintptr_t pointer = (uintptr_t)(attrib._offset + offsets[bufferNum]);
                             GLboolean isNormalized = attrib._element.isNormalized();
 
-                            hasColorAttribute |= slot == Stream::COLOR;
-
                             for (size_t locNum = 0; locNum < locationCount; ++locNum) {
                                 if (attrib._element.isInteger()) {
                                     glVertexAttribIPointer(slot + (GLuint)locNum, count, type, stride,
@@ -131,17 +127,8 @@ void GL41Backend::updateInput() {
                     }
                 }
             }
-
-            if (!hasColorAttribute && _input._hadColorAttribute) {
-                // The previous input stage had a color attribute but this one doesn't, so reset the color to pure white.
-                _input._colorAttribute = glm::vec4(1.0f);
-                glVertexAttrib4fv(Stream::COLOR, &_input._colorAttribute.r);
-            }
         }
         // everything format related should be in sync now
         _input._invalidFormat = false;
     }
-
-    _input._hadColorAttribute = hasColorAttribute;
-    _input._hasColorAttribute = false;
 }

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendInput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendInput.cpp
@@ -35,8 +35,6 @@ void GL45Backend::updateInput() {
 #endif
     _input._lastUpdateStereoState = isStereoNow;
 
-    bool hasColorAttribute = _input._hasColorAttribute;
-
     if (_input._invalidFormat) {
         InputStageState::ActivationCache newActivation;
 
@@ -65,8 +63,6 @@ void GL45Backend::updateInput() {
                     GLboolean isNormalized = attrib._element.isNormalized();
 
                     GLenum perLocationSize = attrib._element.getLocationSize();
-
-                    hasColorAttribute |= slot == Stream::COLOR;
 
                     for (GLuint locNum = 0; locNum < locationCount; ++locNum) {
                         GLuint attriNum = (GLuint)(slot + locNum);
@@ -98,12 +94,6 @@ void GL45Backend::updateInput() {
                 glVertexBindingDivisor(bufferChannelNum, frequency);
 #endif
             }
-
-            if (!hasColorAttribute && _input._hadColorAttribute) {
-                // The previous input stage had a color attribute but this one doesn't, so reset the color to pure white.
-                _input._colorAttribute = glm::vec4(1.0f);
-                glVertexAttrib4fv(Stream::COLOR, &_input._colorAttribute.r);
-            }
         }
 
         // Manage Activation what was and what is expected now
@@ -124,9 +114,6 @@ void GL45Backend::updateInput() {
         _input._invalidFormat = false;
         _stats._ISNumFormatChanges++;
     }
-
-    _input._hadColorAttribute = hasColorAttribute;
-    _input._hasColorAttribute = false;
 
     if (_input._invalidBuffers.any()) {
         auto vbo = _input._bufferVBOs.data();

--- a/libraries/gpu/src/gpu/Batch.cpp
+++ b/libraries/gpu/src/gpu/Batch.cpp
@@ -687,15 +687,6 @@ void Batch::_glUniformMatrix4fv(int32 location, int count, uint8 transpose, cons
     _params.emplace_back(location);
 }
 
-void Batch::_glColor4f(float red, float green, float blue, float alpha) {
-    ADD_COMMAND(glColor4f);
-
-    _params.emplace_back(alpha);
-    _params.emplace_back(blue);
-    _params.emplace_back(green);
-    _params.emplace_back(red);
-}
-
 void Batch::finishFrame(BufferUpdates& updates) {
     PROFILE_RANGE(render_gpu, __FUNCTION__);
 

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -287,8 +287,6 @@ public:
         _glUniformMatrix3fv(location, 1, false, glm::value_ptr(v));
     }
 
-    void _glColor4f(float red, float green, float blue, float alpha);
-
     // Maybe useful but shoudln't be public. Please convince me otherwise
     // Well porting to gles i need it...
     void runLambda(std::function<void()> f);
@@ -362,8 +360,6 @@ public:
         COMMAND_glUniform4iv,
         COMMAND_glUniformMatrix3fv,
         COMMAND_glUniformMatrix4fv,
-
-        COMMAND_glColor4f,
 
         COMMAND_pushProfileRange,
         COMMAND_popProfileRange,

--- a/libraries/gpu/src/gpu/FrameIOKeys.h
+++ b/libraries/gpu/src/gpu/FrameIOKeys.h
@@ -201,8 +201,6 @@ constexpr const char*  COMMAND_NAMES[] = {
     "glUniformMatrix3fv",
     "glUniformMatrix4fv",
 
-    "glColor4f",
-
     "pushProfileRange",
     "popProfileRange",
 };

--- a/libraries/graphics/src/graphics/Geometry.cpp
+++ b/libraries/graphics/src/graphics/Geometry.cpp
@@ -19,7 +19,7 @@ Mesh::Mesh() :
     _vertexBuffer(gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ)),
     _indexBuffer(gpu::Element(gpu::SCALAR, gpu::UINT32, gpu::INDEX)),
     _partBuffer(gpu::Element(gpu::VEC4, gpu::UINT32, gpu::PART)) {
-    auto compactColor = 0xFFFFFFFF;
+    const uint32_t compactColor = 0xFFFFFFFF;
     _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
 }
 
@@ -47,7 +47,7 @@ void Mesh::setVertexFormatAndStream(const gpu::Stream::FormatPointer& vf, const 
     if (!_vertexFormat->hasAttribute(gpu::Stream::COLOR)) {
         int channelNum = _vertexStream.getNumBuffers();
         _vertexFormat->setAttribute(gpu::Stream::COLOR, channelNum, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
-        _vertexStream.addBuffer(_colorBuffer, channelNum, _vertexFormat->getChannels().at(channelNum)._stride);
+        _vertexStream.addBuffer(_colorBuffer, 0, _vertexFormat->getChannels().at(channelNum)._stride);
     }
 }
 
@@ -112,7 +112,7 @@ void Mesh::evalVertexStream() {
     // We require meshes to have a color attribute.  If they don't, we default to white.
     if (!_vertexFormat->hasAttribute(gpu::Stream::COLOR)) {
         _vertexFormat->setAttribute(gpu::Stream::COLOR, channelNum, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
-        _vertexStream.addBuffer(_colorBuffer, channelNum, _vertexFormat->getChannels().at(channelNum)._stride);
+        _vertexStream.addBuffer(_colorBuffer, 0, _vertexFormat->getChannels().at(channelNum)._stride);
     }
 }
 

--- a/libraries/graphics/src/graphics/Geometry.cpp
+++ b/libraries/graphics/src/graphics/Geometry.cpp
@@ -19,6 +19,8 @@ Mesh::Mesh() :
     _vertexBuffer(gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ)),
     _indexBuffer(gpu::Element(gpu::SCALAR, gpu::UINT32, gpu::INDEX)),
     _partBuffer(gpu::Element(gpu::VEC4, gpu::UINT32, gpu::PART)) {
+    auto compactColor = 0xFFFFFFFF;
+    _colorBuffer->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
 }
 
 Mesh::Mesh(const Mesh& mesh) :
@@ -26,7 +28,8 @@ Mesh::Mesh(const Mesh& mesh) :
     _vertexBuffer(mesh._vertexBuffer),
     _attributeBuffers(mesh._attributeBuffers),
     _indexBuffer(mesh._indexBuffer),
-    _partBuffer(mesh._partBuffer) {
+    _partBuffer(mesh._partBuffer),
+    _colorBuffer(mesh._colorBuffer) {
 }
 
 Mesh::~Mesh() {
@@ -39,6 +42,13 @@ void Mesh::setVertexFormatAndStream(const gpu::Stream::FormatPointer& vf, const 
     auto attrib = _vertexFormat->getAttribute(gpu::Stream::POSITION);
     _vertexBuffer = BufferView(vbs->getBuffers()[attrib._channel], vbs->getOffsets()[attrib._channel], vbs->getBuffers()[attrib._channel]->getSize(),
         (gpu::uint16) vbs->getStrides()[attrib._channel], attrib._element);
+
+    // We require meshes to have a color attribute.  If they don't, we default to white.
+    if (!_vertexFormat->hasAttribute(gpu::Stream::COLOR)) {
+        int channelNum = _vertexStream.getNumBuffers();
+        _vertexFormat->setAttribute(gpu::Stream::COLOR, channelNum, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
+        _vertexStream.addBuffer(_colorBuffer, channelNum, _vertexFormat->getChannels().at(channelNum)._stride);
+    }
 }
 
 void Mesh::setVertexBuffer(const BufferView& buffer) {
@@ -97,6 +107,12 @@ void Mesh::evalVertexStream() {
         auto stride = glm::max<gpu::Offset>(_vertexFormat->getChannelStride(channelNum), view._stride);
         _vertexStream.addBuffer(view._buffer, view._offset, stride);
         channelNum++;
+    }
+
+    // We require meshes to have a color attribute.  If they don't, we default to white.
+    if (!_vertexFormat->hasAttribute(gpu::Stream::COLOR)) {
+        _vertexFormat->setAttribute(gpu::Stream::COLOR, channelNum, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
+        _vertexStream.addBuffer(_colorBuffer, channelNum, _vertexFormat->getChannels().at(channelNum)._stride);
     }
 }
 

--- a/libraries/graphics/src/graphics/Geometry.h
+++ b/libraries/graphics/src/graphics/Geometry.h
@@ -15,6 +15,7 @@
 
 #include <AABox.h>
 
+#include <gpu/Forward.h>
 #include <gpu/Resource.h>
 #include <gpu/Stream.h>
 
@@ -27,7 +28,6 @@ typedef glm::vec3 Vec3;
 
 class Mesh;
 using MeshPointer = std::shared_ptr< Mesh >;
-
 
 class Mesh {
 public:
@@ -142,6 +142,8 @@ public:
     std::string modelName;
     std::string displayName;
 
+    gpu::BufferPointer getColorBuffer() const { return _colorBuffer; }
+
 protected:
 
     gpu::Stream::FormatPointer _vertexFormat;
@@ -153,6 +155,8 @@ protected:
     BufferView _indexBuffer;
 
     BufferView _partBuffer;
+
+    gpu::BufferPointer _colorBuffer { std::make_shared<gpu::Buffer>() };
 
     void evalVertexFormat();
     void evalVertexStream();

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1927,7 +1927,7 @@ void renderInstances(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color
     // Add color to named buffer
     {
         gpu::BufferPointer instanceColorBuffer = batch.getNamedBuffer(instanceName, INSTANCE_COLOR_BUFFER);
-        auto compactColor = GeometryCache::toCompactColor(color);
+        const uint32_t compactColor = GeometryCache::toCompactColor(color);
         instanceColorBuffer->append(compactColor);
     }
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -99,14 +99,9 @@ static const gpu::Element NORMAL_ELEMENT { gpu::VEC3, gpu::FLOAT, gpu::XYZ };
 static const gpu::Element TEXCOORD0_ELEMENT { gpu::VEC2, gpu::FLOAT, gpu::UV };
 static const gpu::Element TANGENT_ELEMENT { gpu::VEC3, gpu::FLOAT, gpu::XYZ };
 static const gpu::Element COLOR_ELEMENT { gpu::VEC4, gpu::NUINT8, gpu::RGBA };
-static const gpu::Element TEXCOORD4_ELEMENT { gpu::VEC4, gpu::FLOAT, gpu::XYZW };
 
 static gpu::Stream::FormatPointer SOLID_STREAM_FORMAT;
-static gpu::Stream::FormatPointer INSTANCED_SOLID_STREAM_FORMAT;
-static gpu::Stream::FormatPointer INSTANCED_SOLID_FADE_STREAM_FORMAT;
 static gpu::Stream::FormatPointer WIRE_STREAM_FORMAT;
-static gpu::Stream::FormatPointer INSTANCED_WIRE_STREAM_FORMAT;
-static gpu::Stream::FormatPointer INSTANCED_WIRE_FADE_STREAM_FORMAT;
 
 static const uint SHAPE_VERTEX_STRIDE = sizeof(GeometryCache::ShapeVertex); // position, normal, texcoords, tangent
 static const uint SHAPE_NORMALS_OFFSET = offsetof(GeometryCache::ShapeVertex, normal);
@@ -257,14 +252,6 @@ static const size_t ICOSAHEDRON_TO_SPHERE_TESSELATION_COUNT = 3;
 
 size_t GeometryCache::getShapeTriangleCount(Shape shape) {
     return _shapes[shape]._indicesView.getNumElements() / VERTICES_PER_TRIANGLE;
-}
-
-size_t GeometryCache::getSphereTriangleCount() {
-    return getShapeTriangleCount(Sphere);
-}
-
-size_t GeometryCache::getCubeTriangleCount() {
-    return getShapeTriangleCount(Cube);
 }
 
 using IndexPair = uint64_t;
@@ -647,35 +634,9 @@ gpu::Stream::FormatPointer& getSolidStreamFormat() {
         SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, NORMAL_ELEMENT);
         SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD0, gpu::Stream::TEXCOORD0, TEXCOORD0_ELEMENT);
         SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::TANGENT, gpu::Stream::TANGENT, TANGENT_ELEMENT);
+        SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, COLOR_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
     }
     return SOLID_STREAM_FORMAT;
-}
-
-gpu::Stream::FormatPointer& getInstancedSolidStreamFormat() {
-    if (!INSTANCED_SOLID_STREAM_FORMAT) {
-        INSTANCED_SOLID_STREAM_FORMAT = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
-        INSTANCED_SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, POSITION_ELEMENT);
-        INSTANCED_SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, NORMAL_ELEMENT);
-        INSTANCED_SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD0, gpu::Stream::TEXCOORD0, TEXCOORD0_ELEMENT);
-        INSTANCED_SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::TANGENT, gpu::Stream::TANGENT, TANGENT_ELEMENT);
-        INSTANCED_SOLID_STREAM_FORMAT->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, COLOR_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-    }
-    return INSTANCED_SOLID_STREAM_FORMAT;
-}
-
-gpu::Stream::FormatPointer& getInstancedSolidFadeStreamFormat() {
-    if (!INSTANCED_SOLID_FADE_STREAM_FORMAT) {
-        INSTANCED_SOLID_FADE_STREAM_FORMAT = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
-        INSTANCED_SOLID_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, POSITION_ELEMENT);
-        INSTANCED_SOLID_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, NORMAL_ELEMENT);
-        INSTANCED_SOLID_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD0, gpu::Stream::TEXCOORD0, TEXCOORD0_ELEMENT);
-        INSTANCED_SOLID_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::TANGENT, gpu::Stream::TANGENT, TANGENT_ELEMENT);
-        INSTANCED_SOLID_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, COLOR_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-        INSTANCED_SOLID_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD2, gpu::Stream::TEXCOORD2, TEXCOORD4_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-        INSTANCED_SOLID_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD3, gpu::Stream::TEXCOORD3, TEXCOORD4_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-        INSTANCED_SOLID_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD4, gpu::Stream::TEXCOORD4, TEXCOORD4_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-    }
-    return INSTANCED_SOLID_FADE_STREAM_FORMAT;
 }
 
 gpu::Stream::FormatPointer& getWireStreamFormat() {
@@ -683,47 +644,14 @@ gpu::Stream::FormatPointer& getWireStreamFormat() {
         WIRE_STREAM_FORMAT = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
         WIRE_STREAM_FORMAT->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, POSITION_ELEMENT);
         WIRE_STREAM_FORMAT->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, NORMAL_ELEMENT);
+        WIRE_STREAM_FORMAT->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, COLOR_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
     }
     return WIRE_STREAM_FORMAT;
 }
 
-gpu::Stream::FormatPointer& getInstancedWireStreamFormat() {
-    if (!INSTANCED_WIRE_STREAM_FORMAT) {
-        INSTANCED_WIRE_STREAM_FORMAT = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
-        INSTANCED_WIRE_STREAM_FORMAT->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, POSITION_ELEMENT);
-        INSTANCED_WIRE_STREAM_FORMAT->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, NORMAL_ELEMENT);
-        INSTANCED_WIRE_STREAM_FORMAT->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, COLOR_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-    }
-    return INSTANCED_WIRE_STREAM_FORMAT;
-}
-
-gpu::Stream::FormatPointer& getInstancedWireFadeStreamFormat() {
-    if (!INSTANCED_WIRE_FADE_STREAM_FORMAT) {
-        INSTANCED_WIRE_FADE_STREAM_FORMAT = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
-        INSTANCED_WIRE_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, POSITION_ELEMENT);
-        INSTANCED_WIRE_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, NORMAL_ELEMENT);
-        INSTANCED_WIRE_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, COLOR_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-        INSTANCED_WIRE_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD2, gpu::Stream::TEXCOORD2, TEXCOORD4_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-        INSTANCED_WIRE_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD3, gpu::Stream::TEXCOORD3, TEXCOORD4_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-        INSTANCED_WIRE_FADE_STREAM_FORMAT->setAttribute(gpu::Stream::TEXCOORD4, gpu::Stream::TEXCOORD4, TEXCOORD4_ELEMENT, 0, gpu::Stream::PER_INSTANCE);
-    }
-    return INSTANCED_WIRE_FADE_STREAM_FORMAT;
-}
-
-QHash<SimpleProgramKey, gpu::PipelinePointer> GeometryCache::_simplePrograms;
-
-gpu::ShaderPointer GeometryCache::_simpleShader;
-gpu::ShaderPointer GeometryCache::_transparentShader;
-gpu::ShaderPointer GeometryCache::_unlitShader;
-gpu::ShaderPointer GeometryCache::_simpleFadeShader;
-gpu::ShaderPointer GeometryCache::_unlitFadeShader;
-gpu::ShaderPointer GeometryCache::_forwardSimpleShader;
-gpu::ShaderPointer GeometryCache::_forwardTransparentShader;
-gpu::ShaderPointer GeometryCache::_forwardUnlitShader;
-gpu::ShaderPointer GeometryCache::_forwardSimpleFadeShader;
-gpu::ShaderPointer GeometryCache::_forwardUnlitFadeShader;
-
+std::map<std::tuple<bool, bool, bool, bool>, gpu::ShaderPointer> GeometryCache::_shapeShaders;
 std::map<std::tuple<bool, bool, bool, graphics::MaterialKey::CullFaceMode>, render::ShapePipelinePointer> GeometryCache::_shapePipelines;
+QHash<SimpleProgramKey, gpu::PipelinePointer> GeometryCache::_simplePrograms;
 
 GeometryCache::GeometryCache() :
 _nextID(0) {
@@ -809,101 +737,33 @@ render::ShapePipelinePointer GeometryCache::getFadingShapePipeline(bool textured
     );
 }
 
-void GeometryCache::renderShape(gpu::Batch& batch, Shape shape) {
-    batch.setInputFormat(getSolidStreamFormat());
-    _shapes[shape].draw(batch);
-}
-
-void GeometryCache::renderWireShape(gpu::Batch& batch, Shape shape) {
-    batch.setInputFormat(getWireStreamFormat());
-    _shapes[shape].drawWire(batch);
-}
-
-void GeometryCache::renderShape(gpu::Batch& batch, Shape shape, const glm::vec4& color) {
-    batch.setInputFormat(getSolidStreamFormat());
-    batch._glColor4f(color.r, color.g, color.b, color.a);
-    _shapes[shape].draw(batch);
-}
-
-void GeometryCache::renderWireShape(gpu::Batch& batch, Shape shape, const glm::vec4& color) {
-    batch.setInputFormat(getWireStreamFormat());
-    batch._glColor4f(color.r, color.g, color.b, color.a);
-    _shapes[shape].drawWire(batch);
-}
-
-void setupBatchInstance(gpu::Batch& batch, gpu::BufferPointer colorBuffer) {
+void setupColorInputBuffer(gpu::Batch& batch, gpu::BufferPointer colorBuffer) {
     gpu::BufferView colorView(colorBuffer, COLOR_ELEMENT);
     batch.setInputBuffer(gpu::Stream::COLOR, colorView);
 }
 
+void GeometryCache::renderShape(gpu::Batch& batch, Shape shape, gpu::BufferPointer& colorBuffer) {
+    batch.setInputFormat(getSolidStreamFormat());
+    setupColorInputBuffer(batch, colorBuffer);
+    _shapes[shape].draw(batch);
+}
+
+void GeometryCache::renderWireShape(gpu::Batch& batch, Shape shape, gpu::BufferPointer& colorBuffer) {
+    batch.setInputFormat(getWireStreamFormat());
+    setupColorInputBuffer(batch, colorBuffer);
+    _shapes[shape].drawWire(batch);
+}
+
 void GeometryCache::renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer) {
-    batch.setInputFormat(getInstancedSolidStreamFormat());
-    setupBatchInstance(batch, colorBuffer);
+    batch.setInputFormat(getSolidStreamFormat());
+    setupColorInputBuffer(batch, colorBuffer);
     _shapes[shape].drawInstances(batch, count);
 }
 
 void GeometryCache::renderWireShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer) {
-    batch.setInputFormat(getInstancedWireStreamFormat());
-    setupBatchInstance(batch, colorBuffer);
+    batch.setInputFormat(getWireStreamFormat());
+    setupColorInputBuffer(batch, colorBuffer);
     _shapes[shape].drawWireInstances(batch, count);
-}
-
-void setupBatchFadeInstance(gpu::Batch& batch, gpu::BufferPointer colorBuffer,
-    gpu::BufferPointer fadeBuffer1, gpu::BufferPointer fadeBuffer2, gpu::BufferPointer fadeBuffer3) {
-    gpu::BufferView colorView(colorBuffer, COLOR_ELEMENT);
-    gpu::BufferView texCoord2View(fadeBuffer1, TEXCOORD4_ELEMENT);
-    gpu::BufferView texCoord3View(fadeBuffer2, TEXCOORD4_ELEMENT);
-    gpu::BufferView texCoord4View(fadeBuffer3, TEXCOORD4_ELEMENT);
-    batch.setInputBuffer(gpu::Stream::COLOR, colorView);
-    batch.setInputBuffer(gpu::Stream::TEXCOORD2, texCoord2View);
-    batch.setInputBuffer(gpu::Stream::TEXCOORD3, texCoord3View);
-    batch.setInputBuffer(gpu::Stream::TEXCOORD4, texCoord4View);
-}
-
-void GeometryCache::renderFadeShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer,
-    gpu::BufferPointer& fadeBuffer1, gpu::BufferPointer& fadeBuffer2, gpu::BufferPointer& fadeBuffer3) {
-    batch.setInputFormat(getInstancedSolidFadeStreamFormat());
-    setupBatchFadeInstance(batch, colorBuffer, fadeBuffer1, fadeBuffer2, fadeBuffer3);
-    _shapes[shape].drawInstances(batch, count);
-}
-
-void GeometryCache::renderWireFadeShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer,
-    gpu::BufferPointer& fadeBuffer1, gpu::BufferPointer& fadeBuffer2, gpu::BufferPointer& fadeBuffer3) {
-    batch.setInputFormat(getInstancedWireFadeStreamFormat());
-    setupBatchFadeInstance(batch, colorBuffer, fadeBuffer1, fadeBuffer2, fadeBuffer3);
-    _shapes[shape].drawWireInstances(batch, count);
-}
-
-void GeometryCache::renderCube(gpu::Batch& batch) {
-    renderShape(batch, Cube);
-}
-
-void GeometryCache::renderWireCube(gpu::Batch& batch) {
-    renderWireShape(batch, Cube);
-}
-
-void GeometryCache::renderCube(gpu::Batch& batch, const glm::vec4& color) {
-    renderShape(batch, Cube, color);
-}
-
-void GeometryCache::renderWireCube(gpu::Batch& batch, const glm::vec4& color) {
-    renderWireShape(batch, Cube, color);
-}
-
-void GeometryCache::renderSphere(gpu::Batch& batch) {
-    renderShape(batch, Sphere);
-}
-
-void GeometryCache::renderWireSphere(gpu::Batch& batch) {
-    renderWireShape(batch, Sphere);
-}
-
-void GeometryCache::renderSphere(gpu::Batch& batch, const glm::vec4& color) {
-    renderShape(batch, Sphere, color);
-}
-
-void GeometryCache::renderWireSphere(gpu::Batch& batch, const glm::vec4& color) {
-    renderWireShape(batch, Sphere, color);
 }
 
 void GeometryCache::renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
@@ -963,33 +823,30 @@ void GeometryCache::updateVertices(int id, const QVector<glm::vec2>& points, con
 #endif // def WANT_DEBUG
     }
 
-    const int FLOATS_PER_VERTEX = 2 + 3; // vertices + normals
-    const int NUM_POS_COORDS = 2;
-    const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
+    const int FLOATS_PER_VERTEX = 2; // vertices
     details.isCreated = true;
     details.vertices = points.size();
     details.vertexSize = FLOATS_PER_VERTEX;
 
     auto verticesBuffer = std::make_shared<gpu::Buffer>();
+    auto normalBuffer = std::make_shared<gpu::Buffer>();
     auto colorBuffer = std::make_shared<gpu::Buffer>();
     auto streamFormat = std::make_shared<gpu::Stream::Format>();
     auto stream = std::make_shared<gpu::BufferStream>();
 
     details.verticesBuffer = verticesBuffer;
+    details.normalBuffer = normalBuffer;
     details.colorBuffer = colorBuffer;
     details.streamFormat = streamFormat;
     details.stream = stream;
 
-    details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ), 0);
-    details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
-    // TODO: circle3D overlays use this to define their vertices, so they need tex coords
-    details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+    details.streamFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ));
+    details.streamFormat->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+    details.streamFormat->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
 
-    details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-    details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
-
-    details.vertices = points.size();
-    details.vertexSize = FLOATS_PER_VERTEX;
+    details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::POSITION)._stride);
+    details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::NORMAL)._stride);
+    details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::COLOR)._stride);
 
     float* vertexData = new float[details.vertices * FLOATS_PER_VERTEX];
     float* vertex = vertexData;
@@ -997,7 +854,6 @@ void GeometryCache::updateVertices(int id, const QVector<glm::vec2>& points, con
     int* colorData = new int[details.vertices];
     int* colorDataAt = colorData;
 
-    const glm::vec3 NORMAL(0.0f, -1.0f, 0.0f);
     auto pointCount = points.size();
     auto colorCount = colors.size();
     int compactColor = 0;
@@ -1005,19 +861,16 @@ void GeometryCache::updateVertices(int id, const QVector<glm::vec2>& points, con
         const auto& point = points[i];
         *(vertex++) = point.x;
         *(vertex++) = point.y;
-        *(vertex++) = NORMAL.x;
-        *(vertex++) = NORMAL.y;
-        *(vertex++) = NORMAL.z;
         if (i < colorCount) {
             const auto& color = colors[i];
-            compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-                ((int(color.y * 255.0f) & 0xFF) << 8) |
-                ((int(color.z * 255.0f) & 0xFF) << 16) |
-                ((int(color.w * 255.0f) & 0xFF) << 24);
+            compactColor = GeometryCache::toCompactColor(color);
         }
         *(colorDataAt++) = compactColor;
     }
+
     details.verticesBuffer->append(sizeof(float) * FLOATS_PER_VERTEX * details.vertices, (gpu::Byte*) vertexData);
+    const glm::vec3 NORMAL(0.0f, -1.0f, 0.0f);
+    details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
     details.colorBuffer->append(sizeof(int) * details.vertices, (gpu::Byte*) colorData);
     delete[] vertexData;
     delete[] colorData;
@@ -1040,32 +893,30 @@ void GeometryCache::updateVertices(int id, const QVector<glm::vec3>& points, con
 #endif // def WANT_DEBUG
     }
 
-    const int FLOATS_PER_VERTEX = 3 + 3; // vertices + normals
-    const int NUM_POS_COORDS = 3;
-    const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
+    const int FLOATS_PER_VERTEX = 3; // vertices
     details.isCreated = true;
     details.vertices = points.size();
     details.vertexSize = FLOATS_PER_VERTEX;
 
     auto verticesBuffer = std::make_shared<gpu::Buffer>();
+    auto normalBuffer = std::make_shared<gpu::Buffer>();
     auto colorBuffer = std::make_shared<gpu::Buffer>();
     auto streamFormat = std::make_shared<gpu::Stream::Format>();
     auto stream = std::make_shared<gpu::BufferStream>();
 
     details.verticesBuffer = verticesBuffer;
+    details.normalBuffer = normalBuffer;
     details.colorBuffer = colorBuffer;
     details.streamFormat = streamFormat;
     details.stream = stream;
 
-    details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-    details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
-    details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+    details.streamFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ));
+    details.streamFormat->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+    details.streamFormat->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
 
-    details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-    details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
-
-    details.vertices = points.size();
-    details.vertexSize = FLOATS_PER_VERTEX;
+    details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::POSITION)._stride);
+    details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::NORMAL)._stride);
+    details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::COLOR)._stride);
 
     // Default to white
     int compactColor = 0xFFFFFFFF;
@@ -1075,28 +926,23 @@ void GeometryCache::updateVertices(int id, const QVector<glm::vec3>& points, con
     int* colorData = new int[details.vertices];
     int* colorDataAt = colorData;
 
-    const glm::vec3 NORMAL(0.0f, -1.0f, 0.0f);
     auto pointCount = points.size();
     auto colorCount = colors.size();
     for (auto i = 0; i < pointCount; i++) {
         const glm::vec3& point = points[i];
-        if (i < colorCount) {
-            const glm::vec4& color = colors[i];
-            compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-                ((int(color.y * 255.0f) & 0xFF) << 8) |
-                ((int(color.z * 255.0f) & 0xFF) << 16) |
-                ((int(color.w * 255.0f) & 0xFF) << 24);
-        }
         *(vertex++) = point.x;
         *(vertex++) = point.y;
         *(vertex++) = point.z;
-        *(vertex++) = NORMAL.x;
-        *(vertex++) = NORMAL.y;
-        *(vertex++) = NORMAL.z;
+        if (i < colorCount) {
+            const glm::vec4& color = colors[i];
+            compactColor = GeometryCache::toCompactColor(color);
+        }
         *(colorDataAt++) = compactColor;
     }
 
     details.verticesBuffer->append(sizeof(float) * FLOATS_PER_VERTEX * details.vertices, (gpu::Byte*) vertexData);
+    const glm::vec3 NORMAL(0.0f, -1.0f, 0.0f);
+    details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
     details.colorBuffer->append(sizeof(int) * details.vertices, (gpu::Byte*) colorData);
     delete[] vertexData;
     delete[] colorData;
@@ -1120,69 +966,55 @@ void GeometryCache::updateVertices(int id, const QVector<glm::vec3>& points, con
 #endif // def WANT_DEBUG
     }
 
-    const int FLOATS_PER_VERTEX = 3 + 3 + 2; // vertices + normals + tex coords
+    const int FLOATS_PER_VERTEX = 3 + 2; // vertices + tex coords
     const int NUM_POS_COORDS = 3;
-    const int NUM_NORMAL_COORDS = 3;
-    const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
-    const int VERTEX_TEX_OFFSET = VERTEX_NORMAL_OFFSET + NUM_NORMAL_COORDS * sizeof(float);
+    const int VERTEX_TEX_OFFSET = NUM_POS_COORDS * sizeof(float);
     details.isCreated = true;
     details.vertices = points.size();
     details.vertexSize = FLOATS_PER_VERTEX;
 
     auto verticesBuffer = std::make_shared<gpu::Buffer>();
+    auto normalBuffer = std::make_shared<gpu::Buffer>();
     auto colorBuffer = std::make_shared<gpu::Buffer>();
     auto streamFormat = std::make_shared<gpu::Stream::Format>();
     auto stream = std::make_shared<gpu::BufferStream>();
 
     details.verticesBuffer = verticesBuffer;
+    details.normalBuffer = normalBuffer;
     details.colorBuffer = colorBuffer;
     details.streamFormat = streamFormat;
     details.stream = stream;
 
-    details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-    details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
+    details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ));
     details.streamFormat->setAttribute(gpu::Stream::TEXCOORD, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::UV), VERTEX_TEX_OFFSET);
-    details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+    details.streamFormat->setAttribute(gpu::Stream::NORMAL, 1, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+    details.streamFormat->setAttribute(gpu::Stream::COLOR, 2, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
 
     details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-    details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
+    details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
+    details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(2)._stride);
 
     assert(points.size() == texCoords.size());
-
-    details.vertices = points.size();
-    details.vertexSize = FLOATS_PER_VERTEX;
-
-    int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-        ((int(color.y * 255.0f) & 0xFF) << 8) |
-        ((int(color.z * 255.0f) & 0xFF) << 16) |
-        ((int(color.w * 255.0f) & 0xFF) << 24);
 
     float* vertexData = new float[details.vertices * FLOATS_PER_VERTEX];
     float* vertex = vertexData;
 
-    int* colorData = new int[details.vertices];
-    int* colorDataAt = colorData;
-
-    const glm::vec3 NORMAL(0.0f, -1.0f, 0.0f);
     for (int i = 0; i < points.size(); i++) {
         glm::vec3 point = points[i];
         glm::vec2 texCoord = texCoords[i];
         *(vertex++) = point.x;
         *(vertex++) = point.y;
         *(vertex++) = point.z;
-        *(vertex++) = NORMAL.x;
-        *(vertex++) = NORMAL.y;
-        *(vertex++) = NORMAL.z;
         *(vertex++) = texCoord.x;
         *(vertex++) = texCoord.y;
-
-        *(colorDataAt++) = compactColor;
     }
 
-    details.verticesBuffer->append(sizeof(float) * FLOATS_PER_VERTEX * details.vertices, (gpu::Byte*) vertexData);
-    details.colorBuffer->append(sizeof(int) * details.vertices, (gpu::Byte*) colorData);
+    details.verticesBuffer->append(sizeof(float) * FLOATS_PER_VERTEX * details.vertices, (gpu::Byte*)vertexData);
+    const glm::vec3 NORMAL(0.0f, -1.0f, 0.0f);
+    details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
+    int compactColor = GeometryCache::toCompactColor(color);
+    details.colorBuffer->append(sizeof(compactColor), (gpu::Byte*) &compactColor);
     delete[] vertexData;
-    delete[] colorData;
 
 #ifdef WANT_DEBUG
     qCDebug(renderutils) << "new registered linestrip buffer made -- _registeredVertices.size():" << _registeredVertices.size();
@@ -1239,12 +1071,11 @@ void GeometryCache::renderBevelCornersRect(gpu::Batch& batch, int x, int y, int 
         details.streamFormat = streamFormat;
         details.stream = stream;
 
-        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ));
-        details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+        details.streamFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ));
+        details.streamFormat->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
 
-        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
-
+        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::POSITION)._stride);
+        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::COLOR)._stride);
 
         float vertexBuffer[NUM_FLOATS]; // only vertices, no normals because we're a 2D quad
         int vertexPoint = 0;
@@ -1283,16 +1114,9 @@ void GeometryCache::renderBevelCornersRect(gpu::Batch& batch, int x, int y, int 
         vertexBuffer[vertexPoint++] = x + width;
         vertexBuffer[vertexPoint++] = y + bevelDistance;
 
-        int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-            ((int(color.y * 255.0f) & 0xFF) << 8) |
-            ((int(color.z * 255.0f) & 0xFF) << 16) |
-            ((int(color.w * 255.0f) & 0xFF) << 24);
-        int colors[NUM_VERTICES] = { compactColor, compactColor, compactColor, compactColor,
-            compactColor, compactColor, compactColor, compactColor };
-
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
-        details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        int compactColor = GeometryCache::toCompactColor(color);
+        details.colorBuffer->append(sizeof(compactColor), (gpu::Byte*) &compactColor);
     }
 
     batch.setInputFormat(details.streamFormat);
@@ -1322,52 +1146,46 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
 #endif // def WANT_DEBUG
     }
 
-    const int FLOATS_PER_VERTEX = 2 + 3; // vertices + normals
-    const int VERTICES = 4; // 1 quad = 4 vertices
-    const int NUM_POS_COORDS = 2;
-    const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
-
     if (!details.isCreated) {
+        static const int FLOATS_PER_VERTEX = 2; // vertices
+        static const int VERTICES = 4; // 1 quad = 4 vertices
 
         details.isCreated = true;
         details.vertices = VERTICES;
         details.vertexSize = FLOATS_PER_VERTEX;
 
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
+        auto normalBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
+        details.normalBuffer = normalBuffer;
         details.colorBuffer = colorBuffer;
         details.streamFormat = streamFormat;
         details.stream = stream;
 
-        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ), 0);
-        details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
-        details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+        details.streamFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ));
+        details.streamFormat->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+        details.streamFormat->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
 
-        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
+        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::POSITION)._stride);
+        details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::NORMAL)._stride);
+        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::COLOR)._stride);
 
-
-        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
         float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {
-            minCorner.x, minCorner.y, NORMAL.x, NORMAL.y, NORMAL.z,
-            maxCorner.x, minCorner.y, NORMAL.x, NORMAL.y, NORMAL.z,
-            minCorner.x, maxCorner.y, NORMAL.x, NORMAL.y, NORMAL.z,
-            maxCorner.x, maxCorner.y, NORMAL.x, NORMAL.y, NORMAL.z,
+            minCorner.x, minCorner.y,
+            maxCorner.x, minCorner.y,
+            minCorner.x, maxCorner.y,
+            maxCorner.x, maxCorner.y,
         };
 
-        const int NUM_COLOR_SCALARS_PER_QUAD = 4;
-        int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-            ((int(color.y * 255.0f) & 0xFF) << 8) |
-            ((int(color.z * 255.0f) & 0xFF) << 16) |
-            ((int(color.w * 255.0f) & 0xFF) << 24);
-        int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
-        details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
+        details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
+        int compactColor = GeometryCache::toCompactColor(color);
+        details.colorBuffer->append(sizeof(compactColor), (gpu::Byte*) &compactColor);
     }
 
     batch.setInputFormat(details.streamFormat);
@@ -1409,59 +1227,49 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec2& minCorner, co
 #endif // def WANT_DEBUG
     }
 
-    const int FLOATS_PER_VERTEX = 2 + 3 + 2; // vertices + normals + tex coords
-    const int VERTICES = 4; // 1 quad = 4 vertices
-    const int NUM_POS_COORDS = 2;
-    const int NUM_NORMAL_COORDS = 3;
-    const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
-    const int VERTEX_TEXCOORD_OFFSET = VERTEX_NORMAL_OFFSET + NUM_NORMAL_COORDS * sizeof(float);
-
     if (!details.isCreated) {
+        static const int FLOATS_PER_VERTEX = 2 + 2; // vertices + tex coords
+        static const int VERTICES = 4; // 1 quad = 4 vertices
+        static const int NUM_POS_COORDS = 2;
+        static const int VERTEX_TEXCOORD_OFFSET = NUM_POS_COORDS * sizeof(float);
 
         details.isCreated = true;
         details.vertices = VERTICES;
         details.vertexSize = FLOATS_PER_VERTEX;
 
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
+        auto normalBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
-
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
+        details.normalBuffer = normalBuffer;
         details.colorBuffer = colorBuffer;
-
         details.streamFormat = streamFormat;
         details.stream = stream;
 
-        // zzmp: fix the normal across all renderQuad
-        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ), 0);
-        details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
+        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::XYZ));
         details.streamFormat->setAttribute(gpu::Stream::TEXCOORD, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::UV), VERTEX_TEXCOORD_OFFSET);
-        details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+        details.streamFormat->setAttribute(gpu::Stream::NORMAL, 1, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+        details.streamFormat->setAttribute(gpu::Stream::COLOR, 2, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
 
         details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
+        details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
+        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(2)._stride);
 
-
-        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
         float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {
-            minCorner.x, minCorner.y, NORMAL.x, NORMAL.y, NORMAL.z, texCoordMinCorner.x, texCoordMinCorner.y,
-            maxCorner.x, minCorner.y, NORMAL.x, NORMAL.y, NORMAL.z, texCoordMaxCorner.x, texCoordMinCorner.y,
-            minCorner.x, maxCorner.y, NORMAL.x, NORMAL.y, NORMAL.z, texCoordMinCorner.x, texCoordMaxCorner.y,
-            maxCorner.x, maxCorner.y, NORMAL.x, NORMAL.y, NORMAL.z, texCoordMaxCorner.x, texCoordMaxCorner.y,
+            minCorner.x, minCorner.y, texCoordMinCorner.x, texCoordMinCorner.y,
+            maxCorner.x, minCorner.y, texCoordMaxCorner.x, texCoordMinCorner.y,
+            minCorner.x, maxCorner.y, texCoordMinCorner.x, texCoordMaxCorner.y,
+            maxCorner.x, maxCorner.y, texCoordMaxCorner.x, texCoordMaxCorner.y,
         };
 
-
-        const int NUM_COLOR_SCALARS_PER_QUAD = 4;
-        int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-            ((int(color.y * 255.0f) & 0xFF) << 8) |
-            ((int(color.z * 255.0f) & 0xFF) << 16) |
-            ((int(color.w * 255.0f) & 0xFF) << 24);
-        int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
-        details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
+        details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
+        int compactColor = GeometryCache::toCompactColor(color);
+        details.colorBuffer->append(sizeof(compactColor), (gpu::Byte*) &compactColor);
     }
 
     batch.setInputFormat(details.streamFormat);
@@ -1491,54 +1299,46 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& minCorner, co
 #endif // def WANT_DEBUG
     }
 
-    const int FLOATS_PER_VERTEX = 3 + 3; // vertices + normals
-    const int VERTICES = 4; // 1 quad = 4 vertices
-    const int NUM_POS_COORDS = 3;
-    const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
-
     if (!details.isCreated) {
+        static const int FLOATS_PER_VERTEX = 3; // vertices
+        static const int VERTICES = 4; // 1 quad = 4 vertices
 
         details.isCreated = true;
         details.vertices = VERTICES;
         details.vertexSize = FLOATS_PER_VERTEX;
 
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
+        auto normalBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
-
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
+        details.normalBuffer = normalBuffer;
         details.colorBuffer = colorBuffer;
-
         details.streamFormat = streamFormat;
         details.stream = stream;
 
-        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-        details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
-        details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+        details.streamFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ));
+        details.streamFormat->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+        details.streamFormat->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
 
-        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
+        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::POSITION)._stride);
+        details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::NORMAL)._stride);
+        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::COLOR)._stride);
 
-
-        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
         float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {
-            minCorner.x, minCorner.y, minCorner.z, NORMAL.x, NORMAL.y, NORMAL.z,
-            maxCorner.x, minCorner.y, minCorner.z, NORMAL.x, NORMAL.y, NORMAL.z,
-            minCorner.x, maxCorner.y, maxCorner.z, NORMAL.x, NORMAL.y, NORMAL.z,
-            maxCorner.x, maxCorner.y, maxCorner.z, NORMAL.x, NORMAL.y, NORMAL.z,
+            minCorner.x, minCorner.y, minCorner.z,
+            maxCorner.x, minCorner.y, minCorner.z,
+            minCorner.x, maxCorner.y, maxCorner.z,
+            maxCorner.x, maxCorner.y, maxCorner.z,
         };
 
-        const int NUM_COLOR_SCALARS_PER_QUAD = 4;
-        int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-            ((int(color.y * 255.0f) & 0xFF) << 8) |
-            ((int(color.z * 255.0f) & 0xFF) << 16) |
-            ((int(color.w * 255.0f) & 0xFF) << 24);
-        int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
-        details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
+        details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
+        int compactColor = GeometryCache::toCompactColor(color);
+        details.colorBuffer->append(sizeof(compactColor), (gpu::Byte*) &compactColor);
     }
 
     batch.setInputFormat(details.streamFormat);
@@ -1587,61 +1387,136 @@ void GeometryCache::renderQuad(gpu::Batch& batch, const glm::vec3& topLeft, cons
 #endif // def WANT_DEBUG
     }
 
-    const int FLOATS_PER_VERTEX = 3 + 3 + 2; // vertices + normals + tex coords
-    const int VERTICES = 4; // 1 quad = 4 vertices
-    const int NUM_POS_COORDS = 3;
-    const int NUM_NORMAL_COORDS = 3;
-    const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
-    const int VERTEX_TEXCOORD_OFFSET = VERTEX_NORMAL_OFFSET + NUM_NORMAL_COORDS * sizeof(float);
-
-
     if (!details.isCreated) {
+        static const int FLOATS_PER_VERTEX = 3 + 2; // vertices + tex coords
+        static const int VERTICES = 4; // 1 quad = 4 vertices
+        static const int NUM_POS_COORDS = 3;
+        static const int VERTEX_TEXCOORD_OFFSET = NUM_POS_COORDS * sizeof(float);
 
         details.isCreated = true;
         details.vertices = VERTICES;
         details.vertexSize = FLOATS_PER_VERTEX; // NOTE: this isn't used for BatchItemDetails maybe we can get rid of it
 
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
+        auto normalBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
-        details.verticesBuffer = verticesBuffer;
+        details.normalBuffer = normalBuffer;
+        details.colorBuffer = colorBuffer;
         details.colorBuffer = colorBuffer;
         details.streamFormat = streamFormat;
         details.stream = stream;
 
-        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-        details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
+        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ));
         details.streamFormat->setAttribute(gpu::Stream::TEXCOORD, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::UV), VERTEX_TEXCOORD_OFFSET);
-        details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+        details.streamFormat->setAttribute(gpu::Stream::NORMAL, 1, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+        details.streamFormat->setAttribute(gpu::Stream::COLOR, 2, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
 
         details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
+        details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
+        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(2)._stride);
 
-
-        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
         float vertexBuffer[VERTICES * FLOATS_PER_VERTEX] = {
-            bottomLeft.x, bottomLeft.y, bottomLeft.z, NORMAL.x, NORMAL.y, NORMAL.z, texCoordBottomLeft.x, texCoordBottomLeft.y,
-            bottomRight.x, bottomRight.y, bottomRight.z, NORMAL.x, NORMAL.y, NORMAL.z, texCoordBottomRight.x, texCoordBottomRight.y,
-            topLeft.x, topLeft.y, topLeft.z, NORMAL.x, NORMAL.y, NORMAL.z, texCoordTopLeft.x, texCoordTopLeft.y,
-            topRight.x, topRight.y, topRight.z, NORMAL.x, NORMAL.y, NORMAL.z, texCoordTopRight.x, texCoordTopRight.y,
+            bottomLeft.x, bottomLeft.y, bottomLeft.z, texCoordBottomLeft.x, texCoordBottomLeft.y,
+            bottomRight.x, bottomRight.y, bottomRight.z, texCoordBottomRight.x, texCoordBottomRight.y,
+            topLeft.x, topLeft.y, topLeft.z, texCoordTopLeft.x, texCoordTopLeft.y,
+            topRight.x, topRight.y, topRight.z, texCoordTopRight.x, texCoordTopRight.y,
         };
 
-        const int NUM_COLOR_SCALARS_PER_QUAD = 4;
-        int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-            ((int(color.y * 255.0f) & 0xFF) << 8) |
-            ((int(color.z * 255.0f) & 0xFF) << 16) |
-            ((int(color.w * 255.0f) & 0xFF) << 24);
-        int colors[NUM_COLOR_SCALARS_PER_QUAD] = { compactColor, compactColor, compactColor, compactColor };
-
         details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
-        details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
+        details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
+        int compactColor = GeometryCache::toCompactColor(color);
+        details.colorBuffer->append(sizeof(compactColor), (gpu::Byte*) &compactColor);
     }
 
     batch.setInputFormat(details.streamFormat);
     batch.setInputStream(0, *details.stream);
     batch.draw(gpu::TRIANGLE_STRIP, 4, 0);
+}
+
+void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
+    const glm::vec4& color1, const glm::vec4& color2, int id) {
+
+    bool registered = (id != UNKNOWN_ID);
+    Vec3Pair key(p1, p2);
+
+    BatchItemDetails& details = _registeredLine3DVBOs[id];
+
+    // if this is a registered quad, and we have buffers, then check to see if the geometry changed and rebuild if needed
+    if (registered && details.isCreated) {
+        Vec3Pair& lastKey = _lastRegisteredLine3D[id];
+        if (lastKey != key) {
+            details.clear();
+            _lastRegisteredLine3D[id] = key;
+#ifdef WANT_DEBUG
+            qCDebug(renderutils) << "renderLine() 3D ... RELEASING REGISTERED line";
+#endif // def WANT_DEBUG
+        }
+#ifdef WANT_DEBUG
+        else {
+            qCDebug(renderutils) << "renderLine() 3D ... REUSING PREVIOUSLY REGISTERED line";
+        }
+#endif // def WANT_DEBUG
+    }
+
+    if (!details.isCreated) {
+        static const int FLOATS_PER_VERTEX = 3;  // vertices
+        static const int vertices = 2;
+
+        details.isCreated = true;
+        details.vertices = vertices;
+        details.vertexSize = FLOATS_PER_VERTEX;
+
+        auto verticesBuffer = std::make_shared<gpu::Buffer>();
+        auto normalBuffer = std::make_shared<gpu::Buffer>();
+        auto colorBuffer = std::make_shared<gpu::Buffer>();
+        auto streamFormat = std::make_shared<gpu::Stream::Format>();
+        auto stream = std::make_shared<gpu::BufferStream>();
+
+        details.verticesBuffer = verticesBuffer;
+        details.normalBuffer = normalBuffer;
+        details.colorBuffer = colorBuffer;
+        details.streamFormat = streamFormat;
+        details.stream = stream;
+
+        details.streamFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ));
+        details.streamFormat->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+        details.streamFormat->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+
+        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::POSITION)._stride);
+        details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::NORMAL)._stride);
+        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::COLOR)._stride);
+
+        float vertexBuffer[vertices * FLOATS_PER_VERTEX] = {
+            p1.x, p1.y, p1.z,
+            p2.x, p2.y, p2.z
+        };
+
+        const int NUM_COLOR_SCALARS = 2;
+        int compactColor1 = GeometryCache::toCompactColor(color1);
+        int compactColor2 = GeometryCache::toCompactColor(color2);
+        int colors[NUM_COLOR_SCALARS] = { compactColor1, compactColor2 };
+
+        details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
+        const glm::vec3 NORMAL(0.0f, 0.0f, 1.0f);
+        details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
+        details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
+
+#ifdef WANT_DEBUG
+        if (id == UNKNOWN_ID) {
+            qCDebug(renderutils) << "new renderLine() 3D VBO made -- _line3DVBOs.size():" << _line3DVBOs.size();
+        } else {
+            qCDebug(renderutils) << "new registered renderLine() 3D VBO made -- _registeredLine3DVBOs.size():" << _registeredLine3DVBOs.size();
+        }
+#endif
+    }
+
+    batch.setInputFormat(details.streamFormat);
+    batch.setInputStream(0, *details.stream);
+    batch.draw(gpu::LINES, 2, 0);
 }
 
 void GeometryCache::renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color,
@@ -1664,11 +1539,6 @@ void GeometryCache::renderDashedLine(gpu::Batch& batch, const glm::vec3& start, 
 
     if (!details.isCreated) {
 
-        int compactColor = ((int(color.x * 255.0f) & 0xFF)) |
-            ((int(color.y * 255.0f) & 0xFF) << 8) |
-            ((int(color.z * 255.0f) & 0xFF) << 16) |
-            ((int(color.w * 255.0f) & 0xFF) << 24);
-
         // draw each line segment with appropriate gaps
         const float SEGMENT_LENGTH = dash_length + gap_length;
         float length = glm::distance(start, end);
@@ -1679,77 +1549,60 @@ void GeometryCache::renderDashedLine(gpu::Batch& batch, const glm::vec3& start, 
         glm::vec3 dashVector = segmentVector / SEGMENT_LENGTH * dash_length;
         glm::vec3 gapVector = segmentVector / SEGMENT_LENGTH * gap_length;
 
-        const int FLOATS_PER_VERTEX = 3 + 3; // vertices + normals
-        const int NUM_POS_COORDS = 3;
-        const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
+        const int FLOATS_PER_VERTEX = 3; // vertices
+        details.isCreated = true;
         details.vertices = (segmentCountFloor + 1) * 2;
         details.vertexSize = FLOATS_PER_VERTEX;
-        details.isCreated = true;
 
         auto verticesBuffer = std::make_shared<gpu::Buffer>();
+        auto normalBuffer = std::make_shared<gpu::Buffer>();
         auto colorBuffer = std::make_shared<gpu::Buffer>();
         auto streamFormat = std::make_shared<gpu::Stream::Format>();
         auto stream = std::make_shared<gpu::BufferStream>();
 
         details.verticesBuffer = verticesBuffer;
+        details.normalBuffer = normalBuffer;
         details.colorBuffer = colorBuffer;
         details.streamFormat = streamFormat;
         details.stream = stream;
 
-        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-        details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
-        details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
+        details.streamFormat->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ));
+        details.streamFormat->setAttribute(gpu::Stream::NORMAL, gpu::Stream::NORMAL, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0, gpu::Stream::PER_INSTANCE);
+        details.streamFormat->setAttribute(gpu::Stream::COLOR, gpu::Stream::COLOR, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA), 0, gpu::Stream::PER_INSTANCE);
 
-        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
-
-        int* colorData = new int[details.vertices];
-        int* colorDataAt = colorData;
+        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::POSITION)._stride);
+        details.stream->addBuffer(details.normalBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::NORMAL)._stride);
+        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(gpu::Stream::COLOR)._stride);
 
         float* vertexData = new float[details.vertices * FLOATS_PER_VERTEX];
         float* vertex = vertexData;
 
-        const glm::vec3 NORMAL(1.0f, 0.0f, 0.0f);
         glm::vec3 point = start;
         *(vertex++) = point.x;
         *(vertex++) = point.y;
         *(vertex++) = point.z;
-        *(vertex++) = NORMAL.x;
-        *(vertex++) = NORMAL.y;
-        *(vertex++) = NORMAL.z;
-        *(colorDataAt++) = compactColor;
 
         for (int i = 0; i < segmentCountFloor; i++) {
             point += dashVector;
             *(vertex++) = point.x;
             *(vertex++) = point.y;
             *(vertex++) = point.z;
-            *(vertex++) = NORMAL.x;
-            *(vertex++) = NORMAL.y;
-            *(vertex++) = NORMAL.z;
-            *(colorDataAt++) = compactColor;
 
             point += gapVector;
             *(vertex++) = point.x;
             *(vertex++) = point.y;
             *(vertex++) = point.z;
-            *(vertex++) = NORMAL.x;
-            *(vertex++) = NORMAL.y;
-            *(vertex++) = NORMAL.z;
-            *(colorDataAt++) = compactColor;
         }
         *(vertex++) = end.x;
         *(vertex++) = end.y;
         *(vertex++) = end.z;
-        *(vertex++) = NORMAL.x;
-        *(vertex++) = NORMAL.y;
-        *(vertex++) = NORMAL.z;
-        *(colorDataAt++) = compactColor;
 
         details.verticesBuffer->append(sizeof(float) * FLOATS_PER_VERTEX * details.vertices, (gpu::Byte*) vertexData);
-        details.colorBuffer->append(sizeof(int) * details.vertices, (gpu::Byte*) colorData);
+        const glm::vec3 NORMAL(1.0f, 0.0f, 0.0f);
+        details.normalBuffer->append(3 * sizeof(float), (gpu::Byte*) glm::value_ptr(NORMAL));
+        int compactColor = GeometryCache::toCompactColor(color);
+        details.colorBuffer->append(sizeof(compactColor), (gpu::Byte*) &compactColor);
         delete[] vertexData;
-        delete[] colorData;
 
 #ifdef WANT_DEBUG
         if (registered) {
@@ -1770,6 +1623,7 @@ int GeometryCache::BatchItemDetails::population = 0;
 
 GeometryCache::BatchItemDetails::BatchItemDetails() :
 verticesBuffer(NULL),
+normalBuffer(NULL),
 colorBuffer(NULL),
 streamFormat(NULL),
 stream(NULL),
@@ -1784,6 +1638,7 @@ isCreated(false) {
 
 GeometryCache::BatchItemDetails::BatchItemDetails(const GeometryCache::BatchItemDetails& other) :
 verticesBuffer(other.verticesBuffer),
+normalBuffer(other.normalBuffer),
 colorBuffer(other.colorBuffer),
 streamFormat(other.streamFormat),
 stream(other.stream),
@@ -1808,182 +1663,10 @@ void GeometryCache::BatchItemDetails::clear() {
     isCreated = false;
     uniformBuffer.reset();
     verticesBuffer.reset();
+    normalBuffer.reset();
     colorBuffer.reset();
     streamFormat.reset();
     stream.reset();
-}
-
-void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec3& p1, const glm::vec3& p2,
-    const glm::vec4& color1, const glm::vec4& color2, int id) {
-
-    bool registered = (id != UNKNOWN_ID);
-    Vec3Pair key(p1, p2);
-
-    BatchItemDetails& details = _registeredLine3DVBOs[id];
-
-    int compactColor1 = ((int(color1.x * 255.0f) & 0xFF)) |
-        ((int(color1.y * 255.0f) & 0xFF) << 8) |
-        ((int(color1.z * 255.0f) & 0xFF) << 16) |
-        ((int(color1.w * 255.0f) & 0xFF) << 24);
-
-    int compactColor2 = ((int(color2.x * 255.0f) & 0xFF)) |
-        ((int(color2.y * 255.0f) & 0xFF) << 8) |
-        ((int(color2.z * 255.0f) & 0xFF) << 16) |
-        ((int(color2.w * 255.0f) & 0xFF) << 24);
-
-
-    // if this is a registered quad, and we have buffers, then check to see if the geometry changed and rebuild if needed
-    if (registered && details.isCreated) {
-        Vec3Pair& lastKey = _lastRegisteredLine3D[id];
-        if (lastKey != key) {
-            details.clear();
-            _lastRegisteredLine3D[id] = key;
-#ifdef WANT_DEBUG
-            qCDebug(renderutils) << "renderLine() 3D ... RELEASING REGISTERED line";
-#endif // def WANT_DEBUG
-        }
-#ifdef WANT_DEBUG
-        else {
-            qCDebug(renderutils) << "renderLine() 3D ... REUSING PREVIOUSLY REGISTERED line";
-        }
-#endif // def WANT_DEBUG
-    }
-
-    const int FLOATS_PER_VERTEX = 3 + 3; // vertices + normals
-    const int NUM_POS_COORDS = 3;
-    const int VERTEX_NORMAL_OFFSET = NUM_POS_COORDS * sizeof(float);
-    const int vertices = 2;
-    if (!details.isCreated) {
-
-        details.isCreated = true;
-        details.vertices = vertices;
-        details.vertexSize = FLOATS_PER_VERTEX;
-
-        auto verticesBuffer = std::make_shared<gpu::Buffer>();
-        auto colorBuffer = std::make_shared<gpu::Buffer>();
-        auto streamFormat = std::make_shared<gpu::Stream::Format>();
-        auto stream = std::make_shared<gpu::BufferStream>();
-
-        details.verticesBuffer = verticesBuffer;
-        details.colorBuffer = colorBuffer;
-        details.streamFormat = streamFormat;
-        details.stream = stream;
-
-        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-        details.streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_NORMAL_OFFSET);
-        details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
-
-        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
-
-        const glm::vec3 NORMAL(1.0f, 0.0f, 0.0f);
-        float vertexBuffer[vertices * FLOATS_PER_VERTEX] = {
-            p1.x, p1.y, p1.z, NORMAL.x, NORMAL.y, NORMAL.z,
-            p2.x, p2.y, p2.z, NORMAL.x, NORMAL.y, NORMAL.z };
-
-        const int NUM_COLOR_SCALARS = 2;
-        int colors[NUM_COLOR_SCALARS] = { compactColor1, compactColor2 };
-
-        details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
-        details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
-
-#ifdef WANT_DEBUG
-        if (id == UNKNOWN_ID) {
-            qCDebug(renderutils) << "new renderLine() 3D VBO made -- _line3DVBOs.size():" << _line3DVBOs.size();
-        } else {
-            qCDebug(renderutils) << "new registered renderLine() 3D VBO made -- _registeredLine3DVBOs.size():" << _registeredLine3DVBOs.size();
-        }
-#endif
-    }
-
-    // this is what it takes to render a quad
-    batch.setInputFormat(details.streamFormat);
-    batch.setInputStream(0, *details.stream);
-    batch.draw(gpu::LINES, 2, 0);
-}
-
-void GeometryCache::renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,
-    const glm::vec4& color1, const glm::vec4& color2, int id) {
-
-    bool registered = (id != UNKNOWN_ID);
-    Vec2Pair key(p1, p2);
-
-    BatchItemDetails& details = _registeredLine2DVBOs[id];
-
-    int compactColor1 = ((int(color1.x * 255.0f) & 0xFF)) |
-        ((int(color1.y * 255.0f) & 0xFF) << 8) |
-        ((int(color1.z * 255.0f) & 0xFF) << 16) |
-        ((int(color1.w * 255.0f) & 0xFF) << 24);
-
-    int compactColor2 = ((int(color2.x * 255.0f) & 0xFF)) |
-        ((int(color2.y * 255.0f) & 0xFF) << 8) |
-        ((int(color2.z * 255.0f) & 0xFF) << 16) |
-        ((int(color2.w * 255.0f) & 0xFF) << 24);
-
-
-    // if this is a registered quad, and we have buffers, then check to see if the geometry changed and rebuild if needed
-    if (registered && details.isCreated) {
-        Vec2Pair& lastKey = _lastRegisteredLine2D[id];
-        if (lastKey != key) {
-            details.clear();
-            _lastRegisteredLine2D[id] = key;
-#ifdef WANT_DEBUG
-            qCDebug(renderutils) << "renderLine() 2D ... RELEASING REGISTERED line";
-#endif // def WANT_DEBUG
-        }
-#ifdef WANT_DEBUG
-        else {
-            qCDebug(renderutils) << "renderLine() 2D ... REUSING PREVIOUSLY REGISTERED line";
-        }
-#endif // def WANT_DEBUG
-    }
-
-    const int FLOATS_PER_VERTEX = 2;
-    const int vertices = 2;
-    if (!details.isCreated) {
-
-        details.isCreated = true;
-        details.vertices = vertices;
-        details.vertexSize = FLOATS_PER_VERTEX;
-
-        auto verticesBuffer = std::make_shared<gpu::Buffer>();
-        auto colorBuffer = std::make_shared<gpu::Buffer>();
-        auto streamFormat = std::make_shared<gpu::Stream::Format>();
-        auto stream = std::make_shared<gpu::BufferStream>();
-
-        details.verticesBuffer = verticesBuffer;
-        details.colorBuffer = colorBuffer;
-        details.streamFormat = streamFormat;
-        details.stream = stream;
-
-        details.streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-        details.streamFormat->setAttribute(gpu::Stream::COLOR, 1, gpu::Element(gpu::VEC4, gpu::NUINT8, gpu::RGBA));
-
-        details.stream->addBuffer(details.verticesBuffer, 0, details.streamFormat->getChannels().at(0)._stride);
-        details.stream->addBuffer(details.colorBuffer, 0, details.streamFormat->getChannels().at(1)._stride);
-
-
-        float vertexBuffer[vertices * FLOATS_PER_VERTEX] = { p1.x, p1.y, p2.x, p2.y };
-
-        const int NUM_COLOR_SCALARS = 2;
-        int colors[NUM_COLOR_SCALARS] = { compactColor1, compactColor2 };
-
-        details.verticesBuffer->append(sizeof(vertexBuffer), (gpu::Byte*) vertexBuffer);
-        details.colorBuffer->append(sizeof(colors), (gpu::Byte*) colors);
-
-#ifdef WANT_DEBUG
-        if (id == UNKNOWN_ID) {
-            qCDebug(renderutils) << "new renderLine() 2D VBO made -- _line3DVBOs.size():" << _line2DVBOs.size();
-        } else {
-            qCDebug(renderutils) << "new registered renderLine() 2D VBO made -- _registeredLine2DVBOs.size():" << _registeredLine2DVBOs.size();
-        }
-#endif
-    }
-
-    // this is what it takes to render a quad
-    batch.setInputFormat(details.streamFormat);
-    batch.setInputStream(0, *details.stream);
-    batch.draw(gpu::LINES, 2, 0);
 }
 
 void GeometryCache::useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend) {
@@ -2175,24 +1858,24 @@ gpu::PipelinePointer GeometryCache::getSimplePipeline(bool textured, bool transp
         std::call_once(once, [&]() {
             using namespace shader::render_utils::program;
 
-            _forwardSimpleShader = gpu::Shader::createProgram(simple_forward);
-            _forwardTransparentShader = gpu::Shader::createProgram(simple_translucent_forward);
-            _forwardUnlitShader = gpu::Shader::createProgram(simple_unlit_forward);
+            _shapeShaders[std::make_tuple(false, false, true, false)] = gpu::Shader::createProgram(simple_forward);
+            _shapeShaders[std::make_tuple(true, false, true, false)] = gpu::Shader::createProgram(simple_translucent_forward);
+            _shapeShaders[std::make_tuple(false, true, true, false)] = gpu::Shader::createProgram(simple_unlit_forward);
 
-            _simpleShader = gpu::Shader::createProgram(simple);
-            _transparentShader = gpu::Shader::createProgram(simple_translucent);
-            _unlitShader = gpu::Shader::createProgram(simple_unlit);
+            _shapeShaders[std::make_tuple(false, false, false, false)] = gpu::Shader::createProgram(simple);
+            _shapeShaders[std::make_tuple(true, false, false, false)] = gpu::Shader::createProgram(simple_translucent);
+            _shapeShaders[std::make_tuple(false, true, false, false)] = gpu::Shader::createProgram(simple_unlit);
         });
     } else {
         static std::once_flag once;
         std::call_once(once, [&]() {
             using namespace shader::render_utils::program;
             // Fading is currently disabled during forward rendering
-            _forwardSimpleFadeShader = gpu::Shader::createProgram(simple_forward);
-            _forwardUnlitFadeShader = gpu::Shader::createProgram(simple_unlit_forward);
+            _shapeShaders[std::make_tuple(false, false, true, true)] = gpu::Shader::createProgram(simple_forward);
+            _shapeShaders[std::make_tuple(false, true, true, true)] = gpu::Shader::createProgram(simple_unlit_forward);
 
-            _simpleFadeShader = gpu::Shader::createProgram(simple_fade);
-            _unlitFadeShader = gpu::Shader::createProgram(simple_unlit_fade);
+            _shapeShaders[std::make_tuple(false, false, false, true)] = gpu::Shader::createProgram(simple_fade);
+            _shapeShaders[std::make_tuple(false, true, false, true)] = gpu::Shader::createProgram(simple_unlit_fade);
         });
     }
 
@@ -2220,20 +1903,13 @@ gpu::PipelinePointer GeometryCache::getSimplePipeline(bool textured, bool transp
         PrepareStencil::testMaskDrawShapeNoAA(*state);
     }
 
-    gpu::ShaderPointer program;
-    if (config.isForward()) {
-        program = (config.isUnlit()) ? (config.isFading() ? _forwardUnlitFadeShader : _forwardUnlitShader) :
-                                       (config.isFading() ? _forwardSimpleFadeShader : (config.isTransparent() ? _forwardTransparentShader : _forwardSimpleShader));
-    } else {
-        program = (config.isUnlit()) ? (config.isFading() ? _unlitFadeShader : _unlitShader) :
-                                       (config.isFading() ? _simpleFadeShader : (config.isTransparent() ? _transparentShader : _simpleShader));
-    }
+    gpu::ShaderPointer program = _shapeShaders[std::make_tuple(config.isTransparent(), config.isUnlit(), config.isForward(), config.isFading())];
     gpu::PipelinePointer pipeline = gpu::Pipeline::create(program, state);
     _simplePrograms.insert(config, pipeline);
     return pipeline;
 }
 
-uint32_t toCompactColor(const glm::vec4& color) {
+uint32_t GeometryCache::toCompactColor(const glm::vec4& color) {
     uint32_t compactColor = ((int(color.x * 255.0f) & 0xFF)) |
         ((int(color.y * 255.0f) & 0xFF) << 8) |
         ((int(color.z * 255.0f) & 0xFF) << 16) |
@@ -2251,7 +1927,7 @@ void renderInstances(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color
     // Add color to named buffer
     {
         gpu::BufferPointer instanceColorBuffer = batch.getNamedBuffer(instanceName, INSTANCE_COLOR_BUFFER);
-        auto compactColor = toCompactColor(color);
+        auto compactColor = GeometryCache::toCompactColor(color);
         instanceColorBuffer->append(compactColor);
     }
 
@@ -2268,55 +1944,6 @@ void renderInstances(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color
     });
 }
 
-static const size_t INSTANCE_FADE_BUFFER1 = 1;
-static const size_t INSTANCE_FADE_BUFFER2 = 2;
-static const size_t INSTANCE_FADE_BUFFER3 = 3;
-
-void renderFadeInstances(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color, int fadeCategory, float fadeThreshold,
-    const glm::vec3& fadeNoiseOffset, const glm::vec3& fadeBaseOffset, const glm::vec3& fadeBaseInvSize, bool isWire,
-    const render::ShapePipelinePointer& pipeline, GeometryCache::Shape shape) {
-    // Add pipeline to name
-    std::string instanceName = (isWire ? "wire_shapes_" : "solid_shapes_") + std::to_string(shape) + "_" + std::to_string(std::hash<render::ShapePipelinePointer>()(pipeline));
-
-    // Add color to named buffer
-    {
-        gpu::BufferPointer instanceColorBuffer = batch.getNamedBuffer(instanceName, INSTANCE_COLOR_BUFFER);
-        auto compactColor = toCompactColor(color);
-        instanceColorBuffer->append(compactColor);
-    }
-    // Add fade parameters to named buffers
-    {
-        gpu::BufferPointer fadeBuffer1 = batch.getNamedBuffer(instanceName, INSTANCE_FADE_BUFFER1);
-        gpu::BufferPointer fadeBuffer2 = batch.getNamedBuffer(instanceName, INSTANCE_FADE_BUFFER2);
-        gpu::BufferPointer fadeBuffer3 = batch.getNamedBuffer(instanceName, INSTANCE_FADE_BUFFER3);
-        // Pack parameters in 3 vec4s
-        glm::vec4 fadeData1;
-        glm::vec4 fadeData2;
-        glm::vec4 fadeData3;
-        FadeEffect::packToAttributes(fadeCategory, fadeThreshold, fadeNoiseOffset, fadeBaseOffset, fadeBaseInvSize,
-            fadeData1, fadeData2, fadeData3);
-        fadeBuffer1->append(fadeData1);
-        fadeBuffer2->append(fadeData2);
-        fadeBuffer3->append(fadeData3);
-    }
-
-    // Add call to named buffer
-    batch.setupNamedCalls(instanceName, [args, isWire, pipeline, shape](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-        auto& buffers = data.buffers;
-        batch.setPipeline(pipeline->pipeline);
-        pipeline->prepare(batch, args);
-
-        if (isWire) {
-            DependencyManager::get<GeometryCache>()->renderWireFadeShapeInstances(batch, shape, data.count(),
-                buffers[INSTANCE_COLOR_BUFFER], buffers[INSTANCE_FADE_BUFFER1], buffers[INSTANCE_FADE_BUFFER2], buffers[INSTANCE_FADE_BUFFER3]);
-        }
-        else {
-            DependencyManager::get<GeometryCache>()->renderFadeShapeInstances(batch, shape, data.count(),
-                buffers[INSTANCE_COLOR_BUFFER], buffers[INSTANCE_FADE_BUFFER1], buffers[INSTANCE_FADE_BUFFER2], buffers[INSTANCE_FADE_BUFFER3]);
-        }
-    });
-}
-
 void GeometryCache::renderSolidShapeInstance(RenderArgs* args, gpu::Batch& batch, GeometryCache::Shape shape, const glm::vec4& color, const render::ShapePipelinePointer& pipeline) {
     assert(pipeline != nullptr);
     renderInstances(args, batch, color, false, pipeline, shape);
@@ -2327,72 +1954,9 @@ void GeometryCache::renderWireShapeInstance(RenderArgs* args, gpu::Batch& batch,
     renderInstances(args, batch, color, true, pipeline, shape);
 }
 
-void GeometryCache::renderSolidFadeShapeInstance(RenderArgs* args, gpu::Batch& batch, GeometryCache::Shape shape, const glm::vec4& color,
-    int fadeCategory, float fadeThreshold, const glm::vec3& fadeNoiseOffset, const glm::vec3& fadeBaseOffset, const glm::vec3& fadeBaseInvSize,
-    const render::ShapePipelinePointer& pipeline) {
-    assert(pipeline != nullptr);
-    renderFadeInstances(args, batch, color, fadeCategory, fadeThreshold, fadeNoiseOffset, fadeBaseOffset, fadeBaseInvSize, false, pipeline, shape);
-}
-
-void GeometryCache::renderWireFadeShapeInstance(RenderArgs* args, gpu::Batch& batch, GeometryCache::Shape shape, const glm::vec4& color,
-    int fadeCategory, float fadeThreshold, const glm::vec3& fadeNoiseOffset, const glm::vec3& fadeBaseOffset, const glm::vec3& fadeBaseInvSize,
-    const render::ShapePipelinePointer& pipeline) {
-    assert(pipeline != nullptr);
-    renderFadeInstances(args, batch, color, fadeCategory, fadeThreshold, fadeNoiseOffset, fadeBaseOffset, fadeBaseInvSize, true, pipeline, shape);
-}
-
 void GeometryCache::renderSolidSphereInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color, const render::ShapePipelinePointer& pipeline) {
     assert(pipeline != nullptr);
     renderInstances(args, batch, color, false, pipeline, GeometryCache::Sphere);
-}
-
-void GeometryCache::renderWireSphereInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color, const render::ShapePipelinePointer& pipeline) {
-    assert(pipeline != nullptr);
-    renderInstances(args, batch, color, true, pipeline, GeometryCache::Sphere);
-}
-
-// Enable this in a debug build to cause 'box' entities to iterate through all the
-// available shape types, both solid and wireframes
-//#define DEBUG_SHAPES
-
-
-void GeometryCache::renderSolidCubeInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color, const render::ShapePipelinePointer& pipeline) {
-    assert(pipeline != nullptr);
-#ifdef DEBUG_SHAPES
-    static auto startTime = usecTimestampNow();
-    renderInstances(INSTANCE_NAME, batch, color, pipeline, [](gpu::Batch& batch, gpu::Batch::NamedBatchData& data) {
-
-        auto usecs = usecTimestampNow();
-        usecs -= startTime;
-        auto msecs = usecs / USECS_PER_MSEC;
-        float seconds = msecs;
-        seconds /= MSECS_PER_SECOND;
-        float fractionalSeconds = seconds - floor(seconds);
-        int shapeIndex = (int)seconds;
-
-        // Every second we flip to the next shape.
-        static const int SHAPE_COUNT = 5;
-        GeometryCache::Shape shapes[SHAPE_COUNT] = {
-            GeometryCache::Cube,
-            GeometryCache::Tetrahedron,
-            GeometryCache::Sphere,
-            GeometryCache::Icosahedron,
-            GeometryCache::Line,
-        };
-
-        shapeIndex %= SHAPE_COUNT;
-        GeometryCache::Shape shape = shapes[shapeIndex];
-
-        // For the first half second for a given shape, show the wireframe, for the second half, show the solid.
-        if (fractionalSeconds > 0.5f) {
-            renderInstances(INSTANCE_NAME, batch, color, true, pipeline, shape);
-        } else {
-            renderInstances(INSTANCE_NAME, batch, color, false, pipeline, shape);
-        }
-    });
-#else
-    renderInstances(args, batch, color, false, pipeline, GeometryCache::Cube);
-#endif
 }
 
 void GeometryCache::renderWireCubeInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color, const render::ShapePipelinePointer& pipeline) {

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -180,30 +180,9 @@ public:
     void renderShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
     void renderWireShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer);
 
-    void renderFadeShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer,
-        gpu::BufferPointer& fadeBuffer1, gpu::BufferPointer& fadeBuffer2, gpu::BufferPointer& fadeBuffer3);
-    void renderWireFadeShapeInstances(gpu::Batch& batch, Shape shape, size_t count, gpu::BufferPointer& colorBuffer,
-        gpu::BufferPointer& fadeBuffer1, gpu::BufferPointer& fadeBuffer2, gpu::BufferPointer& fadeBuffer3);
-
     void renderSolidShapeInstance(RenderArgs* args, gpu::Batch& batch, Shape shape, const glm::vec4& color,
-                                    const render::ShapePipelinePointer& pipeline);
-    void renderSolidShapeInstance(RenderArgs* args, gpu::Batch& batch, Shape shape, const glm::vec3& color,
-                                    const render::ShapePipelinePointer& pipeline) {
-        renderSolidShapeInstance(args, batch, shape, glm::vec4(color, 1.0f), pipeline);
-    }
-
+                                  const render::ShapePipelinePointer& pipeline);
     void renderWireShapeInstance(RenderArgs* args, gpu::Batch& batch, Shape shape, const glm::vec4& color,
-        const render::ShapePipelinePointer& pipeline);
-    void renderWireShapeInstance(RenderArgs* args, gpu::Batch& batch, Shape shape, const glm::vec3& color,
-        const render::ShapePipelinePointer& pipeline) {
-        renderWireShapeInstance(args, batch, shape, glm::vec4(color, 1.0f), pipeline);
-    }
-
-    void renderSolidFadeShapeInstance(RenderArgs* args, gpu::Batch& batch, Shape shape, const glm::vec4& color, int fadeCategory, float fadeThreshold,
-        const glm::vec3& fadeNoiseOffset, const glm::vec3& fadeBaseOffset, const glm::vec3& fadeBaseInvSize,
-        const render::ShapePipelinePointer& pipeline);
-    void renderWireFadeShapeInstance(RenderArgs* args, gpu::Batch& batch, Shape shape, const glm::vec4& color, int fadeCategory, float fadeThreshold,
-        const glm::vec3& fadeNoiseOffset, const glm::vec3& fadeBaseOffset, const glm::vec3& fadeBaseInvSize,
         const render::ShapePipelinePointer& pipeline);
 
     void renderSolidSphereInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color,
@@ -211,20 +190,6 @@ public:
     void renderSolidSphereInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec3& color,
                                     const render::ShapePipelinePointer& pipeline) {
         renderSolidSphereInstance(args, batch, glm::vec4(color, 1.0f), pipeline);
-    }
-
-    void renderWireSphereInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color,
-                                    const render::ShapePipelinePointer& pipeline);
-    void renderWireSphereInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec3& color,
-                                    const render::ShapePipelinePointer& pipeline) {
-        renderWireSphereInstance(args, batch, glm::vec4(color, 1.0f), pipeline);
-    }
-
-    void renderSolidCubeInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color,
-                                    const render::ShapePipelinePointer& pipeline);
-    void renderSolidCubeInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec3& color,
-                                    const render::ShapePipelinePointer& pipeline) {
-        renderSolidCubeInstance(args, batch, glm::vec4(color, 1.0f), pipeline);
     }
 
     void renderWireCubeInstance(RenderArgs* args, gpu::Batch& batch, const glm::vec4& color,
@@ -235,23 +200,9 @@ public:
     }
 
     // Dynamic geometry
-    void renderShape(gpu::Batch& batch, Shape shape);
-    void renderWireShape(gpu::Batch& batch, Shape shape);
-    void renderShape(gpu::Batch& batch, Shape shape, const glm::vec4& color);
-    void renderWireShape(gpu::Batch& batch, Shape shape, const glm::vec4& color);
+    void renderShape(gpu::Batch& batch, Shape shape, gpu::BufferPointer& colorBuffer);
+    void renderWireShape(gpu::Batch& batch, Shape shape, gpu::BufferPointer& colorBuffer);
     size_t getShapeTriangleCount(Shape shape);
-
-    void renderCube(gpu::Batch& batch);
-    void renderWireCube(gpu::Batch& batch);
-    void renderCube(gpu::Batch& batch, const glm::vec4& color);
-    void renderWireCube(gpu::Batch& batch, const glm::vec4& color);
-    size_t getCubeTriangleCount();
-
-    void renderSphere(gpu::Batch& batch);
-    void renderWireSphere(gpu::Batch& batch);
-    void renderSphere(gpu::Batch& batch, const glm::vec4& color);
-    void renderWireSphere(gpu::Batch& batch, const glm::vec4& color);
-    size_t getSphereTriangleCount();
 
     void renderGrid(gpu::Batch& batch, const glm::vec2& minCorner, const glm::vec2& maxCorner,
         int majorRows, int majorCols, float majorEdge,
@@ -261,10 +212,6 @@ public:
     void renderBevelCornersRect(gpu::Batch& batch, int x, int y, int width, int height, int bevelDistance, const glm::vec4& color, int id);
 
     void renderUnitQuad(gpu::Batch& batch, const glm::vec4& color, int id);
-
-    void renderUnitQuad(gpu::Batch& batch, int id) {
-        renderUnitQuad(batch, glm::vec4(1), id);
-    }
 
     void renderQuad(gpu::Batch& batch, int x, int y, int width, int height, const glm::vec4& color, int id)
             { renderQuad(batch, glm::vec2(x,y), glm::vec2(x + width, y + height), color, id); }
@@ -306,19 +253,6 @@ public:
 
     void renderDashedLine(gpu::Batch& batch, const glm::vec3& start, const glm::vec3& end, const glm::vec4& color,
                           const float dash_length, const float gap_length, int id);
-
-    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2, const glm::vec3& color, int id)
-                    { renderLine(batch, p1, p2, glm::vec4(color, 1.0f), id); }
-
-    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2, const glm::vec4& color, int id)
-                    { renderLine(batch, p1, p2, color, color, id); }
-
-    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,
-                    const glm::vec3& color1, const glm::vec3& color2, int id)
-                    { renderLine(batch, p1, p2, glm::vec4(color1, 1.0f), glm::vec4(color2, 1.0f), id); }
-
-    void renderLine(gpu::Batch& batch, const glm::vec2& p1, const glm::vec2& p2,
-                                    const glm::vec4& color1, const glm::vec4& color2, int id);
 
     void updateVertices(int id, const QVector<glm::vec2>& points, const glm::vec4& color);
     void updateVertices(int id, const QVector<glm::vec2>& points, const QVector<glm::vec4>& colors);
@@ -364,6 +298,8 @@ public:
 
     graphics::MeshPointer meshFromShape(Shape geometryShape, glm::vec3 color);
 
+    static uint32_t toCompactColor(const glm::vec4& color);
+
 private:
 
     GeometryCache();
@@ -397,6 +333,7 @@ private:
     public:
         static int population;
         gpu::BufferPointer verticesBuffer;
+        gpu::BufferPointer normalBuffer;
         gpu::BufferPointer colorBuffer;
         gpu::BufferPointer uniformBuffer;
         gpu::Stream::FormatPointer streamFormat;
@@ -445,18 +382,9 @@ private:
     QHash<int, Vec2FloatPairPair> _lastRegisteredGridBuffer;
     QHash<int, GridBuffer> _registeredGridBuffers;
 
-    // FIXME: clean these up
-    static gpu::ShaderPointer _simpleShader;
-    static gpu::ShaderPointer _transparentShader;
-    static gpu::ShaderPointer _unlitShader;
-    static gpu::ShaderPointer _simpleFadeShader;
-    static gpu::ShaderPointer _unlitFadeShader;
-    static gpu::ShaderPointer _forwardSimpleShader;
-    static gpu::ShaderPointer _forwardTransparentShader;
-    static gpu::ShaderPointer _forwardUnlitShader;
-    static gpu::ShaderPointer _forwardSimpleFadeShader;
-    static gpu::ShaderPointer _forwardUnlitFadeShader;
-
+    // transparent, unlit, forward, fade
+    static std::map<std::tuple<bool, bool, bool, bool>, gpu::ShaderPointer> _shapeShaders;
+    // transparent, unlit, forward
     static std::map<std::tuple<bool, bool, bool, graphics::MaterialKey::CullFaceMode>, render::ShapePipelinePointer> _shapePipelines;
     static QHash<SimpleProgramKey, gpu::PipelinePointer> _simplePrograms;
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -355,7 +355,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
         procedural->prepare(batch, transform.getTranslation(), transform.getScale(), transform.getRotation(), _created,
                             ProceduralProgramKey(outColor.a < 1.0f, _shapeKey.isDeformed(), _shapeKey.isDualQuatSkinned()));
 
-        auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+        const uint32_t compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
         _drawMesh->getColorBuffer()->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
     } else {
         // apply material properties
@@ -363,7 +363,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
             args->_details._materialSwitches++;
         }
 
-        auto compactColor = 0xFFFFFFFF;
+        const uint32_t compactColor = 0xFFFFFFFF;
         _drawMesh->getColorBuffer()->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
     }
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -354,12 +354,17 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
         outColor = procedural->getColor(outColor);
         procedural->prepare(batch, transform.getTranslation(), transform.getScale(), transform.getRotation(), _created,
                             ProceduralProgramKey(outColor.a < 1.0f, _shapeKey.isDeformed(), _shapeKey.isDualQuatSkinned()));
-        batch._glColor4f(outColor.r, outColor.g, outColor.b, outColor.a);
+
+        auto compactColor = GeometryCache::toCompactColor(glm::vec4(outColor));
+        _drawMesh->getColorBuffer()->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
     } else {
         // apply material properties
         if (RenderPipelines::bindMaterials(_drawMaterials, batch, args->_renderMode, args->_enableTexturing)) {
             args->_details._materialSwitches++;
         }
+
+        auto compactColor = 0xFFFFFFFF;
+        _drawMesh->getColorBuffer()->setData(sizeof(compactColor), (const gpu::Byte*) &compactColor);
     }
 
     // Draw!


### PR DESCRIPTION
1. Cleanup lots of unused cruft in GeometryCache and simplify the remainder, including using per-instance attributes for all the renderXXXX methods when possible instead of repeating data
2. Remove uses of hacky _glColor4f and replace with per-instance buffers managed by owners

The latter change *should* fix #11 and *maybe* #799 (I wasn't able to reproduce either with this PR but we should test more), as well as make it easier to switch to Vulkan.  _glColor4f was used for specifying a fallback vertex color for when models or shapes didn't have them.  This is because our shaders assume the existence of vertex colors, with a default of white.  By specifying this fallback color, we can avoid having different shader variants for hasVertexColor/!hasVertexColor, which saves us from expensive pipeline switches.  But the state management was always messy, leading to colors "bleeding" between objects.  Now everything manages its own true color buffer, simplifying the state management.

### Testing
Make sure shapes and models work, test vertex colors, make sure other entity types like text, image, and line (laser pointers) still work.