### PR TITLE
Update from deprecated actions/checkout and actions/upload-artifact

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -213,7 +213,7 @@ jobs:
         fi
 
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: false
         fetch-depth: 1
@@ -286,7 +286,7 @@ jobs:
 
     - name: Upload artifact to GitHub
       if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_PATTERN }}
         path: pkg-scripts/${{ env.ARTIFACT_PATTERN }}

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -120,7 +120,7 @@ jobs:
         rm -rf ~/overte-files
         rm -rf ~/.cache
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: false
         fetch-depth: 1

--- a/.github/workflows/master_deploy_apidocs.yml
+++ b/.github/workflows/master_deploy_apidocs.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Overte e.V.
+# Copyright 2022-2024 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 name: Master API-docs CI Build and Deploy
@@ -14,7 +14,7 @@ jobs:
 
     name: Build and deploy API-docs
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       working-directory: tools/jsdoc

--- a/.github/workflows/master_deploy_doxygen.yml
+++ b/.github/workflows/master_deploy_doxygen.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Overte e.V.
+# Copyright 2022-2024 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 name: Master Doxygen CI Build and Deploy
@@ -14,7 +14,7 @@ jobs:
 
     name: Build and deploy Doxygen documentation
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -165,7 +165,7 @@ jobs:
         rm -rf ~/overte-files
         rm -rf ~/.cache
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: false
         fetch-depth: 1
@@ -335,7 +335,7 @@ jobs:
 
     - name: Upload Artifact
       if: startsWith(matrix.os, 'Windows') || startsWith(matrix.os, 'macOS')
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACT_PATTERN }}
         path: ./build/${{ env.ARTIFACT_PATTERN }}


### PR DESCRIPTION
Fixes deprecation warnings such as:
```text
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```