### PR TITLE
Remove note about secure WebSockets not being supported.

### DIFF
--- a/libraries/script-engine/src/WebSocketClass.h
+++ b/libraries/script-engine/src/WebSocketClass.h
@@ -33,8 +33,6 @@ class ScriptEngine;
  * <p>Create using <code>new WebSocket(...)</code> in Interface, client entity, avatar, and server entity scripts, or the 
  * {@link WebSocketServer} class in server entity and assignment client scripts.
  *
- * <p><strong>Note:</strong> Does not support secure, <code>wss:</code> protocol.</p>
- *
  * @class WebSocket
  * @param {string|WebSocket} urlOrWebSocket - The URL to connect to or an existing {@link WebSocket} to reuse the connection of.
  *


### PR DESCRIPTION
It just works, even though nobody touched the code in years. Maybe it was broken in older Qt versions?

You can test it out using this script that Silverfish made: https://silverfish-freestuff.s3.amazonaws.com/TestStuff/testWS.js