### PR TITLE
[ Avatar App ] Fixed lingering references to now deleted QML element

### DIFF
--- a/interface/resources/qml/hifi/AvatarApp.qml
+++ b/interface/resources/qml/hifi/AvatarApp.qml
@@ -238,7 +238,6 @@ Rectangle {
         }
 
         pageTitle: currentPage
-        avatarIconVisible: mainPageVisible
         settingsButtonVisible: mainPageVisible
         onSettingsClicked: {
             displayNameInput.focus = false;

--- a/interface/resources/qml/hifi/avatarapp/AvatarAppHeader.qml
+++ b/interface/resources/qml/hifi/avatarapp/AvatarAppHeader.qml
@@ -9,7 +9,6 @@ ShadowRectangle {
     height: 60
 
     property alias pageTitle: title.text
-    property alias avatarIconVisible: avatarIcon.visible
     property alias settingsButtonVisible: settingsButton.visible
 
     signal settingsClicked;
@@ -24,9 +23,8 @@ ShadowRectangle {
     RalewaySemiBold {
         id: title
         size: 22;
-        anchors.left: avatarIcon.visible ? avatarIcon.right : avatarIcon.left
-        anchors.leftMargin: 4
-        anchors.verticalCenter: avatarIcon.verticalCenter
+        x: 20
+        anchors.verticalCenter: parent.verticalCenter
         text: 'Avatar'
     }
 
@@ -34,7 +32,7 @@ ShadowRectangle {
         id: settingsButton
         anchors.right: parent.right
         anchors.rightMargin: 30
-        anchors.verticalCenter: avatarIcon.verticalCenter
+        anchors.verticalCenter: parent.verticalCenter
         text: "&"
 
         MouseArea {


### PR DESCRIPTION
Replaced everything referencing the now deleted avatarIcon element with alternatives, and removed anything that was no longer necessary.
Tested on a clean build.
Fixes: #1154 
![image](https://github.com/user-attachments/assets/a7c6a26b-59de-49e8-8d54-b962ce3efdf9)
