### PR TITLE
Remove remnants of RELEASE_NAME.

### DIFF
--- a/cmake/macros/GenerateInstallers.cmake
+++ b/cmake/macros/GenerateInstallers.cmake
@@ -5,7 +5,7 @@
 #  Created by Leonardo Murillo on 12/16/2015.
 #  Copyright 2015 High Fidelity, Inc.
 #  Copyright 2021 Vircadia contributors.
-#  Copyright 2022 Overte e.V.
+#  Copyright 2022-2024 Overte e.V.
 #
 #  Distributed under the Apache License, Version 2.0.
 #  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -33,8 +33,7 @@ macro(GENERATE_INSTALLERS)
   set(CPACK_PACKAGE_NAME ${_DISPLAY_NAME})
   set(CPACK_PACKAGE_VENDOR "Overte")
   set(CPACK_PACKAGE_VERSION ${BUILD_VERSION})
-  # There is some sort of bug which adds a "-" between the BUILD_VERSION and the RELEASE_NAME.
-  set(CPACK_PACKAGE_FILE_NAME "Overte${_PACKAGE_NAME_EXTRA}-${BUILD_VERSION}${RELEASE_NAME}")
+  set(CPACK_PACKAGE_FILE_NAME "Overte${_PACKAGE_NAME_EXTRA}-${BUILD_VERSION}")
   set(CPACK_NSIS_DISPLAY_NAME ${_DISPLAY_NAME})
   set(CPACK_NSIS_PACKAGE_NAME ${_DISPLAY_NAME})
   set(CPACK_NSIS_COMPRESSOR "LZMA")

--- a/interface/resources/qml/hifi/dialogs/TabletAboutDialog.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAboutDialog.qml
@@ -4,6 +4,7 @@
 //  Created by David Rowe on 18 Apr 2017
 //  Copyright 2017 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -39,7 +40,7 @@ Rectangle {
                 color: "white"
             }
             RalewayRegular {
-                text: "Build " + About.buildVersion + " " + About.releaseName
+                text: "Build " + About.buildVersion
                 size: 16
                 color: "white"
             }


### PR DESCRIPTION
Apparently, I missed some in my previous PR https://github.com/overte-org/overte/pull/1039/.
This gets rid of the `undefined` in our About dialog.