### PR TITLE
Script engine audio listener

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -446,6 +446,34 @@ void AudioClient::setAudioPaused(bool pause) {
     }
 }
 
+QUuid AudioClient::registerScriptListener() {
+    std::lock_guard<std::mutex> lock(_scriptListenersMutex);
+    QUuid listenerID = QUuid::createUuid();
+    while (_scriptListeners.contains(listenerID)) {
+        listenerID = QUuid::createUuid();
+    }
+    _scriptListeners.insert(listenerID, std::make_shared<ScriptAudioListener>());
+    return listenerID;
+}
+
+void AudioClient::unregisterScriptListener(const QUuid& listener) {
+    std::lock_guard<std::mutex> lock(_scriptListenersMutex);
+}
+
+QByteArray AudioClient::getPCMData(const QUuid& listenerID) {
+    std::shared_ptr<ScriptAudioListener> listener;
+    {
+        std::lock_guard<std::mutex> lock(_scriptListenersMutex);
+        if (_scriptListeners.contains(listenerID)) {
+            listener = _scriptListeners[listenerID];
+        } else {
+            qDebug() << "AudioClient::getPCMData: Script listener doesn't exist: " << listenerID;
+            return QByteArray();
+        }
+    }
+    return listener->getData();
+}
+
 HifiAudioDeviceInfo getNamedAudioDeviceForMode(QAudio::Mode mode, const QString& deviceName, const QString& hmdName, bool isHmd=false) {
     HifiAudioDeviceInfo result;
     foreach (HifiAudioDeviceInfo audioDevice, getAvailableDevices(mode,hmdName)) {
@@ -2446,6 +2474,18 @@ qint64 AudioClient::AudioOutputIODevice::readData(char * data, qint64 maxSize) {
     if (_audio->_isRecording) {
         Lock lock(_recordMutex);
         _audio->_audioFileWav.addRawAudioChunk(data, bytesWritten);
+    }
+
+    // Send audio data to script engines.
+    // Hash table needs to be copied to avoid deadlocks and improve performance
+    QHash<QUuid, std::shared_ptr<ScriptAudioListener>> scriptListeners;
+    {
+        std::lock_guard<std::mutex> lock(_audio->_scriptListenersMutex);
+        scriptListeners = _audio->_scriptListeners;
+    }
+    QByteArray dataArray(data, bytesWritten);
+    for (auto listener : _audio->_scriptListeners) {
+        listener->putData(dataArray);
     }
 
     int bytesAudioOutputUnplayed = _audio->_audioOutput->bufferSize() - _audio->_audioOutput->bytesFree();

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -54,6 +54,7 @@
 
 #include <plugins/CodecPlugin.h>
 
+#include "AudioScriptingInterface.h"
 #include "AudioIOStats.h"
 #include "AudioFileWav.h"
 #include "HifiAudioDeviceInfo.h"
@@ -186,6 +187,10 @@ public:
     void setAudioPaused(bool pause);
 
     AudioSolo& getAudioSolo() override { return _solo; }
+
+    QUuid registerScriptListener() override;
+    void unregisterScriptListener(const QUuid& listenerID) override;
+    QByteArray getPCMData(const QUuid& listener) override;
 
 #ifdef Q_OS_WIN
     static QString getWinDeviceName(wchar_t* guid);
@@ -534,6 +539,9 @@ private:
     QTimer* _checkDevicesTimer { nullptr };
     Mutex _checkPeakValuesMutex;
     QTimer* _checkPeakValuesTimer { nullptr };
+
+    Mutex _scriptListenersMutex;
+    QHash<QUuid, std::shared_ptr<ScriptAudioListener>> _scriptListeners;
 
     bool _isRecording { false };
 };

--- a/libraries/audio/src/AbstractAudioInterface.h
+++ b/libraries/audio/src/AbstractAudioInterface.h
@@ -41,6 +41,10 @@ public:
 
     virtual AudioSolo& getAudioSolo() = 0;
 
+    virtual QUuid registerScriptListener() = 0;
+    virtual void unregisterScriptListener(const QUuid& listener) = 0;
+    virtual QByteArray getPCMData(const QUuid& listener) = 0;
+
 public slots:
     virtual bool shouldLoopbackInjectors() { return false; }
 

--- a/libraries/audio/src/AudioScriptingInterface.h
+++ b/libraries/audio/src/AudioScriptingInterface.h
@@ -17,6 +17,8 @@
 #ifndef hifi_AudioScriptingInterface_h
 #define hifi_AudioScriptingInterface_h
 
+#include <queue>
+
 #include "AbstractAudioInterface.h"
 #include "AudioInjector.h"
 #include <DependencyManager.h>
@@ -24,6 +26,17 @@
 
 class ScriptAudioInjector;
 class ScriptEngine;
+
+class ScriptAudioListener {
+    //TODO: add total data size limit
+    //TODO: unregister on script engine destruction
+public:
+    QByteArray getData();
+    void putData(const QByteArray &data);
+private:
+    std::mutex _dataMutex;
+    std::queue<QByteArray> _data;
+};
 
 /// Provides the <code><a href="https://apidocs.overte.org/Audio.html">Audio</a></code> scripting API
 class AudioScriptingInterface : public QObject, public Dependency {
@@ -223,6 +236,10 @@ protected:
      * @returns {boolean} <code>true</code> if the audio input is used in stereo, otherwise <code>false</code>.
      */
     Q_INVOKABLE bool isStereoInput();
+
+    Q_INVOKABLE QUuid registerScriptListener();
+    Q_INVOKABLE void unregisterScriptListener(const QUuid& listener);
+    Q_INVOKABLE QByteArray getPCMData(const QUuid& listener);
 
 signals:
 


### PR DESCRIPTION
This will allow streaming in-game audio into script engine, where it can later be processed or sent to external speech-to-text system, for example through a websocket allowing things such as subtitles, automatic translation, and LLM-based chatbots that react to speech.