### PR TITLE
Fix wireshark dissector

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, const char* argv[]) {
     );
     QCommandLineOption protocolVersionOption(
         "protocolVersion",
-        "Writes the protocol version base64 signature to a file?",
+        "Writes the protocol version base64 signature to a file",
         "path"
     );
     QCommandLineOption noUpdaterOption(

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -130,6 +130,10 @@ void sendWrongProtocolVersionsSignature(bool sendWrongVersion) {
 
 static QByteArray protocolVersionSignature;
 static QString protocolVersionSignatureBase64;
+static QString protocolVersionSignatureHex;
+static QMap<PacketType, uint8_t> protocolVersionMap;
+
+
 static void ensureProtocolVersionsSignature() {
     static std::once_flag once;
     std::call_once(once, [&] {
@@ -139,12 +143,14 @@ static void ensureProtocolVersionsSignature() {
         stream << numberOfProtocols;
         for (uint8_t packetType = 0; packetType < numberOfProtocols; packetType++) {
             uint8_t packetTypeVersion = static_cast<uint8_t>(versionForPacketType(static_cast<PacketType>(packetType)));
+            protocolVersionMap[static_cast<PacketType>(packetType)] = packetTypeVersion;
             stream << packetTypeVersion;
         }
         QCryptographicHash hash(QCryptographicHash::Md5);
         hash.addData(buffer);
         protocolVersionSignature = hash.result();
         protocolVersionSignatureBase64 = protocolVersionSignature.toBase64();
+        protocolVersionSignatureHex = protocolVersionSignature.toHex(0);
     });
 }
 QByteArray protocolVersionsSignature() {
@@ -160,4 +166,14 @@ QByteArray protocolVersionsSignature() {
 QString protocolVersionsSignatureBase64() {
     ensureProtocolVersionsSignature();
     return protocolVersionSignatureBase64;
+}
+
+QString protocolVersionsSignatureHex() {
+    ensureProtocolVersionsSignature();
+    return protocolVersionSignatureHex;
+}
+
+QMap<PacketType, uint8_t> protocolVersionsSignatureMap() {
+    ensureProtocolVersionsSignature();
+    return protocolVersionMap;
 }

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -31,8 +31,15 @@ class PacketTypeEnum {
     Q_GADGET
     Q_ENUMS(Value)
 public:
-    // If adding a new packet packetType, you can replace one marked usable or add at the end.
-    // This enum must hold 256 or fewer packet types (so the value is <= 255) since it is statically typed as a uint8_t
+
+    /**
+     * @brief Packet type identifier
+     *
+     * Identifies the type of packet being sent.
+     *
+     * @note If adding a new packet packetType, you can replace one marked usable or add at the end.
+     * @note This enum must hold 256 or fewer packet types (so the value is <= 255) since it is statically typed as a uint8_t
+     */
     enum class Value : uint8_t {
         Unknown,
         DomainConnectRequestPending,
@@ -143,6 +150,8 @@ public:
         NUM_PACKET_TYPE
     };
 
+    Q_ENUM(Value)
+
     const static QHash<PacketTypeEnum::Value, PacketTypeEnum::Value> getReplicatedPacketMapping() {
         const static QHash<PacketTypeEnum::Value, PacketTypeEnum::Value> REPLICATED_PACKET_MAPPING {
             { PacketTypeEnum::Value::MicrophoneAudioNoEcho, PacketTypeEnum::Value::ReplicatedMicrophoneAudioNoEcho },
@@ -219,9 +228,59 @@ const int NUM_BYTES_MD5_HASH = 16;
 // NOTE: There is a max limit of 255, hopefully we have a better way to manage this by then.
 typedef uint8_t PacketVersion;
 
+/**
+ * @brief Returns the version number of the given packet type
+ *
+ * If the implementation of a packet type is modified in an incompatible way, the implementation
+ * of this function needs to be modified to return an incremented value.
+ *
+ * This is used to determine whether the protocol is compatible between client and server.
+ *
+ * @note Version is limited to a max of 255.
+ *
+ * @param packetType Type of packet
+ * @return PacketVersion Version
+ */
 PacketVersion versionForPacketType(PacketType packetType);
-QByteArray protocolVersionsSignature(); /// returns a unique signature for all the current protocols
+
+/**
+ * @brief Returns a unique signature for all the current protocols
+ *
+ * This computes a MD5 hash that expresses the state of the protocol's specification. The calculation
+ * is done in ensureProtocolVersionsSignature and accounts for the following:
+ *
+ * * Number of known packet types
+ * * versionForPacketType(type) for each packet type.
+ *
+ * There's no provision for backwards compatibility, anything that changes this calculation is a protocol break.
+ *
+ * @return QByteArray MD5 digest as a byte array
+ */
+QByteArray protocolVersionsSignature();
+
+/***
+ * @brief Returns a unique signature for all the current protocols
+ *
+ * Same as protocolVersionsSignature(), in base64.
+ */
 QString protocolVersionsSignatureBase64();
+
+/***
+ * @brief Returns a unique signature for all the current protocols
+ *
+ * Same as protocolVersionsSignature(), in hex;
+ */
+QString protocolVersionsSignatureHex();
+
+/***
+ * @brief Returns the data used to compute the protocol version
+ *
+ * The key is the packet type. The value is the version for that packet type.
+ *
+ * Used for aiding in development.
+ */
+QMap<PacketType, uint8_t> protocolVersionsSignatureMap();
+
 
 #if (PR_BUILD || DEV_BUILD)
 void sendWrongProtocolVersionsSignature(bool sendWrongVersion); /// for debugging version negotiation
@@ -427,5 +486,6 @@ enum class AvatarQueryVersion : PacketVersion {
     SendMultipleFrustums = 21,
     ConicalFrustums = 22
 };
+
 
 #endif // hifi_PacketHeaders_h

--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -259,6 +259,7 @@ function p_hfudt.dissector(buf, pinfo, tree)
       type:append_text(" (".. control_types[shifted_type][1] .. ")")
 
       subtree:add(f_control_type_text, control_types[shifted_type][1])
+      pinfo.cols.info:append(" [" .. control_types[shifted_type][1] .. "]")
     end
 
     if shifted_type == 0 then
@@ -337,10 +338,12 @@ function p_hfudt.dissector(buf, pinfo, tree)
     local packet_type = buf(payload_offset, 1):le_uint()
     local ptype = subtree:add_le(f_type, buf(payload_offset, 1))
     local packet_type_text = packet_types[packet_type]
+
     if packet_type_text ~= nil then
       subtree:add(f_type_text, packet_type_text)
       -- if we know this packet type then add the name
       ptype:append_text(" (".. packet_type_text .. ")")
+      pinfo.cols.info:append(" [" .. packet_type_text .. "]")
     end
 
     -- read the version

--- a/tools/dissectors/2-hf-audio.lua
+++ b/tools/dissectors/2-hf-audio.lua
@@ -1,5 +1,5 @@
 print("Loading hf-audio")
-
+bit32 = require("bit32")
 -- create the audio protocol
 p_hf_audio = Proto("hf-audio", "HF Audio Protocol")
 

--- a/tools/dissectors/3-hf-avatar.lua
+++ b/tools/dissectors/3-hf-avatar.lua
@@ -1,4 +1,5 @@
 print("Loading hf-avatar")
+bit32 = require("bit32")
 
 -- create the avatar protocol
 p_hf_avatar = Proto("hf-avatar", "HF Avatar Protocol")

--- a/tools/dissectors/4-hf-entity.lua
+++ b/tools/dissectors/4-hf-entity.lua
@@ -1,4 +1,5 @@
 print("Loading hf-entity")
+bit32 = require("bit32")
 
 -- create the entity protocol
 p_hf_entity = Proto("hf-entity", "HF Entity Protocol")

--- a/tools/dissectors/5-hf-domain.lua
+++ b/tools/dissectors/5-hf-domain.lua
@@ -1,4 +1,6 @@
 -- create the domain protocol
+print("Loading hf-domain")
+bit32 = require("bit32")
 p_hf_domain = Proto("hf-domain", "HF Domain Protocol")
 
 -- domain packet fields

--- a/tools/dissectors/README.md
+++ b/tools/dissectors/README.md
@@ -1,14 +1,50 @@
-High Fidelity Wireshark Plugins
----------------------------------
+# High Fidelity Wireshark Plugins
 
-Install wireshark 2.4.6 or higher.
 
-Copy these lua files into c:\Users\username\AppData\Roaming\Wireshark\Plugins
+## Installation
 
-After a capture any detected High Fidelity Packets should be easily identifiable by one of the following protocols
 
-* HF-AUDIO - Streaming audio packets
-* HF-AVATAR - Streaming avatar mixer packets
-* HF-ENTITY - Entity server traffic
-* HF-DOMAIN - Domain server traffic
-* HFUDT - All other UDP traffic
+* Install wireshark 2.4.6 or higher.
+* Copy these lua files into `c:\Users\username\AppData\Roaming\Wireshark\Plugins` on Windows, or `$HOME/.local/lib/wireshark/plugins` on Linux.
+
+## Lua version
+
+This is a Lua plugin, which requires the bit32 module to be installed. You can find the Lua version wireshark uses in the About dialog, eg:
+
+    Version 4.2.5 (Git commit 798e06a0f7be).
+
+    Compiled (64-bit) using GCC 14.1.1 20240507 (Red Hat 14.1.1-1), with GLib
+    2.80.2, with Qt 6.7.0, with libpcap, with POSIX capabilities (Linux), with libnl
+    3, with zlib 1.3.0.zlib-ng, with PCRE2, with Lua 5.1.5, with GnuTLS 3.8.5 and
+
+This indicates Lua 5.1 is used (see on the last line)
+
+
+## Requirements
+
+On Fedora 40:
+
+* wireshark-devel
+* lua5.1-bit32
+
+
+## Usage
+
+After a capture any detected Overte Packets should be easily identifiable by one of the following protocols
+
+* `HF-AUDIO` - Streaming audio packets
+* `HF-AVATAR` - Streaming avatar mixer packets
+* `HF-ENTITY` - Entity server traffic
+* `HF-DOMAIN` - Domain server traffic
+* `HFUDT` - All other UDP traffic
+
+
+
+
+## Troubleshooting
+
+### attempt to index global 'bit32' (a nil value)
+
+`[Expert Info (Error/Undecoded): Lua Error: /home/dale/.local/lib/wireshark/plugins/1-hfudt.lua:207: attempt to index global 'bit32' (a nil value)]`
+
+See the installation requirements, you need to install the bit32 Lua module for the right Lua version.

--- a/tools/dissectors/README.md
+++ b/tools/dissectors/README.md
@@ -48,3 +48,26 @@ After a capture any detected Overte Packets should be easily identifiable by one
 `[Expert Info (Error/Undecoded): Lua Error: /home/dale/.local/lib/wireshark/plugins/1-hfudt.lua:207: attempt to index global 'bit32' (a nil value)]`
 
 See the installation requirements, you need to install the bit32 Lua module for the right Lua version.
+
+## Development hints
+
+
+* Symlink files from the development tree to  `$HOME/.local/lib/wireshark/plugins`, to have Wireshark work on the latest dissector code.
+* Capture packets for later analysis in a PCAPNG file.
+* Only save needed packets in the dump
+
+Decode on the commandline with:
+
+    tshark -r packets.pcapng.gz -V
+
+Decode only the first packet:
+
+    tshark -r packets.pcapng.gz -V -c 1
+
+### Useful tshark arguments
+
+* `-x` hex dump
+* `-c N` Only decode first N packets
+* `-O hfudt,hf-domain,hf-entity,hf-avatar,hf-audio` Only dump Overte protocol data, skip dumping UDP/etc parts.
+* `-V` decode protocols
+*


### PR DESCRIPTION
This fixes the Wireshark dissector, and updates it with some parts of the protocol that weren't up to date.

It's almost certainly still incomplete, but at least now it works.

Extended documentation for how to use it on Linux as well.