### PR TITLE
Fix GHA building hundreds of servers

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -26,8 +26,8 @@ env:
 
 jobs:
   build:
-    # Only run master or tagged builds, or PRs if labeled as "server"
-    if: contains( github.event.pull_request.labels.*.name, 'server') || github.event_name != 'pull_request'
+    # Only run master or tagged builds, or PRs when labeled as "server"
+    if: github.event.label.name == 'server'|| github.event_name != 'pull_request'
     name: "${{matrix.os}}, ${{matrix.arch}}"
     strategy:
       matrix:


### PR DESCRIPTION
Every label triggers its own event, so if you had the server label set, it would build servers for *every* label.
I changed it now to only build when the server label has been set. Pushing to the PR will not trigger another build until the server label is removed and added again.