### PR TITLE
Fix C++20 warnings

### DIFF
--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -49,10 +49,10 @@ LODManager::LODManager() {
 const float LOD_ADJUST_RUNNING_AVG_TIMESCALE = 0.08f; // sec
 
 // batchTIme is always contained in presentTime.
-// We favor using batchTime instead of presentTime as a representative value for rendering duration (on present thread) 
+// We favor using batchTime instead of presentTime as a representative value for rendering duration (on present thread)
 // if batchTime + cushionTime < presentTime.
 // since we are shooting for fps around 60, 90Hz, the ideal frames are around 10ms
-// so we are picking a cushion time of 3ms 
+// so we are picking a cushion time of 3ms
 const float LOD_BATCH_TO_PRESENT_CUSHION_TIME = 3.0f; // msec
 
 void LODManager::setRenderTimes(float presentTime, float engineRunTime, float batchTime, float gpuTime) {
@@ -64,8 +64,8 @@ void LODManager::setRenderTimes(float presentTime, float engineRunTime, float ba
 }
 
 void LODManager::autoAdjustLOD(float realTimeDelta) {
-    std::lock_guard<std::mutex> { _automaticLODLock };
- 
+    std::lock_guard<std::mutex> lock{ _automaticLODLock };
+
     // The "render time" is the worse of:
     // - engineRunTime: Time spent in the render thread in the engine producing the gpu::Frame N
     // - batchTime: Time spent in the present thread processing the batches of gpu::Frame N+1
@@ -92,7 +92,7 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
     float smoothBlend = (realTimeDelta <  LOD_ADJUST_RUNNING_AVG_TIMESCALE * _smoothScale) ? realTimeDelta / (LOD_ADJUST_RUNNING_AVG_TIMESCALE * _smoothScale) : 1.0f;
 
     //Evaluate the running averages for the render time
-    // We must sanity check for the output average evaluated to be in a valid range to avoid issues 
+    // We must sanity check for the output average evaluated to be in a valid range to avoid issues
     _nowRenderTime = (1.0f - nowBlend) * _nowRenderTime + nowBlend * maxRenderTime; // msec
     _nowRenderTime = std::max(0.0f, std::min(_nowRenderTime, (float)MSECS_PER_SECOND));
     _smoothRenderTime = (1.0f - smoothBlend) * _smoothRenderTime + smoothBlend * maxRenderTime; // msec
@@ -112,7 +112,7 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
     // Current fps based on latest measurments
     float currentNowFPS = (float)MSECS_PER_SECOND / _nowRenderTime;
     float currentSmoothFPS = (float)MSECS_PER_SECOND / _smoothRenderTime;
- 
+
     // Compute the Variance of the FPS signal (FPS - smouthFPS)^2
     // Also scale it by a percentage for fine tuning (default is 100%)
     float currentVarianceFPS = (currentSmoothFPS - currentNowFPS);
@@ -165,7 +165,7 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
 
     // Compute the output of the PID and record intermediate results for tuning
     _pidOutputs.x = _pidCoefs.x * error;        // Kp * error
-    _pidOutputs.y = _pidCoefs.y * integral;     // Ki * integral 
+    _pidOutputs.y = _pidCoefs.y * integral;     // Ki * integral
     _pidOutputs.z = _pidCoefs.z * derivative;   // Kd * derivative
 
     auto output = _pidOutputs.x + _pidOutputs.y + _pidOutputs.z;
@@ -300,7 +300,7 @@ void LODManager::resetLODAdjust() {
 }
 
 void LODManager::setAutomaticLODAdjust(bool value) {
-    std::lock_guard<std::mutex> { _automaticLODLock };
+    std::lock_guard<std::mutex> lock{ _automaticLODLock };
     _automaticLODAdjust = value;
     saveSettings();
     emit autoLODChanged();
@@ -399,7 +399,7 @@ void LODManager::loadSettings() {
     if (qApp->property(hifi::properties::OCULUS_STORE).toBool() && firstRun.get()) {
         hmdQuality = WORLD_DETAIL_HIGH;
     }
-    
+
     _automaticLODAdjust = automaticLODAdjust.get();
     _lodHalfAngle = lodHalfAngle.get();
 
@@ -457,7 +457,7 @@ float LODManager::getLODTargetFPS() const {
     if (qApp->isHMDMode()) {
         lodTargetFPS = getHMDLODTargetFPS();
     }
-    
+
     // if RefreshRate is slower than LOD target then it becomes the true LOD target
     if (lodTargetFPS > refreshRateFPS) {
         return refreshRateFPS;
@@ -476,7 +476,7 @@ void LODManager::setWorldDetailQuality(WorldDetailQuality quality, bool isHMDMod
         setDesktopLODTargetFPS(desiredFPS);
     }
 }
-    
+
 void LODManager::setWorldDetailQuality(WorldDetailQuality quality) {
     setWorldDetailQuality(quality, qApp->isHMDMode());
     saveSettings();
@@ -492,7 +492,7 @@ ScriptValue worldDetailQualityToScriptValue(ScriptEngine* engine, const WorldDet
 }
 
 bool worldDetailQualityFromScriptValue(const ScriptValue& object, WorldDetailQuality& worldDetailQuality) {
-    worldDetailQuality = 
+    worldDetailQuality =
         static_cast<WorldDetailQuality>(std::min(std::max(object.toInt32(), (int)WORLD_DETAIL_LOW), (int)WORLD_DETAIL_HIGH));
     return true;
 }

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -30,11 +30,11 @@ class QDebug;
 #define BATCH_PREALLOCATE_MIN 128
 namespace gpu {
 
-// The named batch data provides a mechanism for accumulating data into buffers over the course 
-// of many independent calls.  For instance, two objects in the scene might both want to render 
+// The named batch data provides a mechanism for accumulating data into buffers over the course
+// of many independent calls.  For instance, two objects in the scene might both want to render
 // a simple box, but are otherwise unaware of each other.  The common code that they call to render
-// the box can create buffers to store the rendering parameters for each box and register a function 
-// that will be called with the accumulated buffer data when the batch commands are finally 
+// the box can create buffers to store the rendering parameters for each box and register a function
+// that will be called with the accumulated buffer data when the batch commands are finally
 // executed against the backend
 
 
@@ -100,15 +100,15 @@ public:
     void clear();
 
     // Batches may need to override the context level stereo settings
-    // if they're performing framebuffer copy operations, like the 
+    // if they're performing framebuffer copy operations, like the
     // deferred lighting resolution mechanism
     void enableStereo(bool enable = true);
     bool isStereoEnabled() const;
 
-    // Stereo batches will pre-translate the view matrix, but this isn't 
-    // appropriate for skyboxes or other things intended to be drawn at 
-    // infinite distance, so provide a mechanism to render in stereo 
-    // without the pre-translation of the view.  
+    // Stereo batches will pre-translate the view matrix, but this isn't
+    // appropriate for skyboxes or other things intended to be drawn at
+    // infinite distance, so provide a mechanism to render in stereo
+    // without the pre-translation of the view.
     void enableSkybox(bool enable = true);
     bool isSkyboxEnabled() const;
 
@@ -147,7 +147,7 @@ public:
     // Indirect buffer is used by the multiDrawXXXIndirect calls
     // The indirect buffer contains the command descriptions to execute multiple drawcalls in a single call
     void setIndirectBuffer(const BufferPointer& buffer, Offset offset = 0, Offset stride = 0);
-    
+
     // multi command desctription for multiDrawIndexedIndirect
     class DrawIndirectCommand {
     public:
@@ -248,7 +248,7 @@ public:
     void popProfileRange();
 
     // TODO: As long as we have gl calls explicitely issued from interface
-    // code, we need to be able to record and batch these calls. THe long 
+    // code, we need to be able to record and batch these calls. THe long
     // term strategy is to get rid of any GL calls in favor of the HIFI GPU API
     // For now, instead of calling the raw gl Call, use the equivalent call on the batch so the call is beeing recorded
     // THe implementation of these functions is in GLBackend.cpp
@@ -348,7 +348,7 @@ public:
         COMMAND_stopNamedCall,
 
         // TODO: As long as we have gl calls explicitely issued from interface
-        // code, we need to be able to record and batch these calls. THe long 
+        // code, we need to be able to record and batch these calls. THe long
         // term strategy is to get rid of any GL calls in favor of the HIFI GPU API
         COMMAND_glUniform1i,
         COMMAND_glUniform1f,
@@ -377,7 +377,7 @@ public:
         union {
 #if (QT_POINTER_SIZE == 8)
             size_t _size;
-#endif            
+#endif
             int32 _int;
             uint32 _uint;
             float _float;
@@ -385,7 +385,7 @@ public:
         };
 #if (QT_POINTER_SIZE == 8)
         Param(size_t val) : _size(val) {}
-#endif            
+#endif
         Param(int32 val) : _int(val) {}
         Param(uint32 val) : _uint(val) {}
         Param(float val) : _float(val) {}
@@ -569,7 +569,7 @@ private:
 
 #else
 
-#define PROFILE_RANGE_BATCH(batch, name) 
+#define PROFILE_RANGE_BATCH(batch, name)
 
 #endif
 

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -402,7 +402,7 @@ public:
     public:
         typedef T Data;
         Data _data;
-        Cache<T>(const Data& data) : _data(data) {}
+        Cache(const Data& data) : _data(data) {}
         static size_t _max;
 
         class Vector {

--- a/libraries/gpu/src/gpu/Buffer.h
+++ b/libraries/gpu/src/gpu/Buffer.h
@@ -387,8 +387,8 @@ public:
             U t;
             return std::make_shared<gpu::Buffer>(sizeof(U), (const gpu::Byte*) &t, sizeof(U));
         }
-        ~StructBuffer<T>() {};
-        StructBuffer<T>() : gpu::BufferView(makeBuffer<T>()) {}
+        ~StructBuffer() {};
+        StructBuffer() : gpu::BufferView(makeBuffer<T>()) {}
 
 
         T& edit() {

--- a/libraries/gpu/src/gpu/Buffer.h
+++ b/libraries/gpu/src/gpu/Buffer.h
@@ -60,7 +60,7 @@ public:
     Size getNumTypedElements() const { return getSize() / sizeof(T); };
 
     const Byte* getData() const { return getSysmem().readData(); }
-    
+
     // Resize the buffer
     // Keep previous data [0 to min(pSize, mSize)]
     Size resize(Size pSize);
@@ -95,7 +95,7 @@ public:
     // \return the number of bytes copied
     Size append(Size size, const Byte* data);
 
-    template <typename T> 
+    template <typename T>
     Size append(const T& t) {
         return append(sizeof(t), reinterpret_cast<const Byte*>(&t));
     }
@@ -110,10 +110,10 @@ public:
 
 
     const GPUObjectPointer gpuObject {};
-    
+
     // Access the sysmem object, limited to ourselves and GPUObject derived classes
     const Sysmem& getSysmem() const { return _sysmem; }
-    
+
     bool isDirty() const {
         return _pages(PageManager::DIRTY);
     }
@@ -127,7 +127,7 @@ protected:
     // For use by the render thread to avoid the intermediate step of getUpdate/applyUpdate
     void flush() const;
 
-    // FIXME don't maintain a second buffer continuously.  We should be able to apply updates 
+    // FIXME don't maintain a second buffer continuously.  We should be able to apply updates
     // directly to the GL object and discard _renderSysmem and _renderPages
     mutable PageManager _renderPages;
     mutable Sysmem _renderSysmem;
@@ -292,7 +292,7 @@ public:
     // Direct memory access to the buffer contents is incompatible with the paging memory scheme
     template <typename T> Iterator<T> begin() { return Iterator<T>(&edit<T>(0), _stride); }
     template <typename T> Iterator<T> end() { return Iterator<T>(&edit<T>(getNum<T>()), _stride); }
-#else 
+#else
     template <typename T> Iterator<const T> begin() const { return Iterator<const T>(&get<T>(), _stride); }
     template <typename T> Iterator<const T> end() const {
         // reimplement get<T> without bounds checking
@@ -378,7 +378,7 @@ public:
         return *(reinterpret_cast<T*> (_buffer->editData() + elementOffset));
     }
 };
- 
+
 
     template <class T> class StructBuffer : public gpu::BufferView {
     public:

--- a/libraries/shared/src/SimpleMovingAverage.h
+++ b/libraries/shared/src/SimpleMovingAverage.h
@@ -48,8 +48,8 @@ private:
 
 template <class T, int MAX_NUM_SAMPLES> class MovingAverage {
 public:
-    MovingAverage<T, MAX_NUM_SAMPLES>() {}
-    MovingAverage<T, MAX_NUM_SAMPLES>(const MovingAverage<T, MAX_NUM_SAMPLES>& other) {
+    MovingAverage() {}
+    MovingAverage(const MovingAverage<T, MAX_NUM_SAMPLES>& other) {
         *this = other;
     }
     MovingAverage<T, MAX_NUM_SAMPLES>& operator=(const MovingAverage<T, MAX_NUM_SAMPLES>& other) {


### PR DESCRIPTION
The switch to C++20 and newer compilers resulted in a lot of new warnings. This fixes them.

Other warnings still remain.