### PR TITLE
Fix unhandled std::bad_weak_ptr

### DIFF
--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -2054,7 +2054,7 @@ void ScriptManager::loadEntityScript(const EntityItemID& entityID, const QString
     std::weak_ptr<ScriptManager> weakRef(shared_from_this());
     scriptCache->getScriptContents(entityScript,
         [this, weakRef, entityScript, entityID](const QString& url, const QString& contents, bool isURL, bool success, const QString& status) {
-            std::shared_ptr<ScriptManager> strongRef(weakRef);
+            std::shared_ptr<ScriptManager> strongRef = weakRef.lock();
             if (!strongRef) {
                 qCWarning(scriptengine) << "loadEntityScript.contentAvailable -- ScriptManager was deleted during getScriptContents!!";
                 return;


### PR DESCRIPTION
This should fix a large portion (but not all) of crashes when changing domains, especially script-heavy ones.
Fixes https://github.com/overte-org/overte/issues/1036