### PR TITLE
Update make-rpm-server to remove `-` characters.

### DIFF
--- a/pkg-scripts/make-rpm-server
+++ b/pkg-scripts/make-rpm-server
@@ -13,7 +13,8 @@ fi
 # The regex below extracts the path from the VCPKG_INSTALL_ROOT variable. Said variable gets populated during the CMake step.
 VCPKG_INSTALL_ROOT=`grep VCPKG_INSTALL_ROOT $OVERTE/build/vcpkg.cmake | perl -ne 'm/set\(VCPKG_INSTALL_ROOT\s+\"(.*?)\"/; print $1'`
 
-VERSION=${RPMVERSION}
+# Remove minus character from version numbers, because rpmtool doesn't allow them.
+VERSION=${RPMVERSION//-}
 
 if [ "$OVERTE_USE_SYSTEM_QT" = "" ]; then
 SOFILES=`ls \


### PR DESCRIPTION
This should prevent errors such as: Illegal char '-' (0x2d) in: Version:        2024.07.1-rc1.3ddd205