### PR TITLE
Fix access check in getSkeletonModelURLFromScript

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2107,7 +2107,7 @@ const QUrl& AvatarData::getSkeletonModelURL() const {
 }
 
 QString AvatarData::getSkeletonModelURLFromScript() const {
-    if (isMyAvatar() && !isMyAvatarURLProtected() && DependencyManager::get<NodeList>()->getThisNodeCanViewAssetURLs()) {
+    if (isMyAvatar() && !isMyAvatarURLProtected()) {
         return _skeletonModelURL.toString();
     }
 


### PR DESCRIPTION
Big thanks to @AleziaKurdis for pinpointing this issue and providing test script.
Earlier version was breaking flight avatar switcher app.
The test script was reporting null on interface start with it:
```JS

//To reproduce, run this script in Edit>Running Scripts... (with this file on your machine)
//Do: File > Quit
//Launch Interface
//
//Expected: your avatar url
//Curruent: Null

var originalAvatarUrl = "";
originalAvatarUrl = MyAvatar.skeletonModelURL;


//The delay is because if I didn't put it, it was never displayed in the Log window (but it is maybe in the log file... i didn't check)
Script.setTimeout(function () {
    print("##########################################");
    print("FLYAVATAR originalAvatarUrl: " + originalAvatarUrl);
    print("##########################################");
}, 5000);

```