### PR TITLE
Custom shader fallbacks

### DIFF
--- a/interface/resources/shaders/errorShader.frag
+++ b/interface/resources/shaders/errorShader.frag
@@ -1,0 +1,30 @@
+vec3 getErrorColor() {
+    vec3 positionWS = iWorldOrientation * (_positionMS.xyz * iWorldScale) + iWorldPosition;
+    float checkSize = 0.1;
+    vec3 edges = round(mod(positionWS, vec3(checkSize)) / checkSize);
+    float checkerboard = mod(edges.x + edges.y + edges.z, 2.0);
+    return mix(vec3(1, 0, 1), vec3(0.0), checkerboard);
+}
+
+// version 1
+vec3 getProceduralColor() {
+    return getErrorColor();
+}
+
+// version 2
+float getProceduralColors(inout vec3 diffuse, inout vec3 specular, inout float shininess) {
+    diffuse = getErrorColor();
+    return 1.0;
+}
+
+// version 3
+float getProceduralFragment(inout ProceduralFragment data) {
+    data.emissive = getErrorColor();
+    return 1.0;
+}
+
+// version 4
+float getProceduralFragmentWithPosition(inout ProceduralFragmentWithPosition data) {
+    data.emissive = getErrorColor();
+    return 1.0;
+}

--- a/interface/resources/shaders/errorSkyboxShader.frag
+++ b/interface/resources/shaders/errorSkyboxShader.frag
@@ -1,0 +1,7 @@
+vec3 getSkyboxColor() {
+    vec3 normal = normalize(_normal);
+    float checkSize = 0.1;
+    vec3 edges = round(mod(normal, vec3(checkSize)) / checkSize);
+    float checkerboard = mod(edges.x + edges.y + edges.z, 2.0);
+    return mix(vec3(1, 0, 1), vec3(0.0), checkerboard);
+}

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -540,7 +540,7 @@ Menu::Menu() {
 
     action = addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::MaterialProceduralShaders, 0, false);
     connect(action, &QAction::triggered, [action] {
-        ModelMeshPartPayload::enableMaterialProceduralShaders = action->isChecked();
+        Procedural::enableProceduralShaders = action->isChecked();
     });
 
     {

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -379,7 +379,7 @@ void Procedural::prepare(gpu::Batch& batch,
 
         _proceduralPipelines[key] = gpu::Pipeline::create(program, key.isTransparent() ? _transparentState : _opaqueState);
 
-        // Error falllback: pink checkerboard
+        // Error fallback: pink checkerboard
         if (_errorFallbackFragmentSource.isEmpty()) {
             QFile file(_errorFallbackFragmentPath);
             file.open(QIODevice::ReadOnly);
@@ -392,7 +392,7 @@ void Procedural::prepare(gpu::Batch& batch,
         gpu::ShaderPointer errorProgram = gpu::Shader::createProgram(errorVertexShader, errorFragmentShader);
         _errorPipelines[key] = gpu::Pipeline::create(errorProgram, _opaqueState);
 
-        // Disabled falllback: nothing
+        // Disabled fallback: nothing
         vertexSource.replacements.erase(PROCEDURAL_BLOCK);
         fragmentSource.replacements.erase(PROCEDURAL_BLOCK);
         gpu::ShaderPointer disabledVertexShader = gpu::Shader::createVertex(vertexSource);

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -124,13 +124,15 @@ public:
     gpu::Shader::Source _opaqueFragmentSource;
     gpu::Shader::Source _transparentFragmentSource;
 
-    QString _errorFallbackFragmentSource;
+    QString _errorFallbackFragmentPath;
 
     gpu::StatePointer _opaqueState { std::make_shared<gpu::State>() };
     gpu::StatePointer _transparentState { std::make_shared<gpu::State>() };
 
     static std::function<void(gpu::StatePointer)> opaqueStencil;
     static std::function<void(gpu::StatePointer)> transparentStencil;
+
+    static bool enableProceduralShaders;
 
 protected:
     // DO NOT TOUCH
@@ -178,7 +180,7 @@ protected:
     bool _shaderDirty { true };
     bool _uniformsDirty { true };
 
-    QString _errorFallbackFragmentPath;
+    QString _errorFallbackFragmentSource;
 
     // Rendering objects
     UniformLambdas _uniforms;
@@ -186,6 +188,7 @@ protected:
 
     std::unordered_map<ProceduralProgramKey, gpu::PipelinePointer> _proceduralPipelines;
     std::unordered_map<ProceduralProgramKey, gpu::PipelinePointer> _errorPipelines;
+    std::unordered_map<ProceduralProgramKey, gpu::PipelinePointer> _disabledPipelines;
 
     StandardInputs _standardInputs;
     gpu::BufferPointer _standardInputsBuffer;

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -124,6 +124,8 @@ public:
     gpu::Shader::Source _opaqueFragmentSource;
     gpu::Shader::Source _transparentFragmentSource;
 
+    QString _errorFallbackFragmentSource;
+
     gpu::StatePointer _opaqueState { std::make_shared<gpu::State>() };
     gpu::StatePointer _transparentState { std::make_shared<gpu::State>() };
 
@@ -176,11 +178,14 @@ protected:
     bool _shaderDirty { true };
     bool _uniformsDirty { true };
 
+    QString _errorFallbackFragmentPath;
+
     // Rendering objects
     UniformLambdas _uniforms;
     NetworkTexturePointer _channels[MAX_PROCEDURAL_TEXTURE_CHANNELS];
 
     std::unordered_map<ProceduralProgramKey, gpu::PipelinePointer> _proceduralPipelines;
+    std::unordered_map<ProceduralProgramKey, gpu::PipelinePointer> _errorPipelines;
 
     StandardInputs _standardInputs;
     gpu::BufferPointer _standardInputsBuffer;

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -22,6 +22,8 @@ ProceduralSkybox::ProceduralSkybox(uint64_t created) : graphics::Skybox(), _crea
     _procedural._vertexSource = shader::Source::get(shader::graphics::vertex::skybox);
     _procedural._opaqueFragmentSource = shader::Source::get(shader::procedural::fragment::proceduralSkybox);
 
+    _procedural._errorFallbackFragmentPath = ":" + QUrl("qrc:///shaders/errorSkyboxShader.frag").path();
+
     _procedural.setDoesFade(false);
 
     // Adjust the pipeline state for background using the stencil test

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -25,8 +25,6 @@
 
 using namespace render;
 
-bool ModelMeshPartPayload::enableMaterialProceduralShaders = false;
-
 ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int meshIndex, int partIndex, int shapeIndex,
                                            const Transform& transform, const uint64_t& created) :
     _meshIndex(meshIndex),
@@ -345,9 +343,6 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
     }
 
     if (_shapeKey.hasOwnPipeline()) {
-        if (!(enableMaterialProceduralShaders)) {
-            return;
-        }
         auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(_drawMaterials.top().material);
         auto& schema = _drawMaterials.getSchemaBuffer().get<graphics::MultiMaterial::Schema>();
         glm::vec4 outColor = glm::vec4(ColorUtils::tosRGBVec3(schema._albedo), schema._opacity);

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -68,8 +68,6 @@ public:
 
     void setBlendshapeBuffer(const std::unordered_map<int, gpu::BufferPointer>& blendshapeBuffers, const QVector<int>& blendedMeshSizes);
 
-    static bool enableMaterialProceduralShaders;
-
 private:
     void initCache(const ModelPointer& model, int shapeID);
 


### PR DESCRIPTION
closes #640 

currently, if a shader fails to compile, it's undefined behavior and can cause weird glitches.  also, if shaders are disabled, the object just doesn't render at all.  (also, disabling shaders only disables them on models, not materials, shapes, skyboxes, and soon GPU particles)

this adds a pink checkerboard fallback for when a shader fails to compile:

![image](https://github.com/overte-org/overte/assets/53453710/c2b7540a-a48f-4c36-801d-5bb6ec8ea448)

here's an example material entity with an invalid shader:
```
Entities.addEntity({
    type: "Material",
    position: MyAvatar.position,
    materialURL: "materialData",
    priority: 1,
    materialData: JSON.stringify({
        materials: {
            model: "hifi_shader_simple",
            procedural: {
                version: 3,
                fragmentShaderURL: "https://gist.github.com/HifiExperiments/2f087e240ea340577de04bba662c4f47/raw/fd21fd15134da0eafc4304538d8a9db1463c5bf3/errorShader.fs",
            }
        }
    })
});
```

and just completely removes all effects when procedural shaders are disabled (and also makes the disable flag affect everything, not just models):

![image](https://github.com/overte-org/overte/assets/53453710/8ef4ab26-4184-4539-810e-985aadc38775)

(I could change either of these if there's something else that people think would be better)

## Funding

This project is funded through [NGI0 Entrust](https://nlnet.nl/entrust), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Overte).

[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/entrust)