### PR TITLE
Add mouseLook script to default scripts.

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -47,6 +47,7 @@ var DEFAULT_SCRIPTS_SEPARATE = [
     "communityScripts/notificationCore/notificationCore.js",
     "simplifiedUI/ui/simplifiedNametag/simplifiedNametag.js",
     {"stable": "system/more/app-more.js", "beta": "https://more.overte.org/more/app-more.js"},
+	"system/controllers/mouseLook.js",
     "communityScripts/chat/FloofChat.js",
     //"system/chat.js"
 ];


### PR DESCRIPTION
Mouse look is a feature available in the Overte control settings, however it is not functional without this script running. When you clear running scripts and reload all scripts, mouseLook never gets added, breaking the functionality. 