### PR TITLE
Add missing dependencymanager call, fixes test crash

### DIFF
--- a/tests/networking/src/ResourceTests.cpp
+++ b/tests/networking/src/ResourceTests.cpp
@@ -17,6 +17,7 @@
 #include <NodeList.h>
 #include <NetworkAccessManager.h>
 #include <DependencyManager.h>
+#include <ResourceRequestObserver.h>
 #include <StatTracker.h>
 
 QTEST_MAIN(ResourceTests)
@@ -29,6 +30,8 @@ void ResourceTests::initTestCase() {
     DependencyManager::set<NodeList>(NodeType::Agent, INVALID_PORT);
     DependencyManager::set<ResourceCacheSharedItems>();
     DependencyManager::set<ResourceManager>();
+    DependencyManager::set<ResourceRequestObserver>();
+
     const qint64 MAXIMUM_CACHE_SIZE = 1024 * 1024 * 1024; // 1GB
 
     // set up the file cache


### PR DESCRIPTION
```
QDEBUG : ResourceTests::downloadFirst() overte.networking.external_resource: External resource resolved to  QUrl("marketplace/contents/e21c0b95-e502-4d15-8c41-ea2fc40f1125/3585ddf674869a67d31d5964f7b52de1.fst")
QWARN  : ResourceTests::downloadFirst() DependencyManager::get(): No instance available for 23ResourceRequestObserver

=== Received signal at function time: 0ms, total time: 76ms, dumping stack ===
```


This simple fix fixes that.