### PR TITLE
Send OpenGL errors to log on debug builds

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.cpp
@@ -23,7 +23,7 @@ using namespace gpu::gl45;
 GLint GL45Backend::MAX_COMBINED_SHADER_STORAGE_BLOCKS{ 0 };
 GLint GL45Backend::MAX_UNIFORM_LOCATIONS{ 0 };
 
-#ifndef QT_NO_DEBUG
+#ifdef GLAD_DEBUG
 static void post_call_callback_gl(const char *name, void *funcptr, int len_args, ...) {
     (void)funcptr;
     (void)len_args;
@@ -39,7 +39,7 @@ static void post_call_callback_gl(const char *name, void *funcptr, int len_args,
 static void staticInit() {
     static std::once_flag once;
     std::call_once(once, [&] {
-#ifndef QT_NO_DEBUG
+#ifdef GLAD_DEBUG
         // This sets the post call callback to a logging function. By default it prints on
         // stderr and skips our log. It only exists in debug builds.
         glad_set_post_callback(&post_call_callback_gl);


### PR DESCRIPTION
On debug builds, GLAD logs errors to stderr:

`ERROR 1280 in glGetIntegerv`

This is extremely tricky to debug, since it's very unclear where this comes from.

This change sets an alternate callback which sends the same message to our log instead:

`[06/04 23:52:30] [WARNING] [hifi.gpu.gl45] OpenGL error 1280 in glGetIntegerv`

This is much easier to put a breakpoint on to figure out what's going wrong.
