### PR TITLE
Wiggly lasers

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2480,7 +2480,7 @@ void Application::initialize(const QCommandLineParser &parser) {
 
     // Setup the mouse ray pick and related operators
     {
-        auto mouseRayPick = std::make_shared<RayPick>(Vectors::ZERO, Vectors::UP, PickFilter(PickScriptingInterface::getPickEntities() | PickScriptingInterface::getPickLocalEntities()), 0.0f, true);
+        auto mouseRayPick = std::make_shared<RayPick>(Vectors::ZERO, Vectors::UP, PickFilter(PickScriptingInterface::getPickEntities() | PickScriptingInterface::getPickLocalEntities()), 0.0f, 0.0f, true);
         mouseRayPick->parentTransform = std::make_shared<MouseTransformNode>();
         mouseRayPick->setJointState(PickQuery::JOINT_STATE_MOUSE);
         auto mouseRayPickID = DependencyManager::get<PickManager>()->addPick(PickQuery::Ray, mouseRayPick);

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -186,9 +186,10 @@ void LaserPointer::RenderState::update(const glm::vec3& origin, const glm::vec3&
 
             bool hasUnmodifiedEndPoint = false;
             glm::vec3 unmodifiedEndPoint;
+            float directionLength = glm::length(endPoint);
             auto rayPickResult = std::static_pointer_cast<RayPickResult>(pickResult);
             if (rayPickResult && rayPickResult->pickVariant.contains("unmodifiedDirection")) {
-                unmodifiedEndPoint = glm::length(endPoint) * vec3FromVariant(rayPickResult->pickVariant["unmodifiedDirection"]);
+                unmodifiedEndPoint = directionLength * vec3FromVariant(rayPickResult->pickVariant["unmodifiedDirection"]);
                 hasUnmodifiedEndPoint = true;
             }
 
@@ -198,7 +199,7 @@ void LaserPointer::RenderState::update(const glm::vec3& origin, const glm::vec3&
                 if (!oldProperties.getVisible() || !_hasSetLinePoints || !hasUnmodifiedEndPoint) {
                     points.append(frac * endPoint);
                 } else {
-                    points.append(frac * mix(unmodifiedEndPoint, endPoint, frac));
+                    points.append(frac * directionLength * glm::normalize(glm::mix(unmodifiedEndPoint, endPoint, frac)));
                 }
             }
             _hasSetLinePoints = true;

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -13,7 +13,7 @@
 
 #include "PathPointer.h"
 
-#include<EntityItemProperties.h>
+#include <EntityItemProperties.h>
 
 class LaserPointer : public PathPointer {
     using Parent = PathPointer;
@@ -24,21 +24,29 @@ public:
         RenderState(const QUuid& startID, const QUuid& pathID, const QUuid& endID);
 
         const QUuid& getPathID() const { return _pathID; }
-        const bool& doesPathIgnorePicks() const { return _pathIgnorePicks; }
 
         void setLineWidth(float width) { _lineWidth = width; }
         float getLineWidth() const { return _lineWidth; }
 
+        void setNumPoints(size_t numPoints) { _numPoints = std::max(numPoints, (size_t)2); }
+        size_t getNumPoints() const { return _numPoints; }
+
+        const bool& doesPathIgnorePicks() const { return _pathIgnorePicks; }
+
         void cleanup() override;
         void disable() override;
-        void update(const glm::vec3& origin, const glm::vec3& end, const glm::vec3& surfaceNormal, float parentScale, bool distanceScaleEnd, bool centerEndY,
-                    bool faceAvatar, bool followNormal, float followNormalStrength, float distance, const PickResultPointer& pickResult) override;
+        void update(const glm::vec3& origin, const glm::vec3& end, const glm::vec3& surfaceNormal, float parentScale, bool distanceScaleEnd,
+                    bool centerEndY, bool faceAvatar, bool followNormal, float followNormalStrength, float distance,
+                    const PickResultPointer& pickResult) override;
 
     private:
         QUuid _pathID;
 
-        bool _pathIgnorePicks;
-        float _lineWidth;
+        float _lineWidth { 0.0f };
+        size_t _numPoints { 0 };
+        bool _pathIgnorePicks { false };
+
+        bool _hasSetLinePoints { false };
     };
 
     LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates, bool hover, const PointerTriggers& triggers,
@@ -67,7 +75,6 @@ protected:
 
 private:
     static glm::vec3 findIntersection(const PickedObject& pickedObject, const glm::vec3& origin, const glm::vec3& direction);
-
 };
 
 #endif // hifi_LaserPointer_h

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -207,9 +207,11 @@ void ParabolaPointer::RenderState::editParabola(const glm::vec3& color, float al
     }
 }
 
-void ParabolaPointer::RenderState::update(const glm::vec3& origin, const glm::vec3& end, const glm::vec3& surfaceNormal, float parentScale, bool distanceScaleEnd, bool centerEndY,
-                                          bool faceAvatar, bool followNormal, float followNormalStrength, float distance, const PickResultPointer& pickResult) {
-    StartEndRenderState::update(origin, end, surfaceNormal, parentScale, distanceScaleEnd, centerEndY, faceAvatar, followNormal, followNormalStrength, distance, pickResult);
+void ParabolaPointer::RenderState::update(const glm::vec3& origin, const glm::vec3& end, const glm::vec3& surfaceNormal, float parentScale, bool distanceScaleEnd,
+                                          bool centerEndY, bool faceAvatar, bool followNormal, float followNormalStrength, float distance,
+                                          const PickResultPointer& pickResult) {
+    StartEndRenderState::update(origin, end, surfaceNormal, parentScale, distanceScaleEnd, centerEndY, faceAvatar, followNormal, followNormalStrength,
+                                distance, pickResult);
     auto parabolaPickResult = std::static_pointer_cast<ParabolaPickResult>(pickResult);
     if (parabolaPickResult && render::Item::isValidID(_pathID)) {
         render::Transaction transaction;

--- a/interface/src/raypick/PathPointer.cpp
+++ b/interface/src/raypick/PathPointer.cpp
@@ -144,13 +144,11 @@ void PathPointer::updateVisuals(const PickResultPointer& pickResult) {
     auto renderState = _renderStates.find(_currentRenderState);
     auto defaultRenderState = _defaultRenderStates.find(_currentRenderState);
     float parentScale = 1.0f;
-    //if (_scaleWithParent) {
     if (_enabled && _scaleWithParent) {
         glm::vec3 dimensions = DependencyManager::get<PickManager>()->getParentTransform(_pickUID).getScale();
         parentScale = glm::max(glm::max(dimensions.x, dimensions.y), dimensions.z);
     }
 
-    //if (!_currentRenderState.empty() && renderState != _renderStates.end() &&
     if (_enabled && !_currentRenderState.empty() && renderState != _renderStates.end() &&
         (type != IntersectionType::NONE || _pathLength > 0.0f)) {
         glm::vec3 origin = getPickOrigin(pickResult);
@@ -162,14 +160,14 @@ void PathPointer::updateVisuals(const PickResultPointer& pickResult) {
             defaultRenderState->second.second->disable();
         }
     } else if (_enabled && !_currentRenderState.empty() && defaultRenderState != _defaultRenderStates.end()) {
-    //} else if (!_currentRenderState.empty() && defaultRenderState != _defaultRenderStates.end()) {
         if (renderState != _renderStates.end() && renderState->second->isEnabled()) {
             renderState->second->disable();
         }
         glm::vec3 origin = getPickOrigin(pickResult);
         glm::vec3 end = getPickEnd(pickResult, defaultRenderState->second.first);
         defaultRenderState->second.second->update(origin, end, Vectors::UP, parentScale, _distanceScaleEnd, _centerEndY,
-                                                  _faceAvatar, _followNormal, _followNormalStrength, defaultRenderState->second.first, pickResult);
+                                                  _faceAvatar, _followNormal, _followNormalStrength, defaultRenderState->second.first,
+                                                  pickResult);
     } else if (!_currentRenderState.empty()) {
         if (renderState != _renderStates.end() && renderState->second->isEnabled()) {
             renderState->second->disable();
@@ -205,12 +203,12 @@ void PathPointer::editRenderState(const std::string& state, const QVariant& star
 }
 
 void PathPointer::updateRenderState(const QUuid& id, const QVariant& props) {
-    // FIXME: we have to keep using the Overlays interface here, because existing scripts use overlay properties to define pointers
-    if (!id.isNull() && props.isValid()) {
-        QVariantMap propMap = props.toMap();
-        propMap.remove("visible");
-        qApp->getOverlays().editOverlay(id, propMap);
-    }
+    // FIXME: updating render state props no longer works since removing 3D Overlays
+    //if (!id.isNull() && props.isValid()) {
+    //    QVariantMap propMap = props.toMap();
+    //    propMap.remove("visible");
+    //    qApp->getOverlays().editOverlay(id, propMap);
+    //}
 }
 
 Pointer::PickedObject PathPointer::getHoveredObject(const PickResultPointer& pickResult) {
@@ -300,8 +298,9 @@ void StartEndRenderState::disable() {
     _enabled = false;
 }
 
-void StartEndRenderState::update(const glm::vec3& origin, const glm::vec3& end, const glm::vec3& surfaceNormal, float parentScale, bool distanceScaleEnd, bool centerEndY,
-                                 bool faceAvatar, bool followNormal, float followNormalStrength, float distance, const PickResultPointer& pickResult) {
+void StartEndRenderState::update(const glm::vec3& origin, const glm::vec3& end, const glm::vec3& surfaceNormal, float parentScale, bool distanceScaleEnd,
+                                 bool centerEndY, bool faceAvatar, bool followNormal, float followNormalStrength, float distance,
+                                 const PickResultPointer& pickResult) {
     auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
     if (!getStartID().isNull()) {
         EntityItemProperties properties;

--- a/interface/src/raypick/PathPointer.h
+++ b/interface/src/raypick/PathPointer.h
@@ -43,16 +43,17 @@ public:
 
     virtual void cleanup();
     virtual void disable();
-    virtual void update(const glm::vec3& origin, const glm::vec3& end, const glm::vec3& surfaceNormal, float parentScale, bool distanceScaleEnd, bool centerEndY,
-                        bool faceAvatar, bool followNormal, float followNormalStrength, float distance, const PickResultPointer& pickResult);
+    virtual void update(const glm::vec3& origin, const glm::vec3& end, const glm::vec3& surfaceNormal, float parentScale, bool distanceScaleEnd,
+                        bool centerEndY, bool faceAvatar, bool followNormal, float followNormalStrength, float distance,
+                        const PickResultPointer& pickResult);
 
     bool isEnabled() const { return _enabled; }
 
 protected:
     QUuid _startID;
     QUuid _endID;
-    bool _startIgnorePicks;
-    bool _endIgnorePicks;
+    bool _startIgnorePicks { false };
+    bool _endIgnorePicks { false };
 
     glm::vec3 _startDim;
     glm::vec3 _endDim;

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -463,6 +463,10 @@ void PickScriptingInterface::setIncludeItems(unsigned int uid, const ScriptValue
     DependencyManager::get<PickManager>()->setIncludeItems(uid, qVectorQUuidFromScriptValue(includeItems));
 }
 
+void PickScriptingInterface::setDelay(unsigned int uid, float delay) {
+    DependencyManager::get<PickManager>()->setDelay(uid, delay);
+}
+
 bool PickScriptingInterface::isLeftHand(unsigned int uid) {
     return DependencyManager::get<PickManager>()->isLeftHand(uid);
 }
@@ -503,6 +507,15 @@ unsigned int PickScriptingInterface::getPerFrameTimeBudget() const {
 
 void PickScriptingInterface::setPerFrameTimeBudget(unsigned int numUsecs) {
     DependencyManager::get<PickManager>()->setPerFrameTimeBudget(numUsecs);
+}
+
+float PickScriptingInterface::getHandLaserDelay() const {
+    return _handLaserDelaySetting.get();
+}
+
+void PickScriptingInterface::setHandLaserDelay(float delay) {
+    _handLaserDelaySetting.set(delay);
+    emit handLaserDelayChanged(delay);
 }
 
 void PickScriptingInterface::setParentTransform(std::shared_ptr<PickQuery> pick, const QVariantMap& propMap) {

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -121,6 +121,7 @@ PickFilter getPickFilter(unsigned int filter) {
  * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
  * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
  *     default <code>direction</code> value.
+ * @property {number} [delay=0.0] - The delay, in seconds, to apply to the ray direction.
  * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or 
  *     {@link Picks.getPickScriptParameters}. A ray pick's type is {@link PickType.Ray}.
  * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale 
@@ -173,7 +174,14 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMa
         direction = vec3FromVariant(propMap["dirOffset"]);
     }
 
-    auto rayPick = std::make_shared<RayPick>(position, direction, filter, maxDistance, enabled);
+    float delayHalf = 0.0f;
+    if (propMap["delay"].isValid()) {
+        // We want to be within 0.1% of the target in <delay> seconds
+        // https://twitter.com/FreyaHolmer/status/1757836988495847568
+        delayHalf = -std::max(propMap["delay"].toFloat(), 0.0f) / log2(0.001);
+    }
+
+    auto rayPick = std::make_shared<RayPick>(position, direction, filter, maxDistance, delayHalf, enabled);
     setParentTransform(rayPick, propMap);
 
     return rayPick;

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -488,7 +488,7 @@ protected:
     static void setParentTransform(std::shared_ptr<PickQuery> pick, const QVariantMap& propMap);
 
 private:
-    Setting::Handle<float> _handLaserDelaySetting { "handLaserDelay", 0.0f };
+    Setting::Handle<float> _handLaserDelaySetting { "handLaserDelay", 0.35f };
 };
 
 #endif // hifi_PickScriptingInterface_h

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -16,6 +16,7 @@
 #include <PhysicsEngine.h>
 #include <Pick.h>
 #include <PickFilter.h>
+#include <SettingHandle.h>
 
 class ScriptEngine;
 class ScriptValue;
@@ -72,6 +73,7 @@ class ScriptValue;
  * @property {IntersectionType} INTERSECTED_HUD - Intersected the HUD surface. <em>Read-only.</em>
  *
  * @property {number} perFrameTimeBudget - The maximum time, in microseconds, to spend per frame updating pick results.
+ * @property {number} handLaserDelay - The delay, in seconds, applied to the hand lasers to smooth their movement.
  */
 
 class PickScriptingInterface : public QObject, public Dependency {
@@ -105,6 +107,7 @@ class PickScriptingInterface : public QObject, public Dependency {
     Q_PROPERTY(unsigned int INTERSECTED_AVATAR READ getIntersectedAvatar CONSTANT)
     Q_PROPERTY(unsigned int INTERSECTED_HUD READ getIntersectedHud CONSTANT)
     Q_PROPERTY(unsigned int perFrameTimeBudget READ getPerFrameTimeBudget WRITE setPerFrameTimeBudget)
+    Q_PROPERTY(float handLaserDelay READ getHandLaserDelay WRITE setHandLaserDelay)
     SINGLETON_DEPENDENCY
 
 public:
@@ -264,6 +267,15 @@ public:
     Q_INVOKABLE void setIncludeItems(unsigned int uid, const ScriptValue& includeItems);
 
     /*@jsdoc
+     * Sets the delay of a Ray pick.
+     * <p><strong>Note:</strong> Not used by other pick types.</p>
+     * @function Picks.setDelay
+     * @param {number} id - The ID of the pointer.
+     * @param {number} delay - The desired delay in seconds.
+     */
+    Q_INVOKABLE void setDelay(unsigned int uid, float delay);
+
+    /*@jsdoc
      * Checks if a pick is associated with the left hand: a ray or parabola pick with <code>joint</code> property set to 
      * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with 
      * <code>hand</code> property set to <code>0</code>.
@@ -294,6 +306,9 @@ public:
 
     unsigned int getPerFrameTimeBudget() const;
     void setPerFrameTimeBudget(unsigned int numUsecs);
+
+    float getHandLaserDelay() const;
+    void setHandLaserDelay(float delay);
 
 public slots:
 
@@ -461,6 +476,9 @@ public slots:
      */
     static constexpr unsigned int getIntersectedHud() { return IntersectionType::HUD; }
 
+signals:
+    void handLaserDelayChanged(float delay);
+
 protected:
     static std::shared_ptr<PickQuery> buildRayPick(const QVariantMap& properties);
     static std::shared_ptr<PickQuery> buildStylusPick(const QVariantMap& properties);
@@ -468,6 +486,9 @@ protected:
     static std::shared_ptr<PickQuery> buildParabolaPick(const QVariantMap& properties);
 
     static void setParentTransform(std::shared_ptr<PickQuery> pick, const QVariantMap& propMap);
+
+private:
+    Setting::Handle<float> _handLaserDelaySetting { "handLaserDelay", 0.0f };
 };
 
 #endif // hifi_PickScriptingInterface_h

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -25,7 +25,6 @@
 #include <ScriptManager.h>
 
 STATIC_SCRIPT_TYPES_INITIALIZER((+[](ScriptManager* manager){
-    qDebug() << "STATIC_SCRIPT_TYPES_INITIALIZER PointerScriptingInterface";
     auto scriptEngine = manager->engine().get();
     scriptRegisterMetaType<RayPointerProperties, rayPointerPropertiesToScriptValue, rayPointerPropertiesFromScriptValue>(scriptEngine);
     scriptRegisterMetaType<StylusPointerProperties, stylusPointerPropertiesToScriptValue, stylusPointerPropertiesFromScriptValue>(scriptEngine);
@@ -91,7 +90,6 @@ unsigned int PointerScriptingInterface::createStylusPointer(StylusPointerPropert
 unsigned int PointerScriptingInterface::createParabolaPointer(ParabolaPointerProperties properties) {
     return createPointerInternal(PickQuery::PickType::Parabola, properties);
 }
-
 
 bool PointerScriptingInterface::isPointerEnabled(unsigned int uid) const {
     return DependencyManager::get<PointerManager>()->isPointerEnabled(uid);
@@ -178,45 +176,45 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildStylus(const PointerPro
  * Properties that define the visual appearance of a ray pointer when the pointer is intersecting something.
  * @typedef {object} Pointers.RayPointerRenderState
  * @property {string} name - When creating using {@link Pointers.createPointer}, the name of the render state.
- * @property {Overlays.OverlayProperties|Uuid} [start]
+ * @property {Entities.EntityProperties|Uuid} [start]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of 
- *     an overlay to render at the start of the ray pointer. The <code>type</code> property must be specified.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the start of the ray;
- *     <code>null</code> if there is no overlay.
+ *     an entity to render at the start of the ray pointer. The <code>type</code> property must be specified.</p>
+ *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the entity rendered at the start of the ray;
+ *     <code>null</code> if there is no entity.
  *
- * @property {Overlays.OverlayProperties|Uuid} [path]
+ * @property {Entities.EntityProperties|Uuid} [path]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
- *     the overlay rendered for the path of the ray pointer. The <code>type</code> property must be specified and be 
- *     <code>"line3d"</code>.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered for the path of the ray;
- *     <code>null</code> if there is no overlay.
+ *     the entity rendered for the path of the ray pointer. The <code>type</code> property must be specified and be 
+ *     <code>"PolyLine"</code>.</p>  Specify <code>linePoints</code> to control how many segments make up the path.
+ *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the entity rendered for the path of the ray;
+ *     <code>null</code> if there is no entity.
  *
- * @property {Overlays.OverlayProperties|Uuid} [end]
+ * @property {Entities.EntityProperties|Uuid} [end]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
- *     an overlay to render at the end of the ray pointer. The <code>type</code> property must be specified.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the end of the ray; 
- *     <code>null</code> if there is no overlay.
+ *     an entity to render at the end of the ray pointer. The <code>type</code> property must be specified.</p>
+ *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the entity rendered at the end of the ray; 
+ *     <code>null</code> if there is no entity.
  */
 /*@jsdoc
  * The properties of a ray pointer. These include the properties from the underlying ray pick that the pointer uses.
  * @typedef {object} Pointers.RayPointerProperties
- * @property {boolean} [faceAvatar=false] - <code>true</code> if the overlay rendered at the end of the ray rotates about the 
+ * @property {boolean} [faceAvatar=false] - <code>true</code> if the entity rendered at the end of the ray rotates about the 
  *     world y-axis to always face the avatar; <code>false</code> if it maintains its world orientation.
- * @property {boolean} [centerEndY=true] - <code>true</code> if the overlay rendered at the end of the ray is centered on 
- *     the ray end; <code>false</code> if the overlay is positioned against the surface if <code>followNormal</code> is 
+ * @property {boolean} [centerEndY=true] - <code>true</code> if the entity rendered at the end of the ray is centered on 
+ *     the ray end; <code>false</code> if the entity is positioned against the surface if <code>followNormal</code> is 
  *     <code>true</code>, or above the ray end if <code>followNormal</code> is <code>false</code>.
 * @property {boolean} [lockEnd=false] - <code>true</code> if the end of the ray is locked to the center of the object at 
  *     which the ray is pointing; <code>false</code> if the end of the ray is at the intersected surface.
- * @property {boolean} [distanceScaleEnd=false] - <code>true</code> if the dimensions of the overlay at the end of the ray 
+ * @property {boolean} [distanceScaleEnd=false] - <code>true</code> if the dimensions of the entity at the end of the ray 
  *     scale linearly with distance; <code>false</code> if they aren't. 
  * @property {boolean} [scaleWithParent=false] - <code>true</code> if the width of the ray's path and the size of the 
- *     start and end overlays scale linearly with the pointer parent's scale; <code>false</code> if they don't scale.
+ *     start and end entities scale linearly with the pointer parent's scale; <code>false</code> if they don't scale.
  * @property {boolean} [scaleWithAvatar=false] - A synonym for <code>scalewithParent</code>.
  *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} [followNormal=false] - <code>true</code> if the overlay rendered at the end of the ray rotates to 
+ * @property {boolean} [followNormal=false] - <code>true</code> if the entity rendered at the end of the ray rotates to 
  *     follow the normal of the surface if one is intersected; <code>false</code> if it doesn't.
- * @property {number} [followNormalStrength=0.0] - How quickly the overlay rendered at the end of the ray rotates to follow 
- *     the normal of an intersected surface. If <code>0</code> or <code>1</code>, the overlay rotation follows instantaneously; 
+ * @property {number} [followNormalStrength=0.0] - How quickly the entity rendered at the end of the ray rotates to follow 
+ *     the normal of an intersected surface. If <code>0</code> or <code>1</code>, the entity rotation follows instantaneously; 
  *    for other values, the larger the value the more quickly the rotation follows.
  * @property {Pointers.RayPointerRenderState[]|Object.<string, Pointers.RayPointerRenderState>} [renderStates]
  *     <p>A set of visual states that can be switched among using {@link Pointers.setRenderState}. These define the visual 
@@ -236,7 +234,7 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildStylus(const PointerPro
  * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events, 
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger 
- *     events on the entity or overlay currently intersected.
+ *     events on the object currently intersected.
  * @property {PickType} pointerType - The type of pointer returned from {@link Pointers.getPointerProperties} or 
  *     {@link Pointers.getPointerScriptParameters}. A laser pointer's type is {@link PickType(0)|PickType.Ray}.
  * @property {number} [pickID] - The ID of the pick created alongside this pointer, returned from 
@@ -378,41 +376,41 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const Poin
  * Properties that define the visual appearance of a parabola pointer when the pointer is intersecting something.
  * @typedef {object} Pointers.ParabolaPointerRenderState
  * @property {string} name - When creating using {@link Pointers.createPointer}, the name of the render state.
- * @property {Overlays.OverlayProperties|Uuid} [start]
+ * @property {Entities.EntityProperties|Uuid} [start]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
- *     an overlay to render at the start of the parabola pointer. The <code>type</code> property must be specified.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the start of the 
- *     parabola; <code>null</code> if there is no overlay.
+ *     an entity to render at the start of the parabola pointer. The <code>type</code> property must be specified.</p>
+ *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the entity rendered at the start of the 
+ *     parabola; <code>null</code> if there is no entity.
  * @property {Pointers.ParabolaPointerPath|Uuid} [path]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
  *     the rendered path of the parabola pointer.</p>
  *     <p>This property is not provided when getting using {@link Pointers.getPointerProperties}.
- * @property {Overlays.OverlayProperties|Uuid} [end]
+ * @property {Entities.EntityProperties|Uuid} [end]
  *     <p>When creating or editing using {@link Pointers.createPointer} or {@link Pointers.editRenderState}, the properties of
- *     an overlay to render at the end of the ray pointer. The <code>type</code> property must be specified.</p>
- *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the overlay rendered at the end of the parabola;
- *     <code>null</code> if there is no overlay.
+ *     an entity to render at the end of the ray pointer. The <code>type</code> property must be specified.</p>
+ *     <p>When getting using {@link Pointers.getPointerProperties}, the ID of the entity rendered at the end of the parabola;
+ *     <code>null</code> if there is no entity.
  */
 /*@jsdoc
  * The properties of a parabola pointer. These include the properties from the underlying parabola pick that the pointer uses.
  * @typedef {object} Pointers.ParabolaPointerProperties
- * @property {boolean} [faceAvatar=false] - <code>true</code> if the overlay rendered at the end of the ray rotates about the
+ * @property {boolean} [faceAvatar=false] - <code>true</code> if the entity rendered at the end of the ray rotates about the
  *     world y-axis to always face the avatar; <code>false</code> if it maintains its world orientation.
- * @property {boolean} [centerEndY=true] - <code>true</code> if the overlay rendered at the end of the ray is centered on
- *     the ray end; <code>false</code> if the overlay is positioned against the surface if <code>followNormal</code> is
+ * @property {boolean} [centerEndY=true] - <code>true</code> if the entity rendered at the end of the ray is centered on
+ *     the ray end; <code>false</code> if the entity is positioned against the surface if <code>followNormal</code> is
  *     <code>true</code>, or above the ray end if <code>followNormal</code> is <code>false</code>.
 * @property {boolean} [lockEnd=false] - <code>true</code> if the end of the ray is locked to the center of the object at
  *     which the ray is pointing; <code>false</code> if the end of the ray is at the intersected surface.
- * @property {boolean} [distanceScaleEnd=false] - <code>true</code> if the dimensions of the overlay at the end of the ray
+ * @property {boolean} [distanceScaleEnd=false] - <code>true</code> if the dimensions of the entity at the end of the ray
  *     scale linearly with distance; <code>false</code> if they aren't.
  * @property {boolean} [scaleWithParent=false] - <code>true</code> if the width of the ray's path and the size of the
- *     start and end overlays scale linearly with the pointer parent's scale; <code>false</code> if they don't scale.
+ *     start and end entities scale linearly with the pointer parent's scale; <code>false</code> if they don't scale.
  * @property {boolean} [scaleWithAvatar=false] - A synonym for <code>scalewithParent</code>.
  *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {boolean} [followNormal=false] - <code>true</code> if the overlay rendered at the end of the ray rotates to
+ * @property {boolean} [followNormal=false] - <code>true</code> if the entity rendered at the end of the ray rotates to
  *     follow the normal of the surface if one is intersected; <code>false</code> if it doesn't.
- * @property {number} [followNormalStrength=0.0] - How quickly the overlay rendered at the end of the ray rotates to follow
- *     the normal of an intersected surface. If <code>0</code> or <code>1</code>, the overlay rotation follows instantaneously;
+ * @property {number} [followNormalStrength=0.0] - How quickly the entity rendered at the end of the ray rotates to follow
+ *     the normal of an intersected surface. If <code>0</code> or <code>1</code>, the entity rotation follows instantaneously;
  *    for other values, the larger the value the more quickly the rotation follows.
  * @property {Pointers.ParabolaPointerRenderState[]|Object.<string, Pointers.ParabolaPointerRenderState>} [renderStates] 
  *     <p>A set of visual states that can be switched among using {@link Pointers.setRenderState}. These define the visual
@@ -432,7 +430,7 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const Poin
  * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events,
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger
- *     events on the entity or overlay currently intersected.
+ *     events on the object currently intersected.
  * @property {PickType} pointerType - The type of pointer returned from {@link Pointers.getPointerProperties} or 
  *     {@link Pointers.getPointerScriptParameters}. A parabola pointer's type is {@link PickType(0)|PickType.Parabola}.
  * @property {number} [pickID] - The ID of the pick created alongside this pointer, returned from 
@@ -622,7 +620,6 @@ bool rayPointerPropertiesFromScriptValue(const ScriptValue& value, RayPointerPro
             out.properties[*renderStatesName].setValue(renderStates);
         }
     }
-    qDebug() << "rayPointerPropertiesFromScriptValue" << out.properties;
     return true;
 }
 
@@ -675,7 +672,6 @@ bool stylusPointerPropertiesFromScriptValue(const ScriptValue& value, StylusPoin
             out.properties[*renderStatesName].setValue(renderStates);
         }
     }
-    qDebug() << "stylusPointerPropertiesFromScriptValue" << out.properties;
     return true;
 }
 
@@ -714,7 +710,6 @@ bool parabolaPointerPropertiesFromScriptValue(const ScriptValue& value, Parabola
                         pathProperties.copyFromScriptValue(path, false);
                         stateMap.insert("pathPropertyIndex", QVariant(out.entityProperties.length()));
                         out.entityProperties.append(pathProperties);
-                        qDebug() << "parabolaPointerPropertiesFromScriptValue : added path entity";
                     }
 
                     if (stateMap["end"].isValid()) {
@@ -723,7 +718,6 @@ bool parabolaPointerPropertiesFromScriptValue(const ScriptValue& value, Parabola
                         endProperties.copyFromScriptValue(end, false);
                         stateMap.insert("endPropertyIndex", QVariant(out.entityProperties.length()));
                         out.entityProperties.append(endProperties);
-                        qDebug() << "parabolaPointerPropertiesFromScriptValue : added end entity";
                     }
                     renderStates[i].setValue(stateMap);
                 }
@@ -731,6 +725,5 @@ bool parabolaPointerPropertiesFromScriptValue(const ScriptValue& value, Parabola
             out.properties[*renderStatesName].setValue(renderStates);
         }
     }
-    qDebug() << "parabolaPointerPropertiesFromScriptValue" << out.properties;
     return true;
 }

--- a/interface/src/raypick/PointerScriptingInterface.h
+++ b/interface/src/raypick/PointerScriptingInterface.h
@@ -103,7 +103,7 @@ public:
      *     ignorePickIntersection: true
      * };
      * var intersectedPath = {
-     *     type: "line3d",
+     *     type: "PolyLine",
      *     color: { red: 0, green: 255, blue: 0 },
      * };
      * var searchEnd = {
@@ -114,7 +114,7 @@ public:
      *     ignorePickIntersection: true
      * };
      * var searchPath = {
-     *     type: "line3d",
+     *     type: "PolyLine",
      *     color: { red: 255, green: 0, blue: 0 },
      * };
      * 
@@ -224,8 +224,8 @@ public:
      * @param {number} id - The ID of the pointer.
      * @param {string} renderState - The name of the render state to edit.
      * @param {Pointers.RayPointerRenderState|Pointers.ParabolaPointerRenderState} properties - The new properties for the 
-     *     render state. Only the overlay properties to change need be specified.
-     * @example <caption>Change the dimensions of a ray pointer's intersecting end overlay.</caption>
+     *     render state. Only the properties to change need be specified.
+     * @example <caption>Change the dimensions of a ray pointer's intersecting end entity.</caption>
      * var intersectEnd = {
      *     type: "sphere",
      *     dimensions: { x: 0.2, y: 0.2, z: 0.2 },
@@ -234,7 +234,7 @@ public:
      *     ignorePickIntersection: true
      * };
      * var intersectedPath = {
-     *     type: "line3d",
+     *     type: "PolyLine",
      *     color: { red: 0, green: 255, blue: 0 },
      * };
      * var searchEnd = {
@@ -245,7 +245,7 @@ public:
      *     ignorePickIntersection: true
      * };
      * var searchPath = {
-     *     type: "line3d",
+     *     type: "PolyLine",
      *     color: { red: 255, green: 0, blue: 0 },
      * };
      * 
@@ -310,7 +310,7 @@ public:
      *     ignorePickIntersection: true
      * };
      * var intersectedPath = {
-     *     type: "line3d",
+     *     type: "PolyLine",
      *     color: { red: 0, green: 255, blue: 0 },
      * };
      * var searchEnd = {
@@ -321,7 +321,7 @@ public:
      *     ignorePickIntersection: true
      * };
      * var searchPath = {
-     *     type: "line3d",
+     *     type: "PolyLine",
      *     color: { red: 255, green: 0, blue: 0 },
      * };
      * 

--- a/interface/src/raypick/PointerScriptingInterface.h
+++ b/interface/src/raypick/PointerScriptingInterface.h
@@ -423,6 +423,14 @@ public:
      */
     Q_INVOKABLE void setLockEndUUID(unsigned int uid, const QUuid& objectID, bool isAvatar, const glm::mat4& offsetMat = glm::mat4()) const { DependencyManager::get<PointerManager>()->setLockEndUUID(uid, objectID, isAvatar, offsetMat); }
 
+    /*@jsdoc
+     * Sets the delay of a Ray pointer.
+     * <p><strong>Note:</strong> Not used by stylus or parabola pointers.</p>
+     * @function Pointers.setDelay
+     * @param {number} id - The ID of the pointer.
+     * @param {number} delay - The desired delay in seconds.
+     */
+    Q_INVOKABLE void setDelay(unsigned int uid, float delay) const { DependencyManager::get<PointerManager>()->setDelay(uid, delay); }
 
     /*@jsdoc
      * Checks if a pointer is associated with the left hand: a ray or parabola pointer with <code>joint</code> property set to

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -84,9 +84,8 @@ public:
 class RayPick : public Pick<PickRay> {
 
 public:
-    RayPick(glm::vec3 position, glm::vec3 direction, const PickFilter& filter, float maxDistance, bool enabled) :
-        Pick(PickRay(position, direction), filter, maxDistance, enabled) {
-    }
+    RayPick(glm::vec3 position, glm::vec3 direction, const PickFilter& filter, float maxDistance, float delayHalf, bool enabled) :
+        Pick(PickRay(position, direction), filter, maxDistance, enabled), _delayHalf(delayHalf) {}
 
     PickType getType() const override { return PickType::Ray; }
 
@@ -107,6 +106,10 @@ public:
 
 private:
     static glm::vec3 intersectRayWithXYPlane(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& point, const glm::quat& rotation, const glm::vec3& registration);
+
+    float _delayHalf { 0.0f };
+    mutable float _prevUpdate { 0.0f };
+    mutable glm::vec3 _prevDirection { NAN };
 };
 
 #endif // hifi_RayPick_h

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -97,6 +97,8 @@ public:
     PickResultPointer getHUDIntersection(const PickRay& pick) override;
     Transform getResultTransform() const override;
 
+    void setDelay(float delay) override;
+
     // These are helper functions for projecting and intersecting rays
     static glm::vec3 intersectRayWithEntityXYPlane(const QUuid& entityID, const glm::vec3& origin, const glm::vec3& direction);
     static glm::vec2 projectOntoEntityXYPlane(const QUuid& entityID, const glm::vec3& worldPos, bool unNormalized = true);

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -48,29 +48,6 @@ PickQuery::PickType StylusPointer::getType() const {
 }
 
 QUuid StylusPointer::buildStylus(const QVariantMap& properties) {
-    // FIXME: we have to keep using the Overlays interface here, because existing scripts use overlay properties to define pointers
-    /*QVariantMap propertiesMap;
-
-    QString modelUrl = DEFAULT_STYLUS_MODEL_URL;
-
-    if (properties["model"].isValid()) {
-        QVariantMap modelData = properties["model"].toMap();
-
-        if (modelData["url"].isValid()) {
-            modelUrl = modelData["url"].toString();
-        }
-    }
-    // TODO: make these configurable per pointer
-    propertiesMap["name"] = "stylus";
-    propertiesMap["url"] = modelUrl;
-    propertiesMap["loadPriority"] = 10.0f;
-    propertiesMap["solid"] = true;
-    propertiesMap["visible"] = false;
-    propertiesMap["ignorePickIntersection"] = true;
-    propertiesMap["drawInFront"] = false;
-
-    return qApp->getOverlays().addOverlay("model", propertiesMap);*/
-
     EntityItemProperties entityProperties;
     QString modelURL = DEFAULT_STYLUS_MODEL_URL;
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -219,8 +219,8 @@ void setupPreferences() {
         auto setter = [](float value) { DependencyManager::get<PickScriptingInterface>()->setHandLaserDelay(value); };
         auto delaySlider = new SpinnerSliderPreference(UI_CATEGORY, "Laser Delay (seconds)", getter, setter);
         delaySlider->setMin(0.0f);
-        delaySlider->setMax(2.0f);
-        delaySlider->setStep(0.02f);
+        delaySlider->setMax(0.7f);
+        delaySlider->setStep(0.05f);
         delaySlider->setDecimals(2.0f);
         preferences->addPreference(delaySlider);
     }

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -18,6 +18,7 @@
 #include <plugins/PluginManager.h>
 #include <display-plugins/CompositorHelper.h>
 #include <display-plugins/hmd/HmdDisplayPlugin.h>
+#include <raypick/PickScriptingInterface.h>
 #include "scripting/RenderScriptingInterface.h"
 #include "Application.h"
 #include "DialogsManager.h"
@@ -207,6 +208,23 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
 
+    {
+        auto getter = []() -> bool { return qApp->getPreferAvatarFingerOverStylus(); };
+        auto setter = [](bool value) { qApp->setPreferAvatarFingerOverStylus(value); };
+        preferences->addPreference(new CheckPreference(UI_CATEGORY, "Prefer Avatar Finger Over Stylus", getter, setter));
+    }
+
+    {
+        auto getter = []() -> float { return DependencyManager::get<PickScriptingInterface>()->getHandLaserDelay(); };
+        auto setter = [](float value) { DependencyManager::get<PickScriptingInterface>()->setHandLaserDelay(value); };
+        auto delaySlider = new SpinnerSliderPreference(UI_CATEGORY, "Laser Delay (seconds)", getter, setter);
+        delaySlider->setMin(0.0f);
+        delaySlider->setMax(2.0f);
+        delaySlider->setStep(0.02f);
+        delaySlider->setDecimals(2.0f);
+        preferences->addPreference(delaySlider);
+    }
+
     static const QString VIEW_CATEGORY{ "View" };
     {
         auto getter = [myAvatar]()->float { return myAvatar->getRealWorldFieldOfView(); };
@@ -224,12 +242,6 @@ void setupPreferences() {
         preference->setMax(180);
         preference->setStep(1);
         preferences->addPreference(preference);
-    }
-
-    {
-        auto getter = []()->bool { return qApp->getPreferAvatarFingerOverStylus(); };
-        auto setter = [](bool value) { qApp->setPreferAvatarFingerOverStylus(value); };
-        preferences->addPreference(new CheckPreference(UI_CATEGORY, "Prefer Avatar Finger Over Stylus", getter, setter));
     }
 
     // Snapshots

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -170,6 +170,8 @@ public:
     void setIgnoreItems(const QVector<QUuid>& items);
     void setIncludeItems(const QVector<QUuid>& items);
 
+    virtual void setDelay(float delay) {}
+
     virtual QVariantMap toVariantMap() const {
         QVariantMap properties;
 

--- a/libraries/pointers/src/PickManager.cpp
+++ b/libraries/pointers/src/PickManager.cpp
@@ -129,6 +129,13 @@ void PickManager::setIncludeItems(unsigned int uid, const QVector<QUuid>& includ
     }
 }
 
+void PickManager::setDelay(unsigned int uid, float delay) const {
+    auto pick = findPick(uid);
+    if (pick) {
+        pick->setDelay(delay);
+    }
+}
+
 Transform PickManager::getParentTransform(unsigned int uid) const {
     auto pick = findPick(uid);
     if (pick) {

--- a/libraries/pointers/src/PickManager.h
+++ b/libraries/pointers/src/PickManager.h
@@ -48,6 +48,7 @@ public:
     void setPrecisionPicking(unsigned int uid, bool precisionPicking) const;
     void setIgnoreItems(unsigned int uid, const QVector<QUuid>& ignore) const;
     void setIncludeItems(unsigned int uid, const QVector<QUuid>& include) const;
+    void setDelay(unsigned int uid, float delay) const;
 
     Transform getParentTransform(unsigned int uid) const;
     Transform getResultTransform(unsigned int uid) const;

--- a/libraries/pointers/src/Pointer.cpp
+++ b/libraries/pointers/src/Pointer.cpp
@@ -74,6 +74,10 @@ void Pointer::setIncludeItems(const QVector<QUuid>& includeItems) const {
     DependencyManager::get<PickManager>()->setIncludeItems(_pickUID, includeItems);
 }
 
+void Pointer::setDelay(float delay) const {
+    DependencyManager::get<PickManager>()->setDelay(_pickUID, delay);
+}
+
 bool Pointer::isLeftHand() const {
     return DependencyManager::get<PickManager>()->isLeftHand(_pickUID);
 }

--- a/libraries/pointers/src/Pointer.h
+++ b/libraries/pointers/src/Pointer.h
@@ -59,6 +59,7 @@ public:
     virtual void setPrecisionPicking(bool precisionPicking);
     virtual void setIgnoreItems(const QVector<QUuid>& ignoreItems) const;
     virtual void setIncludeItems(const QVector<QUuid>& includeItems) const;
+    virtual void setDelay(float delay) const;
 
     bool isLeftHand() const;
     bool isRightHand() const;

--- a/libraries/pointers/src/PointerManager.cpp
+++ b/libraries/pointers/src/PointerManager.cpp
@@ -157,6 +157,13 @@ void PointerManager::setLockEndUUID(unsigned int uid, const QUuid& objectID, boo
     }
 }
 
+void PointerManager::setDelay(unsigned int uid, float delay) const {
+    auto pointer = find(uid);
+    if (pointer) {
+        pointer->setDelay(delay);
+    }
+}
+
 bool PointerManager::isLeftHand(unsigned int uid) {
     auto pointer = find(uid);
     if (pointer) {

--- a/libraries/pointers/src/PointerManager.h
+++ b/libraries/pointers/src/PointerManager.h
@@ -45,6 +45,7 @@ public:
 
     void setLength(unsigned int uid, float length) const;
     void setLockEndUUID(unsigned int uid, const QUuid& objectID, bool isAvatar, const glm::mat4& offsetMat = glm::mat4()) const;
+    void setDelay(unsigned int uid, float delay) const;
 
     void update();
 

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -205,25 +205,33 @@ public:
  * @typedef {object} PickRay
  * @property {Vec3} origin - The starting position of the ray.
  * @property {Vec3} direction - The direction that the ray travels.
+ * @property {Vec3} unmodifiedDirection - The direction that the ray would travel, if not for applied effects like delays.
  */
 class PickRay : public MathPick {
 public:
-    PickRay() : origin(NAN), direction(NAN)  { }
-    PickRay(const QVariantMap& pickVariant) : origin(vec3FromVariant(pickVariant["origin"])), direction(vec3FromVariant(pickVariant["direction"])) {}
-    PickRay(const glm::vec3& origin, const glm::vec3 direction) : origin(origin), direction(direction) {}
+    PickRay() : origin(NAN), direction(NAN), unmodifiedDirection(NAN)  { }
+    PickRay(const QVariantMap& pickVariant) :
+        origin(vec3FromVariant(pickVariant["origin"])), direction(vec3FromVariant(pickVariant["direction"])),
+        unmodifiedDirection(vec3FromVariant(pickVariant["unmodifiedDirection"])) {}
+    PickRay(const glm::vec3& origin, const glm::vec3& direction) :
+        origin(origin), direction(direction), unmodifiedDirection(direction) {}
+    PickRay(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& unmodifiedDirection) :
+        origin(origin), direction(direction), unmodifiedDirection(unmodifiedDirection) {}
     glm::vec3 origin;
     glm::vec3 direction;
+    glm::vec3 unmodifiedDirection;
 
     operator bool() const override {
-        return !(glm::any(glm::isnan(origin)) || glm::any(glm::isnan(direction)));
+        return !(glm::any(glm::isnan(origin)) || glm::any(glm::isnan(direction)) || glm::any(glm::isnan(unmodifiedDirection)));
     }
     bool operator==(const PickRay& other) const {
-        return (origin == other.origin && direction == other.direction);
+        return (origin == other.origin && direction == other.direction && unmodifiedDirection == other.unmodifiedDirection);
     }
     QVariantMap toVariantMap() const override {
         QVariantMap pickRay;
         pickRay["origin"] = vec3toVariant(origin);
         pickRay["direction"] = vec3toVariant(direction);
+        pickRay["unmodifiedDirection"] = vec3toVariant(unmodifiedDirection);
         return pickRay;
     }
 };

--- a/scripts/system/controllers/controllerDispatcher.js
+++ b/scripts/system/controllers/controllerDispatcher.js
@@ -17,8 +17,7 @@
    controllerDispatcherPlugins:true, controllerDispatcherPluginsNeedSort:true,
    LEFT_HAND, RIGHT_HAND, NEAR_GRAB_PICK_RADIUS, DEFAULT_SEARCH_SPHERE_DISTANCE, DISPATCHER_PROPERTIES,
    getGrabPointSphereOffset, HMD, MyAvatar, Messages, findHandChildEntities, Picks, PickType, Pointers,
-   PointerManager, getGrabPointSphereOffset, HMD, MyAvatar, Messages, findHandChildEntities, Picks, PickType, Pointers,
-   PointerManager, print, Keyboard
+   PointerManager, getGrabPointSphereOffset, HMD, MyAvatar, Messages, findHandChildEntities, print, Keyboard
 */
 
 var controllerDispatcherPlugins = {};
@@ -577,7 +576,6 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
 
         Controller.enableMapping(MAPPING_NAME);
 
-        const POINTER_DELAY = 0.5;
         this.leftPointer = this.pointerManager.createPointer(false, PickType.Ray, {
             joint: "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND",
             filter: Picks.PICK_OVERLAYS | Picks.PICK_ENTITIES | Picks.PICK_INCLUDE_NONCOLLIDABLE,
@@ -587,7 +585,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             scaleWithParent: true,
             distanceScaleEnd: true,
             hand: LEFT_HAND,
-            delay: POINTER_DELAY
+            delay: Picks.handLaserDelay
         });
         Keyboard.setLeftHandLaser(this.leftPointer);
         this.rightPointer = this.pointerManager.createPointer(false, PickType.Ray, {
@@ -599,7 +597,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             scaleWithParent: true,
             distanceScaleEnd: true,
             hand: RIGHT_HAND,
-            delay: POINTER_DELAY
+            delay: Picks.handLaserDelay
         });
         Keyboard.setRightHandLaser(this.rightPointer);
         this.leftHudPointer = this.pointerManager.createPointer(true, PickType.Ray, {
@@ -612,7 +610,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             scaleWithParent: true,
             distanceScaleEnd: true,
             hand: LEFT_HAND,
-            delay: POINTER_DELAY
+            delay: Picks.handLaserDelay
         });
         this.rightHudPointer = this.pointerManager.createPointer(true, PickType.Ray, {
             joint: "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND",
@@ -624,7 +622,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             scaleWithParent: true,
             distanceScaleEnd: true,
             hand: RIGHT_HAND,
-            delay: POINTER_DELAY
+            delay: Picks.handLaserDelay
         });
 
         this.mouseRayPointer = Pointers.createRayPointer({
@@ -671,6 +669,13 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
                     print("WARNING: handControllerGrab.js -- error parsing message: " + data);
                 }
             }
+        };
+
+        this.handLaserDelayChanged = function (delay) {
+            Pointers.setDelay(_this.leftPointer, delay);
+            Pointers.setDelay(_this.rightPointer, delay);
+            Pointers.setDelay(_this.leftHudPointer, delay);
+            Pointers.setDelay(_this.rightHudPointer, delay);
         };
 
         this.cleanup = function () {
@@ -734,6 +739,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
     var controllerDispatcher = new ControllerDispatcher();
     Messages.subscribe('Hifi-Hand-RayPick-Blacklist');
     Messages.messageReceived.connect(controllerDispatcher.handleMessage);
+
+    Picks.handLaserDelayChanged.connect(controllerDispatcher.handLaserDelayChanged);
 
     Script.scriptEnding.connect(function () {
         controllerDispatcher.cleanup();

--- a/scripts/system/controllers/controllerDispatcher.js
+++ b/scripts/system/controllers/controllerDispatcher.js
@@ -577,6 +577,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
 
         Controller.enableMapping(MAPPING_NAME);
 
+        const POINTER_DELAY = 0.5;
         this.leftPointer = this.pointerManager.createPointer(false, PickType.Ray, {
             joint: "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND",
             filter: Picks.PICK_OVERLAYS | Picks.PICK_ENTITIES | Picks.PICK_INCLUDE_NONCOLLIDABLE,
@@ -585,7 +586,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             hover: true,
             scaleWithParent: true,
             distanceScaleEnd: true,
-            hand: LEFT_HAND
+            hand: LEFT_HAND,
+            delay: POINTER_DELAY
         });
         Keyboard.setLeftHandLaser(this.leftPointer);
         this.rightPointer = this.pointerManager.createPointer(false, PickType.Ray, {
@@ -596,7 +598,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             hover: true,
             scaleWithParent: true,
             distanceScaleEnd: true,
-            hand: RIGHT_HAND
+            hand: RIGHT_HAND,
+            delay: POINTER_DELAY
         });
         Keyboard.setRightHandLaser(this.rightPointer);
         this.leftHudPointer = this.pointerManager.createPointer(true, PickType.Ray, {
@@ -608,7 +611,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             hover: true,
             scaleWithParent: true,
             distanceScaleEnd: true,
-            hand: LEFT_HAND
+            hand: LEFT_HAND,
+            delay: POINTER_DELAY
         });
         this.rightHudPointer = this.pointerManager.createPointer(true, PickType.Ray, {
             joint: "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND",
@@ -619,7 +623,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             hover: true,
             scaleWithParent: true,
             distanceScaleEnd: true,
-            hand: RIGHT_HAND
+            hand: RIGHT_HAND,
+            delay: POINTER_DELAY
         });
 
         this.mouseRayPointer = Pointers.createRayPointer({

--- a/scripts/system/libraries/pointersUtils.js
+++ b/scripts/system/libraries/pointersUtils.js
@@ -36,6 +36,7 @@ var Pointer = function(hudLayer, pickType, pointerData) {
         faceCamera: true,
         ignorePickIntersection: true, // always ignore this
         renderLayer: this.renderLayer,
+        linePoints: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     };
     this.halfEnd = {
         type: "Sphere",
@@ -57,6 +58,7 @@ var Pointer = function(hudLayer, pickType, pointerData) {
         faceCamera: true,
         ignorePickIntersection: true, // always ignore this
         renderLayer: this.renderLayer,
+        linePoints: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     };
     this.fullEnd = {
         type: "Sphere",
@@ -78,6 +80,7 @@ var Pointer = function(hudLayer, pickType, pointerData) {
         faceCamera: true,
         ignorePickIntersection: true, // always ignore this
         renderLayer: this.renderLayer,
+        linePoints: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     };
 
     this.renderStates = [


### PR DESCRIPTION
(that's the technical term)

Closes #883 (this only applies smoothing to the lasers.  if we wanted to apply smoothing to the hands, that would be separate).

![overte-snap-by--on-2024-06-09_19-20-50](https://github.com/overte-org/overte/assets/53453710/c486c2f8-594e-446c-8d79-625852142947)

Ray picks support an additional `delay` property which controls how many seconds it takes the end of the ray to catch up.  This can be used to smooth out the ray's movement.  Additionally, ray/laser pointers respect the number of `linePoints` that you specify, allowing you to create bendy/wiggly lasers.

I was only able to test this on desktop, so we need to test in VR.  The delay is configurable in General > Laser Delay (seconds) and defaults to 0 (no delay, like now), but maybe we want some small delay by default?  I also chose 10 points/9 segments for the lasers arbitrarily, but we can increase that if need be.

## Funding

This project is funded through [NGI0 Entrust](https://nlnet.nl/entrust), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Overte).

[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/entrust)