### PR TITLE
Cut back on master builds.

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -10,8 +10,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
   push:
-    branches:
-      - master
     tags:
       # Release tags. E.g. 2024.06.1
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -244,14 +244,12 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: cat ./_CPack_Packages/win64/NSIS/NSISOutput.log
 
-    - name: Upload artifact
-      if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS') || matrix.build_type == 'android'  # Automatic Linux packaging is not implemented
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.s3_access_key_id }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.s3_secret_access_key }}
-      run: $PYTHON_EXEC $GITHUB_WORKSPACE/tools/ci-scripts/upload.py
+    - name: Upload artifact to GitHub
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ARTIFACT_PATTERN }}
+        path: ./build/${{ env.ARTIFACT_PATTERN }}
+        if-no-files-found: error
 
     #- name: Archive symbols
     #  if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')


### PR DESCRIPTION
This PR disables uploading Windows master builds to S3 (instead they will be uploaded to the temporary GitHub artifact storage) to save costs and hassle with the S3.
It also disables Linux server master builds, because building 14 server packages seems way overkill. They hog servers and also cost money.