### PR TITLE
Fix Create App not honoring menu bar actions

### DIFF
--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -2140,7 +2140,7 @@
     Controller.keyPressEvent.connect(keyPressEvent);
 
     function deleteKey(value) {
-        if (value === 0) { // on release
+        if (value === 1) { // on release
             createApp.deleteSelectedEntities();
         }
     }

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -2157,11 +2157,6 @@
     Controller.keyReleaseEvent.connect(keyReleaseEvent);
     Controller.keyPressEvent.connect(keyPressEvent);
 
-    function deleteKey(value) {
-        if (value === 0) { // on release
-            createApp.deleteSelectedEntities();
-        }
-    }
     function deselectKey(value) {
         if (value === 0) { // on release
             selectionManager.clearSelections(this);
@@ -3123,11 +3118,6 @@
     var isOnMacPlatform = Controller.getValue(Controller.Hardware.Application.PlatformMac);
 
     var mapping = Controller.newMapping(CONTROLLER_MAPPING_NAME);
-    if (isOnMacPlatform) {
-        mapping.from([Controller.Hardware.Keyboard.Backspace]).to(deleteKey);
-    } else {
-        mapping.from([Controller.Hardware.Keyboard.Delete]).to(deleteKey);
-    }
     mapping.from([Controller.Hardware.Keyboard.T]).to(toggleKey);
     mapping.from([Controller.Hardware.Keyboard.F]).to(focusKey);
     mapping.from([Controller.Hardware.Keyboard.J]).to(gridKey);
@@ -3138,15 +3128,9 @@
     mapping.from([Controller.Hardware.Keyboard["7"]]).to(quickRotate90xKey);
     mapping.from([Controller.Hardware.Keyboard["8"]]).to(quickRotate90yKey);
     mapping.from([Controller.Hardware.Keyboard["9"]]).to(quickRotate90zKey);
-    mapping.from([Controller.Hardware.Keyboard.X])
-        .when([Controller.Hardware.Keyboard.Control])
-        .to(whenReleased(function() { selectionManager.cutSelectedEntities() }));
     mapping.from([Controller.Hardware.Keyboard.C])
         .when([Controller.Hardware.Keyboard.Control])
         .to(whenReleased(function() { selectionManager.copySelectedEntities() }));
-    mapping.from([Controller.Hardware.Keyboard.V])
-        .when([Controller.Hardware.Keyboard.Control])
-        .to(whenReleased(function() { selectionManager.pasteEntities() }));
     mapping.from([Controller.Hardware.Keyboard.D])
         .when([Controller.Hardware.Keyboard.Control])
         .to(whenReleased(function() { selectionManager.duplicateSelection() }));
@@ -3170,10 +3154,8 @@
 
         var pressedValue = 0.0;
 
-        if ((!isOnMacPlatform && keyUpEvent.keyCodeString === "Delete")
-            || (isOnMacPlatform && keyUpEvent.keyCodeString === "Backspace")) {
-
-            deleteKey(pressedValue);
+        if (isOnMacPlatform && keyUpEvent.keyCodeString === "Backspace") {
+            createApp.deleteSelectedEntities();
         } else if (keyUpEvent.keyCodeString === "T") {
             toggleKey(pressedValue);
         } else if (keyUpEvent.keyCodeString === "F") {
@@ -3194,12 +3176,8 @@
             quickRotate90yKey(pressedValue);
         } else if (keyUpEvent.keyCodeString === "9") {
             quickRotate90zKey(pressedValue);
-        } else if (keyUpEvent.controlKey && keyUpEvent.keyCodeString === "X") {
-            selectionManager.cutSelectedEntities();
         } else if (keyUpEvent.controlKey && keyUpEvent.keyCodeString === "C") {
             selectionManager.copySelectedEntities();
-        } else if (keyUpEvent.controlKey && keyUpEvent.keyCodeString === "V") {
-            selectionManager.pasteEntities();
         } else if (keyUpEvent.controlKey && keyUpEvent.keyCodeString === "D") {
             selectionManager.duplicateSelection();
         } else if (!isOnMacPlatform && keyUpEvent.controlKey && !keyUpEvent.shiftKey && keyUpEvent.keyCodeString === "Z") {

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -2130,6 +2130,24 @@
         if (isActive) {
             cameraManager.keyPressEvent(event);
         }
+        
+        // Hacks to get the menu bar buttons to work
+        // Copy
+        if (event.key === 67 && event.isControl && !event.isShifted) {
+            selectionManager.copySelectedEntities();
+        }
+        // Paste
+        if (event.key === 86 && event.isControl && !event.isShifted) {
+            selectionManager.pasteEntities();
+        }
+        // Cut
+        if (event.key === 88 && event.isControl && !event.isShifted) {
+            selectionManager.cutSelectedEntities();
+        }
+        // Delete
+        if (event.key === 16777223 && !event.isControl && !event.isShifted) {
+            createApp.deleteSelectedEntities();
+        }
     };
     var keyReleaseEvent = function (event) {
         if (isActive) {
@@ -2140,7 +2158,12 @@
     Controller.keyPressEvent.connect(keyPressEvent);
 
     function deleteKey(value) {
-        if (value === 1) { // on release
+        if (value === 0) { // on press
+            createApp.deleteSelectedEntities();
+        }
+    }
+    function copyKey(value){
+        if (value === 1) { // on press
             createApp.deleteSelectedEntities();
         }
     }

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -2130,7 +2130,7 @@
         if (isActive) {
             cameraManager.keyPressEvent(event);
         }
-        
+
         // Hacks to get the menu bar buttons to work
         // Copy
         if (event.key === 67 && event.isControl && !event.isShifted) {
@@ -2158,12 +2158,12 @@
     Controller.keyPressEvent.connect(keyPressEvent);
 
     function deleteKey(value) {
-        if (value === 0) { // on press
+        if (value === 0) { // on release
             createApp.deleteSelectedEntities();
         }
     }
     function copyKey(value){
-        if (value === 1) { // on press
+        if (value === 0) { // on release
             createApp.deleteSelectedEntities();
         }
     }

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -2133,19 +2133,19 @@
 
         // Hacks to get the menu bar buttons to work
         // Copy
-        if (event.key === 67 && event.isControl && !event.isShifted) {
+        if (event.text.toLowerCase() === "c" && event.isControl && !event.isShifted) {
             selectionManager.copySelectedEntities();
         }
         // Paste
-        if (event.key === 86 && event.isControl && !event.isShifted) {
+        if (event.text.toLowerCase() === "v" && event.isControl && !event.isShifted) {
             selectionManager.pasteEntities();
         }
         // Cut
-        if (event.key === 88 && event.isControl && !event.isShifted) {
+        if (event.text.toLowerCase() === "x" && event.isControl && !event.isShifted) {
             selectionManager.cutSelectedEntities();
         }
-        // Delete
-        if (event.key === 16777223 && !event.isControl && !event.isShifted) {
+        // Delete - This uses the physical 'delete' key on a keyboard.
+        if (event.text.toLowerCase() === "delete" && !event.isControl && !event.isShifted) {
             createApp.deleteSelectedEntities();
         }
     };

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -2162,11 +2162,6 @@
             createApp.deleteSelectedEntities();
         }
     }
-    function copyKey(value){
-        if (value === 0) { // on release
-            createApp.deleteSelectedEntities();
-        }
-    }
     function deselectKey(value) {
         if (value === 0) { // on release
             selectionManager.clearSelections(this);


### PR DESCRIPTION
This implements a workaround for the Create app so that it responds to presses on the menu bar.
![Screenshot_20240827_145213](https://github.com/user-attachments/assets/d519750f-394b-4ba4-a0e0-9de333e2c1cd)

Fixes https://github.com/overte-org/overte/issues/588

