### PR TITLE
support VRMC_materials_mtoon and KHR_materials_unlit

### DIFF
--- a/interface/src/avatar/AvatarDoctor.cpp
+++ b/interface/src/avatar/AvatarDoctor.cpp
@@ -333,6 +333,14 @@ void AvatarDoctor::diagnoseTextures() {
         addTextureToList(material.occlusionTexture);
         addTextureToList(material.scatteringTexture);
         addTextureToList(material.lightmapTexture);
+
+        if (material.isMToonMaterial) {
+            addTextureToList(material.shadeTexture);
+            addTextureToList(material.shadingShiftTexture);
+            addTextureToList(material.matcapTexture);
+            addTextureToList(material.rimTexture);
+            addTextureToList(material.uvAnimationTexture);
+        }
     }
 
     for (const auto& materialMapping : model->getMaterialMapping()) {

--- a/interface/src/avatar/AvatarProject.cpp
+++ b/interface/src/avatar/AvatarProject.cpp
@@ -136,6 +136,14 @@ AvatarProject* AvatarProject::createAvatarProject(const QString& projectsFolder,
         addTextureToList(material.occlusionTexture);
         addTextureToList(material.scatteringTexture);
         addTextureToList(material.lightmapTexture);
+
+        if (material.isMToonMaterial) {
+            addTextureToList(material.shadeTexture);
+            addTextureToList(material.shadingShiftTexture);
+            addTextureToList(material.matcapTexture);
+            addTextureToList(material.rimTexture);
+            addTextureToList(material.uvAnimationTexture);
+        }
     }
 
     QDir textureDir(textureFolder.isEmpty() ? fbxInfo.absoluteDir() : textureFolder);

--- a/libraries/baking/src/MaterialBaker.cpp
+++ b/libraries/baking/src/MaterialBaker.cpp
@@ -269,19 +269,32 @@ void MaterialBaker::setMaterials(const QHash<QString, hfm::Material>& materials,
     _materialResource = NetworkMaterialResourcePointer(new NetworkMaterialResource(), [](NetworkMaterialResource* ptr) { ptr->deleteLater(); });
     for (auto& material : materials) {
         _materialResource->parsedMaterials.names.push_back(material.name.toStdString());
-        _materialResource->parsedMaterials.networkMaterials[material.name.toStdString()] = std::make_shared<NetworkMaterial>(material, baseURL);
+        if (!material.isMToonMaterial) {
+            _materialResource->parsedMaterials.networkMaterials[material.name.toStdString()] = std::make_shared<NetworkMaterial>(material, baseURL);
+        } else {
+            _materialResource->parsedMaterials.networkMaterials[material.name.toStdString()] = std::make_shared<NetworkMToonMaterial>(material, baseURL);
+        }
 
         // Store any embedded texture content
         addTexture(material.name, image::TextureUsage::NORMAL_TEXTURE, material.normalTexture);
         addTexture(material.name, image::TextureUsage::ALBEDO_TEXTURE, material.albedoTexture);
-        addTexture(material.name, image::TextureUsage::GLOSS_TEXTURE, material.glossTexture);
-        addTexture(material.name, image::TextureUsage::ROUGHNESS_TEXTURE, material.roughnessTexture);
-        addTexture(material.name, image::TextureUsage::SPECULAR_TEXTURE, material.specularTexture);
-        addTexture(material.name, image::TextureUsage::METALLIC_TEXTURE, material.metallicTexture);
         addTexture(material.name, image::TextureUsage::EMISSIVE_TEXTURE, material.emissiveTexture);
-        addTexture(material.name, image::TextureUsage::OCCLUSION_TEXTURE, material.occlusionTexture);
-        addTexture(material.name, image::TextureUsage::SCATTERING_TEXTURE, material.scatteringTexture);
-        addTexture(material.name, image::TextureUsage::LIGHTMAP_TEXTURE, material.lightmapTexture);
+
+        if (!material.isMToonMaterial) {
+            addTexture(material.name, image::TextureUsage::GLOSS_TEXTURE, material.glossTexture);
+            addTexture(material.name, image::TextureUsage::ROUGHNESS_TEXTURE, material.roughnessTexture);
+            addTexture(material.name, image::TextureUsage::SPECULAR_TEXTURE, material.specularTexture);
+            addTexture(material.name, image::TextureUsage::METALLIC_TEXTURE, material.metallicTexture);
+            addTexture(material.name, image::TextureUsage::OCCLUSION_TEXTURE, material.occlusionTexture);
+            addTexture(material.name, image::TextureUsage::SCATTERING_TEXTURE, material.scatteringTexture);
+            addTexture(material.name, image::TextureUsage::LIGHTMAP_TEXTURE, material.lightmapTexture);
+        } else {
+            addTexture(material.name, image::TextureUsage::ALBEDO_TEXTURE, material.shadeTexture);
+            addTexture(material.name, image::TextureUsage::ROUGHNESS_TEXTURE, material.shadingShiftTexture);
+            addTexture(material.name, image::TextureUsage::EMISSIVE_TEXTURE, material.matcapTexture);
+            addTexture(material.name, image::TextureUsage::ALBEDO_TEXTURE, material.rimTexture);
+            addTexture(material.name, image::TextureUsage::ROUGHNESS_TEXTURE, material.uvAnimationTexture);
+        }
     }
 }
 

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -478,10 +478,9 @@ public:
 protected:
     std::string _name { "" };
     mutable MaterialKey _key { 0 };
-
-private:
     std::string _model { HIFI_PBR };
 
+private:
     // Material properties
     glm::vec3 _emissive { DEFAULT_EMISSIVE };
     float _opacity { DEFAULT_OPACITY };

--- a/libraries/hfm/src/hfm/HFM.cpp
+++ b/libraries/hfm/src/hfm/HFM.cpp
@@ -47,6 +47,24 @@ void HFMMaterial::getTextureNames(QSet<QString>& textureList) const {
     if (!lightmapTexture.isNull()) {
         textureList.insert(lightmapTexture.name);
     }
+
+    if (isMToonMaterial) {
+        if (!shadeTexture.isNull()) {
+            textureList.insert(shadeTexture.name);
+        }
+        if (!shadingShiftTexture.isNull()) {
+            textureList.insert(shadingShiftTexture.name);
+        }
+        if (!matcapTexture.isNull()) {
+            textureList.insert(matcapTexture.name);
+        }
+        if (!rimTexture.isNull()) {
+            textureList.insert(rimTexture.name);
+        }
+        if (!uvAnimationTexture.isNull()) {
+            textureList.insert(uvAnimationTexture.name);
+        }
+    }
 }
 
 void HFMMaterial::setMaxNumPixelsPerTexture(int maxNumPixels) {
@@ -61,6 +79,12 @@ void HFMMaterial::setMaxNumPixelsPerTexture(int maxNumPixels) {
     occlusionTexture.maxNumPixels = maxNumPixels;
     scatteringTexture.maxNumPixels = maxNumPixels;
     lightmapTexture.maxNumPixels = maxNumPixels;
+
+    shadeTexture.maxNumPixels = maxNumPixels;
+    shadingShiftTexture.maxNumPixels = maxNumPixels;
+    matcapTexture.maxNumPixels = maxNumPixels;
+    rimTexture.maxNumPixels = maxNumPixels;
+    uvAnimationTexture.maxNumPixels = maxNumPixels;
 }
 
 bool HFMMaterial::needTangentSpace() const {
@@ -312,6 +336,13 @@ void HFMModel::debugDump() {
         qCDebug(modelformat) << "  useMetallicMap =" << mat.useMetallicMap;
         qCDebug(modelformat) << "  useEmissiveMap =" << mat.useEmissiveMap;
         qCDebug(modelformat) << "  useOcclusionMap =" << mat.useOcclusionMap;
+
+        qCDebug(modelformat) << "  isMToonMaterial =" << mat.isMToonMaterial;
+        qCDebug(modelformat) << "  shadeTexture =" << mat.shadeTexture.filename;
+        qCDebug(modelformat) << "  shadingShiftTexture =" << mat.shadingShiftTexture.filename;
+        qCDebug(modelformat) << "  matcapTexture =" << mat.matcapTexture.filename;
+        qCDebug(modelformat) << "  rimTexture =" << mat.rimTexture.filename;
+        qCDebug(modelformat) << "  uvAnimationTexture =" << mat.uvAnimationTexture.filename;
     }
 
     qCDebug(modelformat) << "---------------- Joints ----------------";

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -224,6 +224,14 @@ public:
     bool useEmissiveMap { false };
     bool useOcclusionMap { false };
 
+
+    bool isMToonMaterial { false };
+    Texture shadeTexture;
+    Texture shadingShiftTexture;
+    Texture matcapTexture;
+    Texture rimTexture;
+    Texture uvAnimationTexture;
+
     bool needTangentSpace() const;
 };
 

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -325,7 +325,11 @@ void GeometryResource::setGeometryDefinition(HFMModel::Pointer hfmModel, const M
     QHash<QString, size_t> materialIDAtlas;
     for (const HFMMaterial& material : _hfmModel->materials) {
         materialIDAtlas[material.materialID] = _materials.size();
-        _materials.push_back(std::make_shared<NetworkMaterial>(material, _textureBaseURL));
+        if (!material.isMToonMaterial) {
+            _materials.push_back(std::make_shared<NetworkMaterial>(material, _textureBaseURL));
+        } else {
+            _materials.push_back(std::make_shared<NetworkMToonMaterial>(material, _textureBaseURL));
+        }
     }
 
     std::shared_ptr<GeometryMeshes> meshes = std::make_shared<GeometryMeshes>();
@@ -357,7 +361,11 @@ void GeometryResource::setTextures() {
     if (_hfmModel) {
         if (DependencyManager::get<TextureCache>()) {
             for (const HFMMaterial& material : _hfmModel->materials) {
-                _materials.push_back(std::make_shared<NetworkMaterial>(material, _textureBaseURL));
+                if (!material.isMToonMaterial) {
+                    _materials.push_back(std::make_shared<NetworkMaterial>(material, _textureBaseURL));
+                } else {
+                    _materials.push_back(std::make_shared<NetworkMToonMaterial>(material, _textureBaseURL));
+                }
             }
         } else {
             qDebug() << "GeometryResource::setTextures: TextureCache dependency not available, skipping textures";
@@ -436,7 +444,11 @@ Geometry::Geometry(const Geometry& geometry) {
 
     _materials.reserve(geometry._materials.size());
     for (const auto& material : geometry._materials) {
-        _materials.push_back(std::make_shared<NetworkMaterial>(*material));
+        if (!material->isMToon()) {
+            _materials.push_back(std::make_shared<NetworkMaterial>(*material));
+        } else if (auto mToonMaterial = std::static_pointer_cast<NetworkMToonMaterial>(material)) {
+            _materials.push_back(std::make_shared<NetworkMToonMaterial>(*mToonMaterial));
+        }
     }
 
     _animGraphOverrideUrl = geometry._animGraphOverrideUrl;
@@ -452,9 +464,13 @@ void Geometry::setTextures(const QVariantMap& textureMap) {
 
                 // FIXME: The Model currently caches the materials (waste of space!)
                 //        so they must be copied in the Geometry copy-ctor
-                // if (material->isOriginal()) {
+                //if (material->isOriginal()) {
                 //    // Copy the material to avoid mutating the cached version
-                //    material = std::make_shared<NetworkMaterial>(*material);
+                //    if (!material->isMToon()) {
+                //        material = std::make_shared<NetworkMaterial>(*material);
+                //    } else {
+                //        material = std::make_shared<NetworkMToonMaterial>(*material);
+                //    }
                 //}
 
                 material->setTextures(textureMap);

--- a/libraries/model-serializers/CMakeLists.txt
+++ b/libraries/model-serializers/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TARGET_NAME model-serializers)
 setup_hifi_library()
 
-link_hifi_libraries(shared graphics networking image hfm)
+link_hifi_libraries(shared graphics networking image hfm procedural material-networking ktx shaders)
 include_hifi_library_headers(gpu image)
 
 target_draco()

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
@@ -826,9 +826,9 @@ NetworkMaterial::NetworkMaterial(const NetworkMaterial& m) :
     Material(m),
     _textures(m._textures),
     _albedoTransform(m._albedoTransform),
+    _isOriginal(m._isOriginal),
     _lightmapTransform(m._lightmapTransform),
-    _lightmapParams(m._lightmapParams),
-    _isOriginal(m._isOriginal)
+    _lightmapParams(m._lightmapParams)
 {}
 
 const QString NetworkMaterial::NO_TEXTURE = QString();
@@ -1135,37 +1135,9 @@ bool NetworkMaterial::checkResetOpacityMap() {
 }
 
 NetworkMToonMaterial::NetworkMToonMaterial(const HFMMaterial& material, const QUrl& textureBaseUrl) :
-    NetworkMaterial(*material._material)
+    NetworkMaterial(material, textureBaseUrl) // handles _name, albedoMap, normalMap, and emissiveMap
 {
-    _name = material.name.toStdString();
-    if (!material.albedoTexture.filename.isEmpty()) {
-        auto map = fetchTextureMap(textureBaseUrl, material.albedoTexture, image::TextureUsage::ALBEDO_TEXTURE, MapChannel::ALBEDO_MAP);
-        if (map) {
-            _albedoTransform = material.albedoTexture.transform;
-            map->setTextureTransform(_albedoTransform);
-
-            if (!material.opacityTexture.filename.isEmpty()) {
-                if (material.albedoTexture.filename == material.opacityTexture.filename) {
-                    // Best case scenario, just indicating that the albedo map contains transparency
-                    // TODO: Different albedo/opacity maps are not currently supported
-                    map->setUseAlphaChannel(true);
-                }
-            }
-        }
-
-        setTextureMap(MapChannel::ALBEDO_MAP, map);
-    }
-
-    if (!material.normalTexture.filename.isEmpty()) {
-        auto type = (material.normalTexture.isBumpmap ? image::TextureUsage::BUMP_TEXTURE : image::TextureUsage::NORMAL_TEXTURE);
-        auto map = fetchTextureMap(textureBaseUrl, material.normalTexture, type, MapChannel::NORMAL_MAP);
-        setTextureMap(MapChannel::NORMAL_MAP, map);
-    }
-
-    if (!material.emissiveTexture.filename.isEmpty()) {
-        auto map = fetchTextureMap(textureBaseUrl, material.emissiveTexture, image::TextureUsage::EMISSIVE_TEXTURE, MapChannel::EMISSIVE_MAP);
-        setTextureMap(MapChannel::EMISSIVE_MAP, map);
-    }
+    _model = VRM_MTOON;
 
     if (!material.shadeTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.shadeTexture, image::TextureUsage::ALBEDO_TEXTURE, (MapChannel)MToonMapChannel::SHADE_MAP);

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.h
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.h
@@ -26,6 +26,7 @@ public:
     NetworkMaterial() : _textures(MapChannel::NUM_MAP_CHANNELS) {}
     NetworkMaterial(const HFMMaterial& material, const QUrl& textureBaseUrl);
     NetworkMaterial(const NetworkMaterial& material);
+    NetworkMaterial(const graphics::Material material) : graphics::Material(material) {}
 
     void setAlbedoMap(const QUrl& url, bool useAlphaChannel);
     void setNormalMap(const QUrl& url, bool isBumpmap);
@@ -60,7 +61,7 @@ protected:
     static const QString NO_TEXTURE;
     const QString& getTextureName(MapChannel channel);
 
-    void setTextures(const QVariantMap& textureMap);
+    virtual void setTextures(const QVariantMap& textureMap);
 
     const bool& isOriginal() const { return _isOriginal; }
 
@@ -68,21 +69,25 @@ protected:
                                                 image::TextureUsage::Type type, MapChannel channel);
     graphics::TextureMapPointer fetchTextureMap(const QUrl& url, image::TextureUsage::Type type, MapChannel channel);
 
+    Transform _albedoTransform;
+
+    bool _isOriginal{ true };
+
 private:
     // Helpers for the ctors
     QUrl getTextureUrl(const QUrl& baseUrl, const HFMTexture& hfmTexture);
 
-    Transform _albedoTransform;
     Transform _lightmapTransform;
     vec2 _lightmapParams;
-
-    bool _isOriginal { true };
 };
 
 class NetworkMToonMaterial : public NetworkMaterial {
 public:
-    NetworkMToonMaterial() : NetworkMaterial() {}
+    NetworkMToonMaterial() : NetworkMaterial() { _model = VRM_MTOON; }
+    NetworkMToonMaterial(const HFMMaterial& material, const QUrl& textureBaseUrl);
     NetworkMToonMaterial(const NetworkMToonMaterial& material);
+
+    void setTextures(const QVariantMap& textureMap) override;
 
     enum MToonMapChannel {
         // Keep aligned with graphics/ShaderConstants.h and graphics-scripting/ScriptableModel.cpp

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.h
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.h
@@ -26,7 +26,6 @@ public:
     NetworkMaterial() : _textures(MapChannel::NUM_MAP_CHANNELS) {}
     NetworkMaterial(const HFMMaterial& material, const QUrl& textureBaseUrl);
     NetworkMaterial(const NetworkMaterial& material);
-    NetworkMaterial(const graphics::Material material) : graphics::Material(material) {}
 
     void setAlbedoMap(const QUrl& url, bool useAlphaChannel);
     void setNormalMap(const QUrl& url, bool isBumpmap);
@@ -71,7 +70,7 @@ protected:
 
     Transform _albedoTransform;
 
-    bool _isOriginal{ true };
+    bool _isOriginal { true };
 
 private:
     // Helpers for the ctors


### PR DESCRIPTION
Fixes #900 and #933 

this was sooooooooooooo much easier with cgltf!  thank you @ksuprynowicz ❤️ 

Here's a super simple gltf file with MToon for testing: https://raw.githubusercontent.com/pixiv/three-vrm/dev/packages/three-vrm-materials-mtoon/examples/models/cube.gltf

There are some unlit models for testing in #900

## Funding

This project is funded through [NGI0 Entrust](https://nlnet.nl/entrust), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Overte).

[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/entrust)