### PR TITLE
Fixed deadlocks in Recording API

### DIFF
--- a/assignment-client/src/AgentScriptingInterface.h
+++ b/assignment-client/src/AgentScriptingInterface.h
@@ -40,7 +40,7 @@
  */
 class AgentScriptingInterface : public QObject {
     Q_OBJECT
-    Q_PROPERTY(bool isAvatar READ isAvatar WRITE setIsAvatar)
+    Q_PROPERTY(bool isAvatar READ getIsAvatar WRITE setIsAvatar)
     Q_PROPERTY(bool isPlayingAvatarSound READ isPlayingAvatarSound)
     Q_PROPERTY(bool isListeningToAudioStream READ isListeningToAudioStream WRITE setIsListeningToAudioStream)
     Q_PROPERTY(bool isNoiseGateEnabled READ isNoiseGateEnabled WRITE setIsNoiseGateEnabled)
@@ -77,15 +77,15 @@ public slots:
 
     /*@jsdoc
      * Checks whether the script is emulating an avatar.
-     * @function Agent.isAvatar
+     * @function Agent.getIsAvatar
      * @returns {boolean} <code>true</code> if the script is emulating an avatar, otherwise <code>false</code>.
      * @example <caption>Check whether the agent is emulating an avatar.</caption>
      * (function () {
-     *     print("Agent is avatar: " + Agent.isAvatar());
+     *     print("Agent is avatar: " + Agent.getIsAvatar());
      *     print("Agent is avatar: " + Agent.isAvatar); // Same result.
      * }());
      */
-    bool isAvatar() const { return _agent->isAvatar(); }
+    bool getIsAvatar() const { return _agent->isAvatar(); }
 
     /*@jsdoc
      * Plays a sound from the position and with the orientation of the emulated avatar's head. No sound is played unless 

--- a/libraries/recording/src/recording/RecordingScriptingInterface.cpp
+++ b/libraries/recording/src/recording/RecordingScriptingInterface.cpp
@@ -129,6 +129,11 @@ void RecordingScriptingInterface::loadRecording(const QString& url, const Script
 }
 
 void RecordingScriptingInterface::startPlaying() {
+    if (QThread::currentThread() != thread()) {
+        BLOCKING_INVOKE_METHOD(this, "startPlaying");
+        return;
+    }
+
     Locker(_mutex);
     _player->play();
 }
@@ -143,6 +148,11 @@ void RecordingScriptingInterface::setPlayerAudioOffset(float audioOffset) {
 }
 
 void RecordingScriptingInterface::setPlayerTime(float time) {
+    if (QThread::currentThread() != thread()) {
+        BLOCKING_INVOKE_METHOD(this, "setPlayerTime", Q_ARG(float, time));
+        return;
+    }
+
     Locker(_mutex);
     _player->seek(time);
 }
@@ -178,6 +188,11 @@ void RecordingScriptingInterface::pausePlayer() {
 }
 
 void RecordingScriptingInterface::stopPlaying() {
+    if (QThread::currentThread() != thread()) {
+        BLOCKING_INVOKE_METHOD(this, "stopPlaying");
+        return;
+    }
+
     Locker(_mutex);
     _player->stop();
 }
@@ -273,6 +288,11 @@ bool RecordingScriptingInterface::saveRecordingToAsset(const ScriptValue& getCli
 }
 
 void RecordingScriptingInterface::loadLastRecording() {
+    if (QThread::currentThread() != thread()) {
+        BLOCKING_INVOKE_METHOD(this, "loadLastRecording");
+        return;
+    }
+
     Locker(_mutex);
 
     if (!_lastClip) {

--- a/libraries/recording/src/recording/RecordingScriptingInterface.cpp
+++ b/libraries/recording/src/recording/RecordingScriptingInterface.cpp
@@ -129,21 +129,11 @@ void RecordingScriptingInterface::loadRecording(const QString& url, const Script
 }
 
 void RecordingScriptingInterface::startPlaying() {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "startPlaying");
-        return;
-    }
-
     Locker(_mutex);
     _player->play();
 }
 
 void RecordingScriptingInterface::setPlayerVolume(float volume) {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "setPlayerVolume", Q_ARG(float, volume));
-        return;
-    }
-
     Locker(_mutex);
     _player->setVolume(std::min(std::max(volume, 0.0f), 1.0f));
 }
@@ -153,10 +143,6 @@ void RecordingScriptingInterface::setPlayerAudioOffset(float audioOffset) {
 }
 
 void RecordingScriptingInterface::setPlayerTime(float time) {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "setPlayerTime", Q_ARG(float, time));
-        return;
-    }
     Locker(_mutex);
     _player->seek(time);
 }
@@ -166,11 +152,6 @@ void RecordingScriptingInterface::setPlayFromCurrentLocation(bool playFromCurren
 }
 
 void RecordingScriptingInterface::setPlayerLoop(bool loop) {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "setPlayerLoop", Q_ARG(bool, loop));
-        return;
-    }
-
     Locker(_mutex);
     _player->loop(loop);
 }
@@ -192,19 +173,11 @@ void RecordingScriptingInterface::setPlayerUseSkeletonModel(bool useSkeletonMode
 }
 
 void RecordingScriptingInterface::pausePlayer() {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "pausePlayer");
-        return;
-    }
     Locker(_mutex);
     _player->pause();
 }
 
 void RecordingScriptingInterface::stopPlaying() {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "stopPlaying");
-        return;
-    }
     Locker(_mutex);
     _player->stop();
 }
@@ -223,11 +196,6 @@ void RecordingScriptingInterface::startRecording() {
         return;
     }
 
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "startRecording");
-        return;
-    }
-
     Locker(_mutex);
     _recorder->start();
 }
@@ -235,11 +203,6 @@ void RecordingScriptingInterface::startRecording() {
 void RecordingScriptingInterface::stopRecording() {
     if (!_recorder->isRecording()) {
         qCWarning(scriptengine) << "Recorder is not running";
-        return;
-    }
-
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "stopRecording");
         return;
     }
 
@@ -258,12 +221,6 @@ QString RecordingScriptingInterface::getDefaultRecordingSaveDirectory() {
 }
 
 void RecordingScriptingInterface::saveRecording(const QString& filename) {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "saveRecording",
-            Q_ARG(QString, filename));
-        return;
-    }
-
     Locker(_mutex);
     if (!_lastClip) {
         qWarning() << "There is no recording to save";
@@ -316,11 +273,6 @@ bool RecordingScriptingInterface::saveRecordingToAsset(const ScriptValue& getCli
 }
 
 void RecordingScriptingInterface::loadLastRecording() {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "loadLastRecording");
-        return;
-    }
-
     Locker(_mutex);
 
     if (!_lastClip) {

--- a/libraries/recording/src/recording/RecordingScriptingInterface.h
+++ b/libraries/recording/src/recording/RecordingScriptingInterface.h
@@ -357,6 +357,8 @@ protected:
     using Locker = std::unique_lock<Mutex>;
     using Flag = std::atomic<bool>;
 
+    Mutex _mutex;
+
     QSharedPointer<recording::Deck> _player;
     QSharedPointer<recording::Recorder> _recorder;
     


### PR DESCRIPTION
This fixes deadlock in Interface and in Assignment Client due to Recording API calls.
Earlier all Recording script API calls happened on main thread using BLOCKING_INVOKE_METHOD, which is fine for ones that don't do anything script engine-related, but will cause a deadlock when script value such as script callback is copied or accessed.
I added a recursive mutex to all calls to be sure that it's thread-safe.