### PR TITLE
Create app: Entity List: "Copy ID" on menu and contextual menu.

### DIFF
--- a/scripts/system/create/entityList/entityList.js
+++ b/scripts/system/create/entityList/entityList.js
@@ -351,6 +351,8 @@ var EntityListTool = function(shouldUseEditTabletApp, selectionManager) {
             that.selectionManager.cutSelectedEntities();
         } else if (data.type === "copy") {
             that.selectionManager.copySelectedEntities();
+        } else if (data.type === "copyID") {
+            that.selectionManager.copyIdFromSelectedEntity();
         } else if (data.type === "paste") {
             that.selectionManager.pasteEntities();
         } else if (data.type === "duplicate") {

--- a/scripts/system/create/entityList/html/entityList.html
+++ b/scripts/system/create/entityList/html/entityList.html
@@ -122,6 +122,12 @@
                     <div class = "menu-item-shortcut">Ctrl-C</div>
                 </div>
             </button>
+            <button class="menu-button" id="hmdcopyid" >
+                <div class = "menu-item">
+                    <div class = "menu-item-caption">Copy ID</div>
+                    <div class = "menu-item-shortcut"></div>
+                </div>
+            </button>            
             <button class="menu-button" id="hmdpaste" >
                 <div class = "menu-item">
                     <div class = "menu-item-caption">Paste</div>

--- a/scripts/system/create/entityList/html/js/entityList.js
+++ b/scripts/system/create/entityList/html/js/entityList.js
@@ -1,6 +1,6 @@
 //  entityList.js
 //
-//  Created by Ryan Huffman on 19 Nov 2014
+//  Created by Ryan Huffman on November 19th, 2014
 //  Copyright 2014 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors.
 //  Copyright 2024 Overte e.V.
@@ -328,6 +328,7 @@ function loaded() {
         elToolsMenu = document.getElementById("tools");
         elMenuBackgroundOverlay = document.getElementById("menuBackgroundOverlay");
         elHmdCopy = document.getElementById("hmdcopy");
+        elHmdCopyID = document.getElementById("hmdcopyid");
         elHmdCut = document.getElementById("hmdcut");
         elHmdPaste = document.getElementById("hmdpaste");
         elHmdDuplicate = document.getElementById("hmdduplicate");        
@@ -422,6 +423,10 @@ function loaded() {
         };
         elHmdCopy.onclick = function() {
             EventBridge.emitWebEvent(JSON.stringify({ type: "copy" }));
+            closeAllEntityListMenu();
+        };
+        elHmdCopyID.onclick = function() {
+            EventBridge.emitWebEvent(JSON.stringify({ type: "copyID" }));
             closeAllEntityListMenu();
         };
         elHmdCut.onclick = function() {
@@ -822,6 +827,9 @@ function loaded() {
                 case "Copy":
                     EventBridge.emitWebEvent(JSON.stringify({ type: "copy" }));
                     break;
+                case "Copy ID":
+                    EventBridge.emitWebEvent(JSON.stringify({ type: "copyID" }));
+                    break;
                 case "Paste":
                     EventBridge.emitWebEvent(JSON.stringify({ type: "paste" }));
                     break;
@@ -861,6 +869,10 @@ function loaded() {
                 enabledContextMenuItems.push("Cut");
                 enabledContextMenuItems.push("Rename");
                 enabledContextMenuItems.push("Delete");
+            }
+            
+            if (selectedEntities.length === 1) {
+                enabledContextMenuItems.push("Copy ID");
             }
 
             entityListContextMenu.open(clickEvent, entityID, enabledContextMenuItems);

--- a/scripts/system/create/entityList/html/js/entityListContextMenu.js
+++ b/scripts/system/create/entityList/html/js/entityListContextMenu.js
@@ -1,9 +1,10 @@
 //
 //  entityListContextMenu.js
 //
-//  exampleContextMenus.js was originally created by David Rowe on 22 Aug 2018.
-//  Modified to entityListContextMenu.js by Thijs Wenker on 10 Oct 2018
+//  exampleContextMenus.js was originally created by David Rowe on August 22nd, 2018.
+//  Modified to entityListContextMenu.js by Thijs Wenker on October 10th, 2018
 //  Copyright 2018 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -137,6 +138,7 @@ EntityListContextMenu.prototype = {
 
         this._addListItem("Cut");
         this._addListItem("Copy");
+        this._addListItem("Copy ID");
         this._addListItem("Paste");
         this._addListSeparator();
         this._addListItem("Rename");

--- a/scripts/system/create/entitySelectionTool/entitySelectionTool.js
+++ b/scripts/system/create/entitySelectionTool/entitySelectionTool.js
@@ -1,12 +1,12 @@
 //
 //  entitySelectionTool.js
 //
-//  Created by Brad hefta-Gaub on 10/1/14.
-//    Modified by Daniela Fontes * @DanielaFifo and Tiago Andrade @TagoWill on 4/7/2017
-//    Modified by David Back on 1/9/2018
+//  Created by Brad hefta-Gaub on October 1st, 2014.
+//    Modified by Daniela Fontes * @DanielaFifo and Tiago Andrade @TagoWill on April 7th, 2017
+//    Modified by David Back on January 9th, 2018
 //  Copyright 2014 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors
-//  Copyright 2022-2023 Overte e.V.
+//  Copyright 2022-2024 Overte e.V.
 //
 //  This script implements a class useful for building tools for editing entities.
 //
@@ -494,6 +494,15 @@ SelectionManager = (function() {
     that.cutSelectedEntities = function() {
         that.copySelectedEntities();
         that.createApp.deleteSelectedEntities();
+    };
+
+    that.copyIdFromSelectedEntity = function() {
+        if (that.selections.length !== 1) {
+            audioFeedback.rejection();
+        } else {
+            Window.copyToClipboard(that.selections[0]);
+            audioFeedback.confirmation();
+        }
     };
 
     that.copySelectedEntities = function() {


### PR DESCRIPTION
This PR adds "**Copy ID**" on **menu** and **contextual menu** of the **Entity List** in the "**Create**" Application.

Addressing Issue #790

![image](https://github.com/overte-org/overte/assets/60075796/b28ad1dc-7677-4448-9ccf-921f470e4581)
enabled if only 1 entity is selected.

![image](https://github.com/overte-org/overte/assets/60075796/208ae43f-13ac-44ed-a973-7367ae5fe80c)
disabled if more than one selected entity.


![image](https://github.com/overte-org/overte/assets/60075796/8f0409f4-a5c7-46b0-aa2b-6cc722645f46)
_(Since this menu is not geared to disable menu items, the copy ID function will make a rejection sound or a confirmation sound depending if the selection is === 1 or not)_
