### PR TITLE
Allow events from VR keyboard to overlay UI

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8598,6 +8598,14 @@ SharedSoundPointer Application::getSampleSound() const {
     return _sampleSound;
 }
 
+void Application::showVRKeyboardForHudUI(bool show) {
+    if (show) {
+        DependencyManager::get<Keyboard>()->setRaised(true, true);
+    } else {
+        DependencyManager::get<Keyboard>()->setRaised(false);
+    }
+}
+
 void Application::loadLODToolsDialog() {
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -431,6 +431,16 @@ public slots:
     Q_INVOKABLE void loadAddAvatarBookmarkDialog() const;
     Q_INVOKABLE void loadAvatarBrowser() const;
     Q_INVOKABLE SharedSoundPointer getSampleSound() const;
+    /**
+     * @brief Shows/hides VR keyboard input for Overlay windows
+     *
+     * This is used by QML scripts to show and hide VR keyboard. Unlike JS API Keyboard.raised = true,
+     * with showVRKeyboardForHudUI the input is passed to the active window on the overlay first.
+     *
+     * @param show
+     * If set to true, then keyboard is shown, for false it's hidden.
+     */
+    Q_INVOKABLE void showVRKeyboardForHudUI(bool show);
 
     void showDialog(const QUrl& widgetUrl, const QUrl& tabletUrl, const QString& name) const;
 

--- a/interface/src/ui/Keyboard.cpp
+++ b/interface/src/ui/Keyboard.cpp
@@ -585,8 +585,8 @@ void Keyboard::handleTriggerBegin(const QUuid& id, const PointerEvent& event) {
 
         QKeyEvent* pressEvent = new QKeyEvent(QEvent::KeyPress, scanCode, Qt::NoModifier, keyString);
         QKeyEvent* releaseEvent = new QKeyEvent(QEvent::KeyRelease, scanCode, Qt::NoModifier, keyString);
-        QCoreApplication::postEvent(QCoreApplication::instance(), pressEvent);
-        QCoreApplication::postEvent(QCoreApplication::instance(), releaseEvent);
+        QCoreApplication::postEvent(qApp->getPrimaryWidget(), pressEvent);
+        QCoreApplication::postEvent(qApp->getPrimaryWidget(), releaseEvent);
 
         if (!getPreferMalletsOverLasers()) {
             key.startTimer(KEY_PRESS_TIMEOUT_MS);

--- a/interface/src/ui/Keyboard.cpp
+++ b/interface/src/ui/Keyboard.cpp
@@ -303,10 +303,13 @@ bool Keyboard::isRaised() const {
     return resultWithReadLock<bool>([&] { return _raised; });
 }
 
-void Keyboard::setRaised(bool raised) {
+void Keyboard::setRaised(bool raised, bool inputToHudUI) {
 
     bool isRaised;
     withReadLock([&] { isRaised = _raised; });
+
+    _inputToHudUI = inputToHudUI;
+
     if (isRaised != raised) {
         raiseKeyboardAnchor(raised);
         raiseKeyboard(raised);
@@ -585,8 +588,13 @@ void Keyboard::handleTriggerBegin(const QUuid& id, const PointerEvent& event) {
 
         QKeyEvent* pressEvent = new QKeyEvent(QEvent::KeyPress, scanCode, Qt::NoModifier, keyString);
         QKeyEvent* releaseEvent = new QKeyEvent(QEvent::KeyRelease, scanCode, Qt::NoModifier, keyString);
-        QCoreApplication::postEvent(qApp->getPrimaryWidget(), pressEvent);
-        QCoreApplication::postEvent(qApp->getPrimaryWidget(), releaseEvent);
+        if (_inputToHudUI) {
+            QCoreApplication::postEvent(qApp->getPrimaryWidget(), pressEvent);
+            QCoreApplication::postEvent(qApp->getPrimaryWidget(), releaseEvent);
+        } else {
+            QCoreApplication::postEvent(QCoreApplication::instance(), pressEvent);
+            QCoreApplication::postEvent(QCoreApplication::instance(), releaseEvent);
+        }
 
         if (!getPreferMalletsOverLasers()) {
             key.startTimer(KEY_PRESS_TIMEOUT_MS);

--- a/interface/src/ui/Keyboard.h
+++ b/interface/src/ui/Keyboard.h
@@ -93,7 +93,7 @@ public:
     void createKeyboard();
     void registerKeyboardHighlighting();
     bool isRaised() const;
-    void setRaised(bool raised);
+    void setRaised(bool raised, bool inputToHudUI = false);
     void setResetKeyboardPositionOnRaise(bool reset);
     bool isPassword() const;
     void setPassword(bool password);
@@ -190,6 +190,8 @@ private:
     QSet<QUuid> _itemsToIgnore;
     std::vector<QHash<QUuid, Key>> _keyboardLayers;
 
+    // Send keyboard events to hud UI if true
+    std::atomic<bool> _inputToHudUI { false };
     bool _created { false };
 };
 


### PR DESCRIPTION
Fixes https://github.com/overte-org/overte/issues/1044
Still work in progress, since there's no way to deactivate overlay windows from VR controllers yet.