### PR TITLE
:wrench: Disable building electron screenshare app on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,9 +252,6 @@ else()
 endif()
 
 set(SCREENSHARE 0)
-if (WIN32)
-  set(SCREENSHARE 1)
-endif()
 if (APPLE AND NOT CLIENT_ONLY)
   # Don't include Screenshare in OSX client-only builds.
   set(SCREENSHARE 1)


### PR DESCRIPTION
This should reduce the Windows installer size by ~220MB