### PR TITLE
Fix controllerScripts uncaught exception.

### DIFF
--- a/scripts/system/controllers/controllerScripts.js
+++ b/scripts/system/controllers/controllerScripts.js
@@ -58,7 +58,7 @@ function runDefaultsTogether() {
 function runDefaultsSeparately() {
     for (var i in CONTOLLER_SCRIPTS) {
         if (CONTOLLER_SCRIPTS.hasOwnProperty(i)) {
-            print("loading " + CONTOLLER_SCRIPTS[j]);
+            print("loading " + CONTOLLER_SCRIPTS[i]);
             Script.load(CONTOLLER_SCRIPTS[i]);
         }
     }


### PR DESCRIPTION
Turns out this issue was very simple. There is a error in the variable name when printing to console.
Fixing this issue properly launches scripts without an exception. 