### PR TITLE
Fix selfie mode movement

### DIFF
--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -1,183 +1,185 @@
 {
-    "name": "Keyboard/Mouse to Actions",
-    "channels": [
-        { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton", "!Keyboard.Control"], "to": "Actions.LATERAL_LEFT" },
-        { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "!Keyboard.Control"], "to": "Actions.LATERAL_RIGHT" },
-        { "from": "Keyboard.Q", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_LEFT" },
-        { "from": "Keyboard.Q", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_RIGHT" },
-        { "from": "Keyboard.E", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_RIGHT" },
-        { "from": "Keyboard.E", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_LEFT" },
-        { "from": "Keyboard.T", "when": "!Keyboard.Control", "to": "Actions.TogglePushToTalk" },
+  "name": "Keyboard/Mouse to Actions",
+  "channels": [
+      { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton", "Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeRight" },
+      { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton","!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
+      { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeRight" },
+      { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
+      { "from": "Keyboard.Q", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_LEFT" },
+      { "from": "Keyboard.Q", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_RIGHT" },
+      { "from": "Keyboard.E", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_RIGHT" },
+      { "from": "Keyboard.E", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_LEFT" },
+      { "from": "Keyboard.T", "when": "!Keyboard.Control", "to": "Actions.TogglePushToTalk" },
 
-        { "comment" : "Mouse turn need to be small continuous increments",
-          "from": { "makeAxis" : [
-                [ "Keyboard.MouseMoveLeft" ],
-                [ "Keyboard.MouseMoveRight" ]
-            ]
-          },
-          "when": [ "Application.InHMD", "Application.SnapTurn", "Keyboard.RightMouseButton" ],
-          "to": "Actions.StepYaw",
-          "filters":
-            [
-                "constrainToInteger",
-                { "type": "pulse", "interval": 0.2 },
-                { "type": "scale", "scale": 22.5 }
-            ]
+      { "comment" : "Mouse turn need to be small continuous increments",
+        "from": { "makeAxis" : [
+              [ "Keyboard.MouseMoveLeft" ],
+              [ "Keyboard.MouseMoveRight" ]
+          ]
         },
+        "when": [ "Application.InHMD", "Application.SnapTurn", "Keyboard.RightMouseButton" ],
+        "to": "Actions.StepYaw",
+        "filters":
+          [
+              "constrainToInteger",
+              { "type": "pulse", "interval": 0.2 },
+              { "type": "scale", "scale": 22.5 }
+          ]
+      },
 
-        { "comment" : "Touchpad turn need to be small continuous increments, but without the RMB constraint",
-          "from": { "makeAxis" : [
-                [ "Keyboard.TouchpadLeft" ],
-                [ "Keyboard.TouchpadRight" ]
-            ]
-          },
-          "when": [ "Application.InHMD", "Application.SnapTurn" ],
-          "to": "Actions.StepYaw",
-          "filters":
-            [
-                "constrainToInteger",
-                { "type": "pulse", "interval": 0.2 },
-                { "type": "scale", "scale": 22.5 }
-            ]
+      { "comment" : "Touchpad turn need to be small continuous increments, but without the RMB constraint",
+        "from": { "makeAxis" : [
+              [ "Keyboard.TouchpadLeft" ],
+              [ "Keyboard.TouchpadRight" ]
+          ]
         },
+        "when": [ "Application.InHMD", "Application.SnapTurn" ],
+        "to": "Actions.StepYaw",
+        "filters":
+          [
+              "constrainToInteger",
+              { "type": "pulse", "interval": 0.2 },
+              { "type": "scale", "scale": 22.5 }
+          ]
+      },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.Left" ],
-                ["Keyboard.Right"]
-            ]
-          },
-          "when": ["Application.InHMD", "Application.SnapTurn", "!Keyboard.Shift"],
-          "to": "Actions.StepYaw",
-          "filters":
-            [
-                { "type": "pulse", "interval": 0.5, "resetOnZero": true },
-                { "type": "scale", "scale": 22.5 }
-            ]
+      { "from": { "makeAxis" : [
+              ["Keyboard.Left" ],
+              ["Keyboard.Right"]
+          ]
         },
+        "when": ["Application.InHMD", "Application.SnapTurn", "!Keyboard.Shift"],
+        "to": "Actions.StepYaw",
+        "filters":
+          [
+              { "type": "pulse", "interval": 0.5, "resetOnZero": true },
+              { "type": "scale", "scale": 22.5 }
+          ]
+      },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.A"],
-                ["Keyboard.D"]
-            ]
-          },
-          "when": [ "Application.InHMD", "Application.SnapTurn" ],
-          "to": "Actions.StepYaw",
-          "filters":
-            [
-                { "type": "pulse", "interval": 0.5, "resetOnZero": true },
-                { "type": "scale", "scale": 22.5 }
-            ]
+      { "from": { "makeAxis" : [
+              ["Keyboard.A"],
+              ["Keyboard.D"]
+          ]
         },
+        "when": [ "Application.InHMD", "Application.SnapTurn" ],
+        "to": "Actions.StepYaw",
+        "filters":
+          [
+              { "type": "pulse", "interval": 0.5, "resetOnZero": true },
+              { "type": "scale", "scale": 22.5 }
+          ]
+      },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.Left"],
-                ["Keyboard.Right"]
-            ]
-          },
-          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Shift"],
-          "to": "Actions.Yaw"
+      { "from": { "makeAxis" : [
+              ["Keyboard.Left"],
+              ["Keyboard.Right"]
+          ]
         },
+        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Shift"],
+        "to": "Actions.Yaw"
+      },
 
-        { "from": "Keyboard.Left",
-          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
-          "to": "Actions.LATERAL_LEFT"
-        },
+      { "from": "Keyboard.Left",
+        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
+        "to": "Actions.LATERAL_LEFT"
+      },
 
-        { "from": "Keyboard.Right",
-          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
-          "to": "Actions.LATERAL_RIGHT"
-        },
+      { "from": "Keyboard.Right",
+        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
+        "to": "Actions.LATERAL_RIGHT"
+      },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.A"],
-                ["Keyboard.D"]
-            ]
-          },
-          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Control"],
-          "to": "Actions.Yaw"
+      { "from": { "makeAxis" : [
+              ["Keyboard.A"],
+              ["Keyboard.D"]
+          ]
         },
+        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Control"],
+        "to": "Actions.Yaw"
+      },
 
-        { "from": "Keyboard.A",
-          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
-          "to": "Actions.LATERAL_LEFT"
-        },
+      { "from": "Keyboard.A",
+        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
+        "to": "Actions.LATERAL_LEFT"
+      },
 
-        { "from": "Keyboard.D",
-          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
-          "to": "Actions.LATERAL_RIGHT"
-        },
+      { "from": "Keyboard.D",
+        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
+        "to": "Actions.LATERAL_RIGHT"
+      },
 
-        { "from": { "makeAxis" : [
-                ["Keyboard.TouchpadLeft"],
-                ["Keyboard.TouchpadRight"]
-            ]
-          },
-          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity"],
-          "to": "Actions.Yaw"
+      { "from": { "makeAxis" : [
+              ["Keyboard.TouchpadLeft"],
+              ["Keyboard.TouchpadRight"]
+          ]
         },
+        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity"],
+        "to": "Actions.Yaw"
+      },
 
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
-          "when": ["Keyboard.RightMouseButton", "!Application.CaptureMouse"],
-          "to": "Actions.DeltaYaw",
-          "filters":
-            [
-                { "type": "scale", "scale": 0.6 }
-            ]
-        },
+      { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
+        "when": ["Keyboard.RightMouseButton", "!Application.CaptureMouse"],
+        "to": "Actions.DeltaYaw",
+        "filters":
+          [
+              { "type": "scale", "scale": 0.6 }
+          ]
+      },
 
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
-          "to": "Actions.DeltaYaw",
-          "when": "Application.CaptureMouse",
-          "filters":
-            [
-                { "type": "scale", "scale": 0.2 }
-            ]
-        },
+      { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
+        "to": "Actions.DeltaYaw",
+        "when": "Application.CaptureMouse",
+        "filters":
+          [
+              { "type": "scale", "scale": 0.2 }
+          ]
+      },
 
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
-          "when": ["!Application.CameraSelfie", "!Application.CameraLookAt", "!Application.CaptureMouse", "Keyboard.RightMouseButton"],
-          "to": "Actions.DeltaPitch",
-          "filters":
-            [
-                { "type": "scale", "scale": 0.6 }
-            ]
-        },
+      { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+        "when": ["!Application.CameraSelfie", "!Application.CameraLookAt", "!Application.CaptureMouse", "Keyboard.RightMouseButton"],
+        "to": "Actions.DeltaPitch",
+        "filters":
+          [
+              { "type": "scale", "scale": 0.6 }
+          ]
+      },
 
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
-          "to": "Actions.DeltaPitch",
-          "when": "Application.CaptureMouse",
-          "filters":
-            [
-                { "type": "scale", "scale": 0.2 }
-            ]
-        },
+      { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+        "to": "Actions.DeltaPitch",
+        "when": "Application.CaptureMouse",
+        "filters":
+          [
+              { "type": "scale", "scale": 0.2 }
+          ]
+      },
 
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
-          "when": ["Application.CameraLookAt", "Keyboard.RightMouseButton"],
-          "to": "Actions.DeltaPitch",
-          "filters":
-            [
-                { "type": "scale", "scale": 0.2 }
-            ]
-        },
+      { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+        "when": ["Application.CameraLookAt", "Keyboard.RightMouseButton"],
+        "to": "Actions.DeltaPitch",
+        "filters":
+          [
+              { "type": "scale", "scale": 0.2 }
+          ]
+      },
 
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveDown", "Keyboard.MouseMoveUp"] },
-          "when": ["Application.CameraSelfie", "Keyboard.RightMouseButton"],
-          "to": "Actions.DeltaPitch",
-          "filters":
-            [
-                { "type": "scale", "scale": 0.2 }
-            ]
-        },
+      { "from": { "makeAxis" : ["Keyboard.MouseMoveDown", "Keyboard.MouseMoveUp"] },
+        "when": ["Application.CameraSelfie", "Keyboard.RightMouseButton"],
+        "to": "Actions.DeltaPitch",
+        "filters":
+          [
+              { "type": "scale", "scale": 0.2 }
+          ]
+      },
 
         { "from": "Keyboard.W", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.S", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_BACKWARD" },
         { "from": "Keyboard.S", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.W", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_BACKWARD" },
-        { "from": "Keyboard.Shift", "when": ["!Keyboard.Left", "!Keyboard.Right"], "to": "Actions.SPRINT" },
-        { "from": "Keyboard.C", "when": "!Keyboard.Control", "to": "Actions.VERTICAL_DOWN" },
-        { "from": "Keyboard.Left", "when": "Keyboard.Shift", "to": "Actions.LATERAL_LEFT" },
-        { "from": "Keyboard.Right", "when": "Keyboard.Shift", "to": "Actions.LATERAL_RIGHT" },
+      { "from": "Keyboard.Shift", "when": ["!Keyboard.Left", "!Keyboard.Right"], "to": "Actions.SPRINT" },
+      { "from": "Keyboard.C", "when": "!Keyboard.Control", "to": "Actions.VERTICAL_DOWN" },
+      { "from": "Keyboard.Left", "when": "Keyboard.Shift", "to": "Actions.LATERAL_LEFT" },
+      { "from": "Keyboard.Right", "when": "Keyboard.Shift", "to": "Actions.LATERAL_RIGHT" },
         { "from": "Keyboard.Up", "when": "Application.CameraFirstPerson", "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.Up", "when": "Application.CameraFirstPersonLookat", "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.Up", "when": "Application.CameraThirdPerson", "to": "Actions.LONGITUDINAL_FORWARD" },
@@ -189,22 +191,22 @@
         { "from": "Keyboard.Down", "when": "Application.CameraLookAt", "to": "Actions.LONGITUDINAL_BACKWARD" },
         { "from": "Keyboard.Down", "when": "Application.CameraSelfie", "to": "Actions.LONGITUDINAL_FORWARD" },
 
-        { "from": "Keyboard.PgDown", "to": "Actions.VERTICAL_DOWN" },
-        { "from": "Keyboard.PgUp", "to": "Actions.VERTICAL_UP" },
+      { "from": "Keyboard.PgDown", "to": "Actions.VERTICAL_DOWN" },
+      { "from": "Keyboard.PgUp", "to": "Actions.VERTICAL_UP" },
 
-        { "from": "Keyboard.TouchpadDown", "to": "Actions.PITCH_DOWN" },
-        { "from": "Keyboard.TouchpadUp", "to": "Actions.PITCH_UP" },
+      { "from": "Keyboard.TouchpadDown", "to": "Actions.PITCH_DOWN" },
+      { "from": "Keyboard.TouchpadUp", "to": "Actions.PITCH_UP" },
 
-        { "from": "Keyboard.MouseWheelUp", "to": "Actions.LATERAL_RIGHT" },
-        { "from": "Keyboard.MouseWheelDown", "to": "Actions.LATERAL_LEFT" },
-        { "from": "Keyboard.MouseWheelLeft", "to": "Actions.BOOM_OUT", "filters": [ { "type": "scale", "scale": 0.02 } ]},
-        { "from": "Keyboard.MouseWheelRight", "to": "Actions.BOOM_IN", "filters": [ { "type": "scale", "scale": 0.02 } ]},
-        { "from": "Keyboard.GesturePinchOut", "to": "Actions.BOOM_OUT"},
-        { "from": "Keyboard.GesturePinchIn", "to": "Actions.BOOM_IN"},
+      { "from": "Keyboard.MouseWheelUp", "to": "Actions.LATERAL_RIGHT" },
+      { "from": "Keyboard.MouseWheelDown", "to": "Actions.LATERAL_LEFT" },
+      { "from": "Keyboard.MouseWheelLeft", "to": "Actions.BOOM_OUT", "filters": [ { "type": "scale", "scale": 0.02 } ]},
+      { "from": "Keyboard.MouseWheelRight", "to": "Actions.BOOM_IN", "filters": [ { "type": "scale", "scale": 0.02 } ]},
+      { "from": "Keyboard.GesturePinchOut", "to": "Actions.BOOM_OUT"},
+      { "from": "Keyboard.GesturePinchIn", "to": "Actions.BOOM_IN"},
 
-        { "from": "Keyboard.Space", "to": "Actions.VERTICAL_UP" },
-        { "from": "Keyboard.R", "to": "Actions.ACTION1" },
-        { "from": "Keyboard.T", "to": "Actions.ACTION2" },
-        { "from": "Keyboard.Tab", "to": "Actions.ContextMenu" }
-    ]
+      { "from": "Keyboard.Space", "to": "Actions.VERTICAL_UP" },
+      { "from": "Keyboard.R", "to": "Actions.ACTION1" },
+      { "from": "Keyboard.T", "to": "Actions.ACTION2" },
+      { "from": "Keyboard.Tab", "to": "Actions.ContextMenu" }
+  ]
 }

--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -1,176 +1,177 @@
 {
-  "name": "Keyboard/Mouse to Actions",
-  "channels": [
-      { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton", "Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeRight" },
-      { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton","!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
-      { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeRight" },
-      { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
-      { "from": "Keyboard.Q", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_LEFT" },
-      { "from": "Keyboard.Q", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_RIGHT" },
-      { "from": "Keyboard.E", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_RIGHT" },
-      { "from": "Keyboard.E", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_LEFT" },
-      { "from": "Keyboard.T", "when": "!Keyboard.Control", "to": "Actions.TogglePushToTalk" },
+    "name": "Keyboard/Mouse to Actions",
+    "channels": [
+        { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton", "Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeRight" },
+        { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton","!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
+        { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeRight" },
+        { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
+        { "from": "Keyboard.Q", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_LEFT" },
+        { "from": "Keyboard.Q", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_RIGHT" },
+        { "from": "Keyboard.E", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_RIGHT" },
+        { "from": "Keyboard.E", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LATERAL_LEFT" },
+        { "from": "Keyboard.T", "when": "!Keyboard.Control", "to": "Actions.TogglePushToTalk" },
 
-      { "comment" : "Mouse turn need to be small continuous increments",
-        "from": { "makeAxis" : [
-              [ "Keyboard.MouseMoveLeft" ],
-              [ "Keyboard.MouseMoveRight" ]
-          ]
+        { "comment" : "Mouse turn need to be small continuous increments",
+          "from": { "makeAxis" : [
+                [ "Keyboard.MouseMoveLeft" ],
+                [ "Keyboard.MouseMoveRight" ]
+            ]
+          },
+          "when": [ "Application.InHMD", "Application.SnapTurn", "Keyboard.RightMouseButton" ],
+          "to": "Actions.StepYaw",
+          "filters":
+            [
+                "constrainToInteger",
+                { "type": "pulse", "interval": 0.2 },
+                { "type": "scale", "scale": 22.5 }
+            ]
         },
-        "when": [ "Application.InHMD", "Application.SnapTurn", "Keyboard.RightMouseButton" ],
-        "to": "Actions.StepYaw",
-        "filters":
-          [
-              "constrainToInteger",
-              { "type": "pulse", "interval": 0.2 },
-              { "type": "scale", "scale": 22.5 }
-          ]
-      },
 
-      { "comment" : "Touchpad turn need to be small continuous increments, but without the RMB constraint",
-        "from": { "makeAxis" : [
-              [ "Keyboard.TouchpadLeft" ],
-              [ "Keyboard.TouchpadRight" ]
-          ]
+        { "comment" : "Touchpad turn need to be small continuous increments, but without the RMB constraint",
+          "from": { "makeAxis" : [
+                [ "Keyboard.TouchpadLeft" ],
+                [ "Keyboard.TouchpadRight" ]
+            ]
+          },
+          "when": [ "Application.InHMD", "Application.SnapTurn" ],
+          "to": "Actions.StepYaw",
+          "filters":
+            [
+                "constrainToInteger",
+                { "type": "pulse", "interval": 0.2 },
+                { "type": "scale", "scale": 22.5 }
+            ]
         },
-        "when": [ "Application.InHMD", "Application.SnapTurn" ],
-        "to": "Actions.StepYaw",
-        "filters":
-          [
-              "constrainToInteger",
-              { "type": "pulse", "interval": 0.2 },
-              { "type": "scale", "scale": 22.5 }
-          ]
-      },
 
-      { "from": { "makeAxis" : [
-              ["Keyboard.Left" ],
-              ["Keyboard.Right"]
-          ]
+        { "from": { "makeAxis" : [
+                ["Keyboard.Left" ],
+                ["Keyboard.Right"]
+            ]
+          },
+          "when": ["Application.InHMD", "Application.SnapTurn", "!Keyboard.Shift"],
+          "to": "Actions.StepYaw",
+          "filters":
+            [
+                { "type": "pulse", "interval": 0.5, "resetOnZero": true },
+                { "type": "scale", "scale": 22.5 }
+            ]
         },
-        "when": ["Application.InHMD", "Application.SnapTurn", "!Keyboard.Shift"],
-        "to": "Actions.StepYaw",
-        "filters":
-          [
-              { "type": "pulse", "interval": 0.5, "resetOnZero": true },
-              { "type": "scale", "scale": 22.5 }
-          ]
-      },
 
-      { "from": { "makeAxis" : [
-              ["Keyboard.A"],
-              ["Keyboard.D"]
-          ]
+        { "from": { "makeAxis" : [
+                ["Keyboard.A"],
+                ["Keyboard.D"]
+            ]
+          },
+          "when": [ "Application.InHMD", "Application.SnapTurn" ],
+          "to": "Actions.StepYaw",
+          "filters":
+            [
+                { "type": "pulse", "interval": 0.5, "resetOnZero": true },
+                { "type": "scale", "scale": 22.5 }
+            ]
         },
-        "when": [ "Application.InHMD", "Application.SnapTurn" ],
-        "to": "Actions.StepYaw",
-        "filters":
-          [
-              { "type": "pulse", "interval": 0.5, "resetOnZero": true },
-              { "type": "scale", "scale": 22.5 }
-          ]
-      },
 
-      { "from": { "makeAxis" : [
-              ["Keyboard.Left"],
-              ["Keyboard.Right"]
-          ]
+        { "from": { "makeAxis" : [
+                ["Keyboard.Left"],
+                ["Keyboard.Right"]
+            ]
+          },
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Shift"],
+          "to": "Actions.Yaw"
         },
-        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Shift"],
-        "to": "Actions.Yaw"
-      },
 
-      { "from": "Keyboard.Left",
-        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
-        "to": "Actions.LATERAL_LEFT"
-      },
-
-      { "from": "Keyboard.Right",
-        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
-        "to": "Actions.LATERAL_RIGHT"
-      },
-
-      { "from": { "makeAxis" : [
-              ["Keyboard.A"],
-              ["Keyboard.D"]
-          ]
+        { "from": "Keyboard.Left",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
+          "to": "Actions.LATERAL_LEFT"
         },
-        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Control"],
-        "to": "Actions.Yaw"
-      },
 
-      { "from": "Keyboard.A",
-        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
-        "to": "Actions.LATERAL_LEFT"
-      },
-
-      { "from": "Keyboard.D",
-        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
-        "to": "Actions.LATERAL_RIGHT"
-      },
-
-      { "from": { "makeAxis" : [
-              ["Keyboard.TouchpadLeft"],
-              ["Keyboard.TouchpadRight"]
-          ]
+        { "from": "Keyboard.Right",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Shift"],
+          "to": "Actions.LATERAL_RIGHT"
         },
-        "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity"],
-        "to": "Actions.Yaw"
-      },
 
-      { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
-        "when": ["Keyboard.RightMouseButton", "!Application.CaptureMouse"],
-        "to": "Actions.DeltaYaw",
-        "filters":
-          [
-              { "type": "scale", "scale": 0.6 }
-          ]
-      },
+        { "from": { "makeAxis" : [
+                ["Keyboard.A"],
+                ["Keyboard.D"]
+            ]
+          },
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "!Application.CaptureMouse", "!Keyboard.Control"],
+          "to": "Actions.Yaw"
+        },
 
-      { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
-        "to": "Actions.DeltaYaw",
-        "when": "Application.CaptureMouse",
-        "filters":
-          [
-              { "type": "scale", "scale": 0.2 }
-          ]
-      },
+        { "from": "Keyboard.A",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
+          "to": "Actions.LATERAL_LEFT"
+        },
 
-      { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
-        "when": ["!Application.CameraSelfie", "!Application.CameraLookAt", "!Application.CaptureMouse", "Keyboard.RightMouseButton"],
-        "to": "Actions.DeltaPitch",
-        "filters":
-          [
-              { "type": "scale", "scale": 0.6 }
-          ]
-      },
+        { "from": "Keyboard.D",
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity", "Application.CaptureMouse", "!Keyboard.Control"],
+          "to": "Actions.LATERAL_RIGHT"
+        },
 
-      { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
-        "to": "Actions.DeltaPitch",
-        "when": "Application.CaptureMouse",
-        "filters":
-          [
-              { "type": "scale", "scale": 0.2 }
-          ]
-      },
+        { "from": { "makeAxis" : [
+                ["Keyboard.TouchpadLeft"],
+                ["Keyboard.TouchpadRight"]
+            ]
+          },
+          "when": ["!Application.CameraFSM", "!Application.CameraIndependent", "!Application.CameraEntity"],
+          "to": "Actions.Yaw"
+        },
 
-      { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
-        "when": ["Application.CameraLookAt", "Keyboard.RightMouseButton"],
-        "to": "Actions.DeltaPitch",
-        "filters":
-          [
-              { "type": "scale", "scale": 0.2 }
-          ]
-      },
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
+          "when": ["Keyboard.RightMouseButton", "!Application.CaptureMouse"],
+          "to": "Actions.DeltaYaw",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.6 }
+            ]
+        },
 
-      { "from": { "makeAxis" : ["Keyboard.MouseMoveDown", "Keyboard.MouseMoveUp"] },
-        "when": ["Application.CameraSelfie", "Keyboard.RightMouseButton"],
-        "to": "Actions.DeltaPitch",
-        "filters":
-          [
-              { "type": "scale", "scale": 0.2 }
-          ]
-      },
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
+          "to": "Actions.DeltaYaw",
+          "when": "Application.CaptureMouse",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.2 }
+            ]
+        },
+
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+          "when": ["!Application.CameraSelfie", "!Application.CameraLookAt", "!Application.CaptureMouse", "Keyboard.RightMouseButton"],
+          "to": "Actions.DeltaPitch",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.6 }
+            ]
+        },
+
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+          "to": "Actions.DeltaPitch",
+          "when": "Application.CaptureMouse",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.2 }
+            ]
+        },
+
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+          "when": ["Application.CameraLookAt", "Keyboard.RightMouseButton"],
+          "to": "Actions.DeltaPitch",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.2 }
+            ]
+        },
+
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveDown", "Keyboard.MouseMoveUp"] },
+          "when": ["Application.CameraSelfie", "Keyboard.RightMouseButton"],
+          "to": "Actions.DeltaPitch",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.2 }
+            ]
+        },
+
 
         { "from": "Keyboard.W", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.S", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_BACKWARD" },

--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -2,7 +2,7 @@
     "name": "Keyboard/Mouse to Actions",
     "channels": [
         { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton", "Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeRight" },
-        { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton","!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
+        { "from": "Keyboard.A", "when": ["Keyboard.RightMouseButton", "!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
         { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeRight" },
         { "from": "Keyboard.D", "when": ["Keyboard.RightMouseButton", "Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.StrafeLeft" },
         { "from": "Keyboard.Q", "when": ["!Application.CameraSelfie", "!Keyboard.Control", "!Application.CaptureMouse"], "to": "Actions.LATERAL_LEFT" },

--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -177,10 +177,10 @@
         { "from": "Keyboard.S", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_BACKWARD" },
         { "from": "Keyboard.S", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.W", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_BACKWARD" },
-      { "from": "Keyboard.Shift", "when": ["!Keyboard.Left", "!Keyboard.Right"], "to": "Actions.SPRINT" },
-      { "from": "Keyboard.C", "when": "!Keyboard.Control", "to": "Actions.VERTICAL_DOWN" },
-      { "from": "Keyboard.Left", "when": "Keyboard.Shift", "to": "Actions.LATERAL_LEFT" },
-      { "from": "Keyboard.Right", "when": "Keyboard.Shift", "to": "Actions.LATERAL_RIGHT" },
+        { "from": "Keyboard.Shift", "when": ["!Keyboard.Left", "!Keyboard.Right"], "to": "Actions.SPRINT" },
+        { "from": "Keyboard.C", "when": "!Keyboard.Control", "to": "Actions.VERTICAL_DOWN" },
+        { "from": "Keyboard.Left", "when": "Keyboard.Shift", "to": "Actions.LATERAL_LEFT" },
+        { "from": "Keyboard.Right", "when": "Keyboard.Shift", "to": "Actions.LATERAL_RIGHT" },
         { "from": "Keyboard.Up", "when": "Application.CameraFirstPerson", "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.Up", "when": "Application.CameraFirstPersonLookat", "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.Up", "when": "Application.CameraThirdPerson", "to": "Actions.LONGITUDINAL_FORWARD" },
@@ -192,22 +192,22 @@
         { "from": "Keyboard.Down", "when": "Application.CameraLookAt", "to": "Actions.LONGITUDINAL_BACKWARD" },
         { "from": "Keyboard.Down", "when": "Application.CameraSelfie", "to": "Actions.LONGITUDINAL_FORWARD" },
 
-      { "from": "Keyboard.PgDown", "to": "Actions.VERTICAL_DOWN" },
-      { "from": "Keyboard.PgUp", "to": "Actions.VERTICAL_UP" },
+        { "from": "Keyboard.PgDown", "to": "Actions.VERTICAL_DOWN" },
+        { "from": "Keyboard.PgUp", "to": "Actions.VERTICAL_UP" },
 
-      { "from": "Keyboard.TouchpadDown", "to": "Actions.PITCH_DOWN" },
-      { "from": "Keyboard.TouchpadUp", "to": "Actions.PITCH_UP" },
+        { "from": "Keyboard.TouchpadDown", "to": "Actions.PITCH_DOWN" },
+        { "from": "Keyboard.TouchpadUp", "to": "Actions.PITCH_UP" },
 
-      { "from": "Keyboard.MouseWheelUp", "to": "Actions.LATERAL_RIGHT" },
-      { "from": "Keyboard.MouseWheelDown", "to": "Actions.LATERAL_LEFT" },
-      { "from": "Keyboard.MouseWheelLeft", "to": "Actions.BOOM_OUT", "filters": [ { "type": "scale", "scale": 0.02 } ]},
-      { "from": "Keyboard.MouseWheelRight", "to": "Actions.BOOM_IN", "filters": [ { "type": "scale", "scale": 0.02 } ]},
-      { "from": "Keyboard.GesturePinchOut", "to": "Actions.BOOM_OUT"},
-      { "from": "Keyboard.GesturePinchIn", "to": "Actions.BOOM_IN"},
+        { "from": "Keyboard.MouseWheelUp", "to": "Actions.LATERAL_RIGHT" },
+        { "from": "Keyboard.MouseWheelDown", "to": "Actions.LATERAL_LEFT" },
+        { "from": "Keyboard.MouseWheelLeft", "to": "Actions.BOOM_OUT", "filters": [ { "type": "scale", "scale": 0.02 } ]},
+        { "from": "Keyboard.MouseWheelRight", "to": "Actions.BOOM_IN", "filters": [ { "type": "scale", "scale": 0.02 } ]},
+        { "from": "Keyboard.GesturePinchOut", "to": "Actions.BOOM_OUT"},
+        { "from": "Keyboard.GesturePinchIn", "to": "Actions.BOOM_IN"},
 
-      { "from": "Keyboard.Space", "to": "Actions.VERTICAL_UP" },
-      { "from": "Keyboard.R", "to": "Actions.ACTION1" },
-      { "from": "Keyboard.T", "to": "Actions.ACTION2" },
-      { "from": "Keyboard.Tab", "to": "Actions.ContextMenu" }
+        { "from": "Keyboard.Space", "to": "Actions.VERTICAL_UP" },
+        { "from": "Keyboard.R", "to": "Actions.ACTION1" },
+        { "from": "Keyboard.T", "to": "Actions.ACTION2" },
+        { "from": "Keyboard.Tab", "to": "Actions.ContextMenu" }
   ]
 }

--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -172,7 +172,6 @@
             ]
         },
 
-
         { "from": "Keyboard.W", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_FORWARD" },
         { "from": "Keyboard.S", "when": ["!Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_BACKWARD" },
         { "from": "Keyboard.S", "when": ["Application.CameraSelfie", "!Keyboard.Control"], "to": "Actions.LONGITUDINAL_FORWARD" },
@@ -209,5 +208,5 @@
         { "from": "Keyboard.R", "to": "Actions.ACTION1" },
         { "from": "Keyboard.T", "to": "Actions.ACTION2" },
         { "from": "Keyboard.Tab", "to": "Actions.ContextMenu" }
-  ]
+    ]
 }

--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -147,10 +147,19 @@
 
         { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
           "to": "Actions.DeltaPitch",
-          "when": "Application.CaptureMouse",
+          "when": ["Application.CaptureMouse", "!Application.CameraSelfie"],
           "filters":
             [
                 { "type": "scale", "scale": 0.2 }
+            ]
+        },
+
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+          "to": "Actions.DeltaPitch",
+          "when": ["Application.CaptureMouse", "Application.CameraSelfie"],
+          "filters":
+            [
+                { "type": "scale", "scale": -0.2 }
             ]
         },
 


### PR DESCRIPTION
Currently in Selfie mode (View 2 on the keyboard) if you were to press either "A" or "D" keys with the intention of moving your character, your avatar will be moving in a unexpected way.
This pull adds an additional check to see if the user is in "Selfie Mode" and will move the character in the expected direction.
In effect, this mirrors the current movement direction. So in Selfie Mode you will be moving to the left in the perspective of your character when you press the "D" key.

Fixes #821
Closes #135. Unless I am misreading this issue, this would have been a problem solved a long while ago. What is described is not what I observe. 