### PR TITLE
:bug: Fixed avatar bounding box being to big on some avatars with tails

### DIFF
--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -587,7 +587,7 @@ void CharacterController::setLocalBoundingBox(const glm::vec3& minCorner, const 
     }
 
     // it's ok to change offset immediately -- there are no thread safety issues here
-    _shapeLocalOffset = minCorner + 0.5f * scale;
+    _shapeLocalOffset = glm::vec3((minCorner + 0.5f * scale).x, (minCorner + 0.5f * scale).y, -(minCorner + 0.5f * scale).z);
 
     if (_rigidBody) {
         // update CCD with new _radius


### PR DESCRIPTION
Before:
![interface_2024-03-10_21-02-53](https://github.com/overte-org/overte/assets/9480940/ded61436-09f0-4036-9066-c4ae6e050762)

After:
![interface_2024-03-10_21-03-05](https://github.com/overte-org/overte/assets/9480940/21e95db1-e3f0-4ea7-afdb-39be1b7a2581)
