### PR TITLE
SimplifiedUI adjustemnts

### DIFF
--- a/interface/resources/qml/hifi/simplifiedUI/helpApp/faq/HelpFAQ.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/helpApp/faq/HelpFAQ.qml
@@ -3,6 +3,7 @@
 //
 //  Created by Zach Fox on 2019-08-08
 //  Copyright 2019 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -78,7 +79,7 @@ Item {
             temporaryText: "Viewing!"
 
             onClicked: {
-                Qt.openUrlExternally("https://www.highfidelity.com/knowledge");
+                Qt.openUrlExternally("https://overte.org/");
             }
         }
 

--- a/interface/resources/qml/hifi/simplifiedUI/helpApp/support/HelpSupport.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/helpApp/support/HelpSupport.qml
@@ -3,6 +3,7 @@
 //
 //  Created by Zach Fox on 2019-08-20
 //  Copyright 2019 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -76,7 +77,7 @@ Item {
             temporaryText: "Opening browser..."
 
             onClicked: {
-                Qt.openUrlExternally("https://www.highfidelity.com/knowledge/kb-tickets/new");
+                Qt.openUrlExternally("https://overte.org/contact.html");
             }
         }
     }

--- a/interface/resources/qml/hifi/simplifiedUI/settingsApp/dev/Dev.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/settingsApp/dev/Dev.qml
@@ -3,6 +3,7 @@
 //
 //  Created by Zach Fox on 2019-06-11
 //  Copyright 2019 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -93,9 +94,9 @@ Flickable {
                     width: parent.width
                     height: 18
                     labelTextOn: "Keep Old Menus (File, Edit, etc)"
-                    checked: Settings.getValue("simplifiedUI/keepMenus", false);
+                    checked: Settings.getValue("simplifiedUI/keepMenus", true);
                     onClicked: {
-                        Settings.setValue("simplifiedUI/keepMenus", !Settings.getValue("simplifiedUI/keepMenus", false));
+                        Settings.setValue("simplifiedUI/keepMenus", !Settings.getValue("simplifiedUI/keepMenus", true));
                     }
                 }
 

--- a/interface/resources/qml/hifi/simplifiedUI/settingsApp/general/General.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/settingsApp/general/General.qml
@@ -3,6 +3,7 @@
 //
 //  Created by Zach Fox on 2019-05-06
 //  Copyright 2019 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -175,7 +176,7 @@ Flickable {
                 spacing: simplifiedUI.margins.settings.spacingBetweenRadiobuttons
 
                 SimplifiedControls.RadioButton {
-                    id: performanceLow
+                    id: performanceLowPower
                     text: "Low Power Quality" + (PlatformInfo.getTierProfiled() === PerformanceEnums.LOW_POWER ? " (Recommended)" : "")
                     checked: Performance.getPerformancePreset() === PerformanceEnums.LOW_POWER
                     onClicked: {

--- a/interface/resources/qml/hifi/simplifiedUI/simplifiedControls/Button.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/simplifiedControls/Button.qml
@@ -3,6 +3,7 @@
 //
 //  Created by Zach Fox on 2019-05-08
 //  Copyright 2019 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -96,12 +97,11 @@ Original.Button {
         }
     }
 
-    contentItem:  HifiStylesUit.FiraSansMedium {
+    contentItem:  Text {
         id: buttonText
         //topPadding: -2 // Necessary for proper alignment using Graphik Medium
         wrapMode: Text.Wrap
         color: enabled ? simplifiedUI.colors.controls.button.text.enabled : simplifiedUI.colors.controls.button.text.disabled
-        size: simplifiedUI.sizes.controls.button.textSize
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
         text: root.text

--- a/scripts/simplifiedUI/ui/simplifiedUI.js
+++ b/scripts/simplifiedUI/ui/simplifiedUI.js
@@ -7,6 +7,7 @@
 //  Authors: Wayne Chen & Zach Fox
 //  Created: 2019-05-01
 //  Copyright 2019 High Fidelity, Inc.
+//  Copyright 2022 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -20,7 +21,7 @@ var DEFAULT_SCRIPTS_PATH_PREFIX = ScriptDiscoveryService.defaultScriptsPath + "/
 
 
 var MENU_NAMES = ["File", "Edit", "Display", "View", "Navigate", "Settings", "Developer", "Help"];
-var keepMenusSetting = Settings.getValue("simplifiedUI/keepMenus", false);
+var keepMenusSetting = Settings.getValue("simplifiedUI/keepMenus", true);
 function maybeRemoveDesktopMenu() {    
     if (!keepMenusSetting) {
         MENU_NAMES.forEach(function(menu) {

--- a/scripts/simplifiedUI/ui/simplifiedUI.js
+++ b/scripts/simplifiedUI/ui/simplifiedUI.js
@@ -7,7 +7,7 @@
 //  Authors: Wayne Chen & Zach Fox
 //  Created: 2019-05-01
 //  Copyright 2019 High Fidelity, Inc.
-//  Copyright 2022 Overte e.V.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
The simplified UI script had some issues.

First major issue is due to conflicting IDs in the [QML](https://github.com/overte-org/overte/blob/8661e8a858663b48e8485c2cd7120dc3e2d7b87e/interface/resources/qml/hifi/simplifiedUI/settingsApp/general/General.qml#L178) on line 178 and 187, the QML would never properly render.

As a result of this issue, it becomes trivial to be in a sort of soft locked state as you could never open the settings window to disable the removal of the toolbar to easily disable the Simple UI script. From what I could tell you would have to go into one of your config files (interface.json in AppData on Windows? and .config/Overte on linux) and remove the script from "RunningScripts" from there.

You can access the developer tab in the Settings window by pressing the key combination "Ctrl + Alt + Shift + D". [See here](https://github.com/overte-org/overte/blob/c541b64f668c53d2dc80eafe7737a2dc564bbe57/interface/resources/qml/hifi/simplifiedUI/settingsApp/SettingsApp.qml#L33). From there you can disable the setting "Keep Old Menus" and refresh the interface by pressing "Ctrl + R".