### PR TITLE
Create App: Revolutionary "Paste" Url buttons for the "Create Model", "Create Material" and "Create Voxels" UI

### DIFF
--- a/scripts/system/create/qml/NewMaterialDialog.qml
+++ b/scripts/system/create/qml/NewMaterialDialog.qml
@@ -2,9 +2,10 @@
 //  NewMaterialDialog.qml
 //  qml/hifi
 //
-//  Created by Sam Gondelman on 1/17/18
+//  Created by Sam Gondelman on January 17th, 2018
 //  Copyright 2018 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -55,9 +56,24 @@ Rectangle {
 
         Text {
             id: text1
-            text: qsTr("Material URL <i>(Optional)</i>")
+            text: qsTr("Material URL <i>(Optional)</i>&nbsp;&nbsp;&nbsp;")
             color: "#ffffff"
             font.pixelSize: 12
+        }
+
+        Button {
+            id: pasteBtn
+            text: "Paste"
+            font.pixelSize: 11
+            height: 16
+            width: 40
+            radius: 4
+            anchors.top: text1.top
+            anchors.left: text1.right
+            anchors.bottom: text1.bottom
+            onClicked: {
+                materialURL.paste()
+            }
         }
 
         TextInput {
@@ -65,7 +81,7 @@ Rectangle {
             height: 20
             text: qsTr("")
             color: "white"
-            anchors.top: text1.bottom
+            anchors.top: pasteBtn.bottom
             anchors.topMargin: 5
             anchors.left: parent.left
             anchors.leftMargin: 0

--- a/scripts/system/create/qml/NewModelDialog.qml
+++ b/scripts/system/create/qml/NewModelDialog.qml
@@ -2,9 +2,10 @@
 //  NewModelDialog.qml
 //  qml/hifi
 //
-//  Created by Seth Alves on 2017-2-10
+//  Created by Seth Alves on February 10th, 2017
 //  Copyright 2017 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -55,17 +56,30 @@ Rectangle {
 
         Text {
             id: text1
-            text: qsTr("Model URL <i>(.fbx, .fst, .glb, .gltf, .obj, .gz)</i>")
+            text: qsTr("Model URL <i>(.fbx, .fst, .glb, .gltf, .obj, .gz)</i>&nbsp;&nbsp;&nbsp;")
             color: "#ffffff"
             font.pixelSize: 12
         }
-
+        Button {
+            id: pasteBtn
+            text: "Paste"
+            font.pixelSize: 11
+            height: 16
+            width: 40
+            radius: 4
+            anchors.top: text1.top + 10
+            anchors.left: text1.right
+            anchors.bottom: text1.bottom
+            onClicked: {
+                modelURL.paste()
+            }
+        }
         TextInput {
             id: modelURL
             height: 20
             text: qsTr("")
             color: "white"
-            anchors.top: text1.bottom
+            anchors.top: pasteBtn.bottom
             anchors.topMargin: 5
             anchors.left: parent.left
             anchors.leftMargin: 0

--- a/scripts/system/create/qml/NewPolyVoxDialog.qml
+++ b/scripts/system/create/qml/NewPolyVoxDialog.qml
@@ -1,12 +1,12 @@
 //
 //  NewPolyVoxDialog.qml
-//  Created by dr Karol Suprynowicz on 2022.05.17.
+//  Created by dr Karol Suprynowicz on May 17th, 2022
 //  based on NewModelDialog.qml
 //  qml/hifi
 //
 //  Copyright 2017 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors
-//  Copyright 2022 Overte e.V.
+//  Copyright 2022-2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -117,9 +117,24 @@ Rectangle {
             id: text1
             anchors.top: texturePreset.bottom
             anchors.topMargin: 5
-            text: qsTr("X Texture URL")
+            text: qsTr("X Texture URL <i>&nbsp;&nbsp;&nbsp;</i>")
             color: "#ffffff"
             font.pixelSize: 12
+        }
+
+        Button {
+            id: pasteBtn1
+            text: "Paste"
+            font.pixelSize: 11
+            height: 16
+            width: 40
+            radius: 4
+            anchors.top: text1.top
+            anchors.left: text1.right
+            anchors.bottom: text1.bottom
+            onClicked: {
+                xTextureURL.paste()
+            }
         }
 
         TextInput {
@@ -127,7 +142,7 @@ Rectangle {
             height: 20
             text: qsTr("")
             color: "white"
-            anchors.top: text1.bottom
+            anchors.top: pasteBtn1.bottom
             anchors.topMargin: 5
             anchors.left: parent.left
             anchors.leftMargin: 0
@@ -167,11 +182,25 @@ Rectangle {
 
         Text {
             id: text2
-            text: qsTr("Y Texture URL")
+            text: qsTr("Y Texture URL <i>&nbsp;&nbsp;&nbsp;</i>")
             color: "#ffffff"
             font.pixelSize: 12
             anchors.top: textInputBox1.bottom
             anchors.topMargin: 5
+        }
+        Button {
+            id: pasteBtn2
+            text: "Paste"
+            font.pixelSize: 11
+            height: 16
+            width: 40
+            radius: 4
+            anchors.top: text2.top
+            anchors.left: text2.right
+            anchors.bottom: text2.bottom
+            onClicked: {
+                yTextureURL.paste()
+            }
         }
 
         TextInput {
@@ -179,7 +208,7 @@ Rectangle {
             height: 20
             text: qsTr("")
             color: "white"
-            anchors.top: text2.bottom
+            anchors.top: pasteBtn2.bottom
             anchors.topMargin: 5
             anchors.left: parent.left
             anchors.leftMargin: 0
@@ -219,11 +248,25 @@ Rectangle {
         
         Text {
             id: text3
-            text: qsTr("Z Texture URL")
+            text: qsTr("Z Texture URL <i>&nbsp;&nbsp;&nbsp;</i>")
             color: "#ffffff"
             font.pixelSize: 12
             anchors.top: textInputBox2.bottom
             anchors.topMargin: 5
+        }
+        Button {
+            id: pasteBtn3
+            text: "Paste"
+            font.pixelSize: 11
+            height: 16
+            width: 40
+            radius: 4
+            anchors.top: text3.top
+            anchors.left: text3.right
+            anchors.bottom: text3.bottom
+            onClicked: {
+                zTextureURL.paste()
+            }
         }
 
         TextInput {
@@ -231,7 +274,7 @@ Rectangle {
             height: 20
             text: qsTr("")
             color: "white"
-            anchors.top: text3.bottom
+            anchors.top: pasteBtn3.bottom
             anchors.topMargin: 5
             anchors.left: parent.left
             anchors.leftMargin: 0


### PR DESCRIPTION
This PR adds "**Paste**" buttons in the following UI:
"**Create Model**"
![image](https://github.com/user-attachments/assets/ce473fbc-b526-483f-b8c8-8cede831261d)

"**Create Material**"
![image](https://github.com/user-attachments/assets/b2c7edbb-1488-4189-b841-e5aa015ad5db)

"**Create Voxels**"
![image](https://github.com/user-attachments/assets/7683d93b-0207-4daa-853b-042a4b760ab8)

It was totally dysfunctional in HMD. (I should have addressed that long time ago)

