### PR TITLE
Revert "Disabled texture loading for agent"

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -108,6 +108,7 @@ Agent::Agent(ReceivedMessage& message) :
 
     DependencyManager::set<ModelFormatRegistry>();
     DependencyManager::set<ModelCache>();
+    DependencyManager::set<TextureCache>();
 
     // Needed to ensure the creation of the DebugDraw instance on the main thread
     DebugDraw::getInstance();
@@ -848,6 +849,7 @@ void Agent::aboutToFinish() {
 
     DependencyManager::destroy<ModelFormatRegistry>();
     DependencyManager::destroy<ModelCache>();
+    DependencyManager::destroy<TextureCache>();
 
     DependencyManager::destroy<PluginManager>();
 

--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -143,6 +143,9 @@ static AnimPose composeAnimPose(const HFMJoint& joint, const glm::quat rotation,
 }
 
 void ScriptableAvatar::update(float deltatime) {
+    // TODO: the current decision to use geometry resource results in loading textures, but it works way better
+    // than previous choice of loading avatar as animation, which was missing data such as joint names hash,
+    // and also didn't support glTF models. Optimizing this will be left fot future PR.
     if (!_geometryResource && !_skeletonModelFilenameURL.isEmpty()) { // AvatarData will parse the .fst, but not get the .fbx skeleton.
         _geometryResource = DependencyManager::get<ModelCache>()->getGeometryResource(_skeletonModelFilenameURL);
     }

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -355,12 +355,8 @@ void GeometryResource::deleter() {
 
 void GeometryResource::setTextures() {
     if (_hfmModel) {
-        if (DependencyManager::get<TextureCache>()) {
-            for (const HFMMaterial& material : _hfmModel->materials) {
-                _materials.push_back(std::make_shared<NetworkMaterial>(material, _textureBaseURL));
-            }
-        } else {
-            qDebug() << "GeometryResource::setTextures: TextureCache dependency not available, skipping textures";
+        for (const HFMMaterial& material : _hfmModel->materials) {
+            _materials.push_back(std::make_shared<NetworkMaterial>(material, _textureBaseURL));
         }
     }
 }

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
@@ -865,13 +865,7 @@ graphics::TextureMapPointer NetworkMaterial::fetchTextureMap(const QUrl& baseUrl
     }
 
     const auto url = getTextureUrl(baseUrl, hfmTexture);
-    auto textureCache = DependencyManager::get<TextureCache>();
-    NetworkTexturePointer texture;
-    if (textureCache) {
-        textureCache->getTexture(url, type, hfmTexture.content, hfmTexture.maxNumPixels, hfmTexture.sourceChannel);
-    } else {
-        qDebug() << "GeometryResource::setTextures: TextureCache dependency not available, skipping textures";
-    }
+    const auto texture = DependencyManager::get<TextureCache>()->getTexture(url, type, hfmTexture.content, hfmTexture.maxNumPixels, hfmTexture.sourceChannel);
     _textures[channel] = Texture { hfmTexture.name, texture };
 
     auto map = std::make_shared<graphics::TextureMap>();


### PR DESCRIPTION
This reverts commit a0aae43386dc8cf6ca4ea2ab6da141b4d691a5c8 to fix loading textures on avatars.