### PR TITLE
remove unnecessary fullscreen pass when haze is off/disabled

### DIFF
--- a/libraries/graphics/src/graphics/Haze.cpp
+++ b/libraries/graphics/src/graphics/Haze.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Nissim Hadar on 9/13/2017.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -181,4 +182,8 @@ void Haze::setHazeBackgroundBlend(const float hazeBackgroundBlend) {
     if (params.hazeBackgroundBlend != newBlend) {
         _hazeParametersBuffer.edit<Parameters>().hazeBackgroundBlend = newBlend;
     }
+}
+
+bool Haze::isActive() const {
+    return (_hazeParametersBuffer.get<Parameters>().hazeMode & HAZE_MODE_IS_ACTIVE) == HAZE_MODE_IS_ACTIVE;
 }

--- a/libraries/graphics/src/graphics/Haze.h
+++ b/libraries/graphics/src/graphics/Haze.h
@@ -4,6 +4,7 @@
 //
 //  Created by Nissim Hadar on 9/13/2017.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -94,6 +95,8 @@ namespace graphics {
 
         using UniformBufferView = gpu::BufferView;
         UniformBufferView getHazeParametersBuffer() const { return _hazeParametersBuffer; }
+
+        bool isActive() const;
 
     protected:
         class Parameters {

--- a/libraries/render-utils/src/DrawHaze.cpp
+++ b/libraries/render-utils/src/DrawHaze.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Nissim Hadar on 9/1/2017.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -54,6 +55,10 @@ void DrawHaze::run(const render::RenderContextPointer& renderContext, const Inpu
     const auto lightFrame = inputs.get5();
 
     auto depthBuffer = framebuffer->getLinearDepthTexture();
+
+    if (!lightingModel->isHazeEnabled() || !haze->isActive()) {
+        return;
+    }
 
     RenderArgs* args = renderContext->args;
 

--- a/libraries/render-utils/src/Haze.slf
+++ b/libraries/render-utils/src/Haze.slf
@@ -6,6 +6,7 @@
 //
 //  Created by Nissim Hadar on 9/5/2107.
 //  Copyright 2016 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -45,10 +46,6 @@ layout(location=0) in vec2 varTexCoord0;
 layout(location=0) out vec4 outFragColor;
 
 void main(void) {
-    if ((isHazeEnabled() == 0.0) || (hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) != HAZE_MODE_IS_ACTIVE) {
-        discard;
-    }
-
     vec4 fragPositionES = unpackPositionFromZeye(varTexCoord0);
     mat4 viewInverse = getViewInverse();
 


### PR DESCRIPTION
in deferred rendering mode, haze is applied as a fullscreen pass after we've rendered opaque objects.  but when haze is off, this shader still runs and just early exits.  this is expensive for no reason, we can just early exit on the CPU