### PR TITLE
Update Ubuntu 20.04 amd64 Qt package

### DIFF
--- a/hifi_qt.py
+++ b/hifi_qt.py
@@ -157,7 +157,7 @@ endif()
                 u_major = int( distro.major_version() or '0' )
                 if distro.id() == 'ubuntu' or distro.id() == 'linuxmint':
                     if (distro.id() == 'ubuntu' and u_major == 20) or distro.id() == 'linuxmint' and u_major == 20:
-                        self.qtUrl = self.assets_url + '/dependencies/qt5/qt5-install-5.15.10-2023.10.01-kde_d2122ee587cceb5b2f4130b7074f86db9aca570e-ubuntu-20.04-amd64.tar.xz'
+                        self.qtUrl = self.assets_url + '/dependencies/qt5/qt5-install-5.15.14-2024.06.17-kde_570f5b2105df1ea052bec0d6dbf8a00137274371-ubuntu-20.04-amd64.tar.xz'
                     elif (distro.id() == 'ubuntu' and u_major > 20) or (distro.id() == 'linuxmint' and u_major > 20):
                         self.__no_qt_package_error()
                     else:

--- a/tools/qt-builder/Dockerfile_Ubuntu_20.04_Qt5
+++ b/tools/qt-builder/Dockerfile_Ubuntu_20.04_Qt5
@@ -4,11 +4,11 @@
 # - Check which commit you are building https://invent.kde.org/qt/qt/qt5/-/tree/kde/5.15
 # - Adjust this file to include the commit hash you are building, the date, the number of threads you want to use (-j10), the platform, and the Qt and QtWebEngine versions.
 #     Keep in mind that building Qt requires a lot of memory. You should have over 1.2GiB of system memory available per thread.
-# - Run the build process with something like `PROGRESS_NO_TRUNC=1 DOCKER_BUILDKIT=1 BUILDKIT_STEP_LOG_MAX_SIZE=-1 docker build --progress plain -t overte-qt5:5.15.10-2023.10.01-kde_d2122ee587cceb5b2f4130b7074f86db9aca570e -f Dockerfile_Ubuntu_20.04_Qt5 .`
+# - Run the build process with something like `PROGRESS_NO_TRUNC=1 DOCKER_BUILDKIT=1 BUILDKIT_STEP_LOG_MAX_SIZE=-1 docker build --progress plain -t overte-qt5:5.15.14-2024.06.17-kde_570f5b2105df1ea052bec0d6dbf8a00137274371 -f Dockerfile_Ubuntu_20.04_Qt5 .`
 #     Buildkit is used to cache intermittent steps in case you need to modify something afterwards.
 # - Once the build has completed, create a container from the image and export the created Qt package.
-#     `docker create --name extract overte-qt5:5.15.10-2023.10.01-kde_d2122ee587cceb5b2f4130b7074f86db9aca570e`
-#     `docker cp extract:qt5-install-5.15.10-2023.10.01-kde_d2122ee587cceb5b2f4130b7074f86db9aca570e-ubuntu-20.04-amd64.tar.xz /path/on/host`
+#     `docker create --name extract overte-qt5:5.15.14-2024.06.17-kde_570f5b2105df1ea052bec0d6dbf8a00137274371`
+#     `docker cp extract:qt5-install-5.15.14-2024.06.17-kde_570f5b2105df1ea052bec0d6dbf8a00137274371-ubuntu-20.04-amd64.tar.xz /path/on/host`
 #     `docker rm extract`
 
 FROM ubuntu:20.04
@@ -58,12 +58,12 @@ WORKDIR ../../qt5-install
 RUN find . -name \*.prl -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
 
 # Overwrite QtWebengine version to work around version conflicts
-RUN find . -name \Qt5WebEngine*Config.cmake -exec sed -i '' -e 's/5\.15\.14/5\.15\.10/g' {} \;
-RUN cp lib/libQt5WebEngine.so.5.15.14 lib/libQt5WebEngine.so.5.15.10
-RUN cp lib/libQt5WebEngineCore.so.5.15.14 lib/libQt5WebEngineCore.so.5.15.10
-RUN cp lib/libQt5WebEngineWidgets.so.5.15.14 lib/libQt5WebEngineWidgets.so.5.15.10
-RUN cp lib/libQt5Pdf.so.5.15.14 lib/libQt5Pdf.so.5.15.10
-RUN cp lib/libQt5PdfWidgets.so.5.15.14 lib/libQt5PdfWidgets.so.5.15.10
+RUN find . -name \Qt5WebEngine*Config.cmake -exec sed -i '' -e 's/5\.15\.17/5\.15\.14/g' {} \;
+RUN cp lib/libQt5WebEngine.so.5.15.17 lib/libQt5WebEngine.so.5.15.14
+RUN cp lib/libQt5WebEngineCore.so.5.15.17 lib/libQt5WebEngineCore.so.5.15.14
+RUN cp lib/libQt5WebEngineWidgets.so.5.15.17 lib/libQt5WebEngineWidgets.so.5.15.14
+RUN cp lib/libQt5Pdf.so.5.15.17 lib/libQt5Pdf.so.5.15.14
+RUN cp lib/libQt5PdfWidgets.so.5.15.17 lib/libQt5PdfWidgets.so.5.15.14
 
 
 COPY ./qt.conf ./bin/
@@ -71,4 +71,4 @@ COPY ./qt.conf ./bin/
 RUN cp ../qt5-build/config.summary ./
 
 WORKDIR ..
-RUN XZ_OPT='-T0' tar -Jcvf qt5-install-5.15.10-2023.10.01-kde_d2122ee587cceb5b2f4130b7074f86db9aca570e-ubuntu-20.04-amd64.tar.xz qt5-install
+RUN XZ_OPT='-T0' tar -Jcvf qt5-install-5.15.14-2024.06.17-kde_570f5b2105df1ea052bec0d6dbf8a00137274371-ubuntu-20.04-amd64.tar.xz qt5-install


### PR DESCRIPTION
Update Ubuntu 20.04 amd64 Qt package to 5.15.14 with QtWebEngine 5.15.17.

Quickly smoke-tested on: https://public.overte.org/build/overte/PR1032/Overte-PR1032-f928307-debug-x86_64.AppImage