### PR TITLE
Hard code link colors in Armored Chat

### DIFF
--- a/scripts/communityScripts/armored-chat/armored_chat.qml
+++ b/scripts/communityScripts/armored-chat/armored_chat.qml
@@ -510,7 +510,7 @@ Rectangle {
         mess = mess.replace(arrow, "&lt;");
 
         var link = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
-        mess = mess.replace(link, (match) => {return "<a onclick='Window.openUrl("+match+")' href='" + match + "'>" + match + "</a> <a onclick='Window.openUrl("+match+")'>⮺</a>"});
+        mess = mess.replace(link, (match) => {return `<a style="color:#4EBAFD" onclick='Window.openUrl("+match+")' href='` + match + `'>` + match + `</a> <a onclick='Window.openUrl(`+match+`)'>⮺</a>`});
 
         var newline = /\n/gi;
         mess = mess.replace(newline, "<br>");


### PR DESCRIPTION
Fixes #1082 

Links are rendered differently on my machine than on the typical machine. I neglected to hard code a link color as I didn't notice the problem.

Examples:
https://webaim.org/resources/contrastchecker/?fcolor=1005FB&bcolor=262626
https://webaim.org/resources/contrastchecker/?fcolor=1005FB&bcolor=1A1A1A