### PR TITLE
GitHub Action Runner auto-scaling

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -33,72 +33,77 @@ jobs:
           - os: debian-11
             image: docker.io/overte/overte-server-build:0.1.3-debian-11-amd64
             arch: amd64
-            runner: linux_amd64
+            # https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners/wiki/Meta-Labels
+            # self_hosted makes the Hetzner auto-scaler put up the job.
+            # type-cx52 is a Hetzner VPS server type. In this case cs52 is a server with 16-cores and 32GB of RAM.
+            # image-x86-app-docker-ce is a Hetzner image.
+            # https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners/wiki/Specifying-The-Runner-Image
+            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
 
           - os: debian-11
             image: docker.io/overte/overte-server-build:0.1.3-debian-11-aarch64
             arch: aarch64
-            runner: linux_aarch64
+            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
 
           - os: debian-12
             image: docker.io/overte/overte-server-build:0.1.3-debian-12-amd64
             arch: amd64
-            runner: linux_amd64
+            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
 
           - os: debian-12
             image: docker.io/overte/overte-server-build:0.1.3-debian-12-aarch64
             arch: aarch64
-            runner: linux_aarch64
+            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
 
           - os: ubuntu-20.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-20.04-amd64
             arch: amd64
-            runner: linux_amd64
+            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
 
           - os: ubuntu-22.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-22.04-amd64
             arch: amd64
-            runner: linux_amd64
+            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
 
           - os: ubuntu-22.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-22.04-aarch64
             arch: aarch64
-            runner: linux_aarch64
+            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
 
           - os: ubuntu-24.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-24.04-amd64
             arch: amd64
-            runner: linux_amd64
+            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
 
           - os: ubuntu-24.04
             image: docker.io/overte/overte-server-build:0.1.3-ubuntu-24.04-aarch64
             arch: aarch64
-            runner: linux_aarch64
+            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
 
           - os: fedora-39
             image: docker.io/overte/overte-server-build:0.1.4-fedora-39-amd64
             arch: amd64
-            runner: linux_amd64
+            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
 
           - os: fedora-39
             image: docker.io/overte/overte-server-build:0.1.4-fedora-39-aarch64
             arch: aarch64
-            runner: linux_aarch64
+            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
 
           - os: fedora-40
             image: docker.io/overte/overte-server-build:0.1.4-fedora-39-amd64
             arch: amd64
-            runner: linux_amd64
+            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
 
           - os: fedora-40
             image: docker.io/overte/overte-server-build:0.1.4-fedora-39-aarch64
             arch: aarch64
-            runner: linux_aarch64
+            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
 
           - os: rockylinux-9
             image: docker.io/overte/overte-server-build:0.1.3-rockylinux-9-amd64
             arch: amd64
-            runner: linux_amd64
+            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
 
       fail-fast: false
 

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -21,6 +21,8 @@ env:
   UPLOAD_ENDPOINT: "https://fra1.digitaloceanspaces.com"
   CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT }}
   CMAKE_BACKTRACE_TOKEN: server_${{ github.event.number }}_${{ github.sha }}
+  # Disable VCPKG caching to save time.
+  VCPKG_FEATURE_FLAGS: -binarycaching
 
 jobs:
   build:

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -1,6 +1,6 @@
 # Copyright 2013-2019 High Fidelity, Inc.
 # Copyright 2020-2022 Vircadia contributors
-# Copyright 2021-2022 Overte e.V.
+# Copyright 2021-2024 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 name: Master CI Build
@@ -26,6 +26,8 @@ env:
   UPLOAD_ENDPOINT: "https://fra1.digitaloceanspaces.com"
   CMAKE_BACKTRACE_URL: ${{ secrets.SENTRY_MINIDUMP_ENDPOINT }}
   CMAKE_BACKTRACE_TOKEN: master_${{ github.event.number }}_${{ github.sha }}
+  # Disable VCPKG caching to save time.
+  VCPKG_FEATURE_FLAGS: -binarycaching
 
   # OSX-specific variables
   DEVELOPER_DIR: /Applications/Xcode_11.2.app/Contents/Developer

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,6 +1,6 @@
 # Copyright 2013-2019 High Fidelity, Inc.
 # Copyright 2020-2022 Vircadia contributors.
-# Copyright 2021-2022 Overte e.V.
+# Copyright 2021-2024 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 name: Pull Request CI Build
@@ -54,7 +54,12 @@ jobs:
             #- os: macOS-10.15
             #  build_type: full
             - os: Ubuntu 20.04
-              runner: linux_amd64
+              # https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners/wiki/Meta-Labels
+              # self_hosted makes the Hetzner auto-scaler put up the job.
+              # type-cx52 is a Hetzner VPS server type. In this case cs52 is a server with 16-cores and 32GB of RAM.
+              # image-x86-app-docker-ce is a Hetzner image.
+              # https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners/wiki/Specifying-The-Runner-Image
+              runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
               arch: amd64
               build_type: full
               apt-dependencies: pkg-config libxext-dev libdouble-conversion-dev libpcre2-16-0 libpulse0 libharfbuzz-dev libnss3 libnspr4 libxdamage1 libasound2 # add missing dependencies to docker image when convenient
@@ -65,7 +70,7 @@ jobs:
             #  apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 python3-github python3-distro
             # Do not change the names of self-hosted runners without knowing what you are doing, as they correspond to labels that have to be set on the runner.
             - os: Ubuntu 22.04
-              runner: linux_aarch64
+              runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
               arch: aarch64
               build_type: full
               image: docker.io/overte/overte-full-build:0.1.1-ubuntu-22.04-aarch64

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -24,6 +24,8 @@ env:
   # We can't use secrets or actions here, so the actual value has to be hardcoded.
   CMAKE_BACKTRACE_URL: "https://o4504831972343808.ingest.sentry.io/api/4504832427950080/minidump/?sentry_key=f511de295975461b8f92a36f4a4a4f32"
   CMAKE_BACKTRACE_TOKEN: PR_${{ github.event.number }}_${{ github.sha }}
+  # Disable VCPKG caching to save time.
+  VCPKG_FEATURE_FLAGS: -binarycaching
 
   UPLOAD_BUCKET: overte-public
   UPLOAD_REGION: fra1


### PR DESCRIPTION
This PR enables automatically starting GitHub Actions Runners using https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners. It takes around 2 minutes from starting the job to a runner picking up the job.

This should save some money and vastly improve build times.
I set the maximum number of runners at the same time to 30 for now.

@daleglass the server setup is very easy and involves passing a configuration file containing two tokens and an SSH key to a Python package. If you are interested in adding this to Ansible, I can show you how this works.