### PR TITLE
Skip packet capacity test when built in debug mode, as it triggers an assertion

### DIFF
--- a/tests/networking/src/PacketTests.cpp
+++ b/tests/networking/src/PacketTests.cpp
@@ -92,6 +92,9 @@ void PacketTests::readTest() {
 }
 
 void PacketTests::writePastCapacityTest() {
+    #ifndef QT_NO_DEBUG
+    QSKIP("This test triggers an assertion when built in debug mode");
+    #else
     auto packet = NLPacket::create(PacketType::Unknown);
 
     auto size = packet->getPayloadCapacity();
@@ -116,6 +119,7 @@ void PacketTests::writePastCapacityTest() {
 
     // NLPacket::write() shouldn't allow the caller to write if no space is left
     QCOMPARE(packet->getPayloadSize(), size);
+    #endif
 }
 
 void PacketTests::primitiveTest() {


### PR DESCRIPTION
This happens in debug mode:

```
********* Start testing of PacketTests *********
Config: Using QtTest library 5.15.13, Qt 5.15.13 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 14.1.1 20240507 (Red Hat 14.1.1-1)), fedora 40
PASS   : PacketTests::initTestCase()
PASS   : PacketTests::emptyPacketTest()
PASS   : PacketTests::writeTest()
PASS   : PacketTests::readTest()
QFATAL : PacketTests::writePastCapacityTest() ASSERT failure in BasePacket::writeData: "not enough space for write", file /home/dale/git/overte/libraries/networking/src/udt/BasePacket.cpp, line 175
FAIL!  : PacketTests::writePastCapacityTest() Received a fatal error.
   Loc: [Unknown file(0)]
Totals: 4 passed, 1 failed, 0 skipped, 0 blacklisted, 0ms
********* Finished testing of PacketTests *********
zsh: IOT instruction (core dumped)  ./networking-PacketTests
```

That's because BasePacket.cpp contains an assertion. 