### PR TITLE
add a setting to workaround the GLES colorspace conversion issue

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -46,6 +46,7 @@
 #include "avatar/AvatarManager.h"
 #include "avatar/AvatarPackager.h"
 #include "AvatarBookmarks.h"
+#include <display-plugins/OpenGLDisplayPlugin.h>
 #include "DomainAccountManager.h"
 #include "MainWindow.h"
 #include "render/DrawStatus.h"
@@ -547,6 +548,13 @@ Menu::Menu() {
         auto drawStatusConfig = qApp->getRenderEngine()->getConfiguration()->getConfig<render::DrawStatus>("RenderMainView.DrawStatus");
         addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::HighlightTransitions, 0, false,
             drawStatusConfig, SLOT(setShowFade(bool)));
+    }
+
+    {
+        action = addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::ExtraLinearTosRGBConversion, 0, OpenGLDisplayPlugin::getExtraLinearToSRGBConversion());
+        connect(action, &QAction::triggered, [action] {
+            OpenGLDisplayPlugin::setExtraLinearToSRGBConversion(action->isChecked());
+        });
     }
 
     // Developer > Assets >>>

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -237,7 +237,8 @@ namespace MenuOption {
     const QString ComputeBlendshapes = "Compute Blendshapes";
     const QString HighlightTransitions = "Highlight Transitions";
     const QString MaterialProceduralShaders = "Enable Procedural Materials";
-}
+    const QString ExtraLinearTosRGBConversion = "Extra Linear to sRGB Conversion";
+    }
 
 #endif // hifi_Menu_h
 

--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
@@ -112,14 +112,6 @@ bool Basic2DWindowOpenGLDisplayPlugin::internalActivate() {
     return Parent::internalActivate();
 }
 
-gpu::PipelinePointer Basic2DWindowOpenGLDisplayPlugin::getRenderTexturePipeline() {
-#if defined(Q_OS_ANDROID)
-    return _linearToSRGBPipeline;
-#else
-    return _drawTexturePipeline;
-#endif
-}
-
 void Basic2DWindowOpenGLDisplayPlugin::compositeExtra() {
 #if defined(Q_OS_ANDROID)
     auto& virtualPadManager = VirtualPad::Manager::instance();

--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.h
@@ -37,8 +37,6 @@ public:
 
     virtual void pluginUpdate() override {};
 
-    virtual gpu::PipelinePointer getRenderTexturePipeline() override;
-
 protected:
     mutable bool _isThrottled = false;
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -18,6 +18,7 @@
 #include <QtGui/QImage>
 
 #include <GLMHelpers.h>
+#include <SettingHandle.h>
 #include <SimpleMovingAverage.h>
 #include <shared/RateCounter.h>
 
@@ -85,6 +86,9 @@ public:
     void copyTextureToQuickFramebuffer(NetworkTexturePointer source,
                                        QOpenGLFramebufferObject* target,
                                        GLsync* fenceSync) override;
+
+    static void setExtraLinearToSRGBConversion(bool value) { _extraLinearToSRGBConversionSetting.set(value); }
+    static bool getExtraLinearToSRGBConversion() { return _extraLinearToSRGBConversionSetting.get(); };
 
 protected:
     friend class PresentThread;
@@ -201,4 +205,7 @@ protected:
 
     QImage getScreenshot(float aspectRatio);
     QImage getSecondaryCameraScreenshot();
+
+private:
+    static Setting::Handle<bool> _extraLinearToSRGBConversionSetting;
 };


### PR DESCRIPTION
addresses #943 

this *might* also fix instances where rendering is too dark in HMDs, since I think that still uses this code path