### PR TITLE
Fix stutter when an object is fading

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -242,8 +242,6 @@
 #include <raypick/RayPick.h>
 #include <raypick/MouseTransformNode.h>
 
-#include <FadeEffect.h>
-
 #include "ResourceRequestObserver.h"
 
 #include "webbrowser/WebBrowserSuggestionsEngine.h"
@@ -913,7 +911,6 @@ bool setupEssentials(const QCommandLineParser& parser, bool runningMarkerExisted
     DependencyManager::set<SelectionScriptingInterface>();
     DependencyManager::set<TTSScriptingInterface>();
 
-    DependencyManager::set<FadeEffect>();
     DependencyManager::set<ResourceRequestObserver>();
     DependencyManager::set<Keyboard>();
     DependencyManager::set<KeyboardScriptingInterface>();

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1748,9 +1748,8 @@ ShapePipelinePointer shapePipelineFactory(const ShapePlumber& plumber, const Sha
                 if (!std::get<2>(key)) {
                     _pipelines[std::make_tuple(std::get<0>(key), std::get<1>(key), std::get<2>(key), wireframe)] = std::make_shared<render::ShapePipeline>(pipeline, nullptr, nullptr, nullptr);
                 } else {
-                    const auto& fadeEffect = DependencyManager::get<FadeEffect>();
                     _pipelines[std::make_tuple(std::get<0>(key), std::get<1>(key), std::get<2>(key), wireframe)] = std::make_shared<render::ShapePipeline>(pipeline, nullptr,
-                        fadeEffect->getBatchSetter(), fadeEffect->getItemUniformSetter());
+                        FadeEffect::getBatchSetter(), FadeEffect::getItemUniformSetter());
                 }
             }
         }

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -842,6 +842,8 @@ void AmbientOcclusionEffect::run(const render::RenderContextPointer& renderConte
     config->setGPUBatchRunTime(_gpuTimer->getGPUAverage(), _gpuTimer->getBatchAverage());
 }
 
+gpu::PipelinePointer DebugAmbientOcclusion::_debugPipeline;
+
 void DebugAmbientOcclusion::configure(const Config& config) {
     _showCursorPixel = config.showCursorPixel;
 
@@ -851,7 +853,7 @@ void DebugAmbientOcclusion::configure(const Config& config) {
     }
 }
 
-const gpu::PipelinePointer& DebugAmbientOcclusion::getDebugPipeline() {
+gpu::PipelinePointer& DebugAmbientOcclusion::getDebugPipeline() {
     if (!_debugPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::ssao_debugOcclusion);
         gpu::StatePointer state = std::make_shared<gpu::State>();

--- a/libraries/render-utils/src/AmbientOcclusionEffect.h
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.h
@@ -283,9 +283,9 @@ private:
     };
     gpu::StructBuffer<Parameters> _parametersBuffer;
 
-    const gpu::PipelinePointer& getDebugPipeline();
+    static gpu::PipelinePointer& getDebugPipeline();
 
-    gpu::PipelinePointer _debugPipeline;
+    static gpu::PipelinePointer _debugPipeline;
 
     bool _showCursorPixel { false };
 };

--- a/libraries/render-utils/src/AntialiasingEffect.h
+++ b/libraries/render-utils/src/AntialiasingEffect.h
@@ -213,18 +213,18 @@ public:
     void configure(const Config& config);
     void run(const render::RenderContextPointer& renderContext, const Inputs& inputs);
 
-    const gpu::PipelinePointer& getAntialiasingPipeline(const render::RenderContextPointer& renderContext);
-    const gpu::PipelinePointer& getBlendPipeline();
-    const gpu::PipelinePointer& getDebugBlendPipeline();
+    static gpu::PipelinePointer& getAntialiasingPipeline();
+    static gpu::PipelinePointer& getBlendPipeline();
+    static gpu::PipelinePointer& getDebugBlendPipeline();
 
 private:
 
     gpu::FramebufferSwapChainPointer _antialiasingBuffers;
     gpu::TexturePointer _antialiasingTextures[2];
     gpu::BufferPointer _blendParamsBuffer;
-    gpu::PipelinePointer _antialiasingPipeline;
-    gpu::PipelinePointer _blendPipeline;
-    gpu::PipelinePointer _debugBlendPipeline;
+    static gpu::PipelinePointer _antialiasingPipeline;
+    static gpu::PipelinePointer _blendPipeline;
+    static gpu::PipelinePointer _debugBlendPipeline;
 
     TAAParamsBuffer _params;
     AntialiasingConfig::Mode _mode{ AntialiasingConfig::TAA };
@@ -251,8 +251,8 @@ public:
     void configure(const Config& config) {}
     void run(const render::RenderContextPointer& renderContext, const gpu::FramebufferPointer& sourceBuffer);
     
-    const gpu::PipelinePointer& getAntialiasingPipeline();
-    const gpu::PipelinePointer& getBlendPipeline();
+    static gpu::PipelinePointer& getAntialiasingPipeline();
+    static gpu::PipelinePointer& getBlendPipeline();
 
 private:
     gpu::FramebufferPointer _antialiasingBuffer;
@@ -260,8 +260,8 @@ private:
     gpu::TexturePointer _antialiasingTexture;
     gpu::BufferPointer _paramsBuffer;
     
-    gpu::PipelinePointer _antialiasingPipeline;
-    gpu::PipelinePointer _blendPipeline;
+    static gpu::PipelinePointer _antialiasingPipeline;
+    static gpu::PipelinePointer _blendPipeline;
     int _geometryId { 0 };
 };
 #endif

--- a/libraries/render-utils/src/BloomEffect.cpp
+++ b/libraries/render-utils/src/BloomEffect.cpp
@@ -19,6 +19,11 @@
 
 #define BLOOM_BLUR_LEVEL_COUNT  3
 
+gpu::PipelinePointer BloomThreshold::_pipeline;
+gpu::PipelinePointer BloomApply::_pipeline;
+gpu::PipelinePointer BloomDraw::_pipeline;
+gpu::PipelinePointer DebugBloom::_pipeline;
+
 BloomThreshold::BloomThreshold(unsigned int downsamplingFactor) {
     assert(downsamplingFactor > 0);
     _parameters.edit()._sampleCount = downsamplingFactor;

--- a/libraries/render-utils/src/BloomEffect.h
+++ b/libraries/render-utils/src/BloomEffect.h
@@ -43,8 +43,8 @@ private:
 
 #include "BloomThreshold.shared.slh"
 
+    static gpu::PipelinePointer _pipeline;
     gpu::FramebufferPointer _outputBuffer;
-    gpu::PipelinePointer _pipeline;
     gpu::StructBuffer<Parameters> _parameters;
 };
 
@@ -68,7 +68,7 @@ private:
 
 #include "BloomApply.shared.slh"
 
-    gpu::PipelinePointer _pipeline;
+    static gpu::PipelinePointer _pipeline;
     gpu::StructBuffer<Parameters> _parameters;
 };
 
@@ -83,7 +83,7 @@ public:
 
 private:
 
-    gpu::PipelinePointer _pipeline;
+    static gpu::PipelinePointer _pipeline;
 };
 
 class DebugBloomConfig : public render::Job::Config {
@@ -125,7 +125,7 @@ public:
     void run(const render::RenderContextPointer& renderContext, const Inputs& inputs);
 
 private:
-    gpu::PipelinePointer _pipeline;
+    static gpu::PipelinePointer _pipeline;
     gpu::BufferPointer _params;
     DebugBloomConfig::Mode _mode;
 };

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -250,6 +250,9 @@ static std::string getFileContent(const std::string& fileName, const std::string
     return defaultContent;
 }
 
+DebugDeferredBuffer::StandardPipelines DebugDeferredBuffer::_pipelines;
+DebugDeferredBuffer::CustomPipelines DebugDeferredBuffer::_customPipelines;
+
 #include <QStandardPaths>  // TODO REMOVE: Temporary until UI
 DebugDeferredBuffer::DebugDeferredBuffer() {
     // TODO REMOVE: Temporary until UI
@@ -334,7 +337,7 @@ std::string DebugDeferredBuffer::getShaderSourceCode(Mode mode, const std::strin
     return std::string();
 }
 
-bool DebugDeferredBuffer::pipelineNeedsUpdate(Mode mode, const std::string& customFile) const {
+bool DebugDeferredBuffer::pipelineNeedsUpdate(Mode mode, const std::string& customFile) {
     if (mode != CustomMode) {
         return !_pipelines[mode];
     }
@@ -351,7 +354,7 @@ bool DebugDeferredBuffer::pipelineNeedsUpdate(Mode mode, const std::string& cust
     return true;
 }
 
-const gpu::PipelinePointer& DebugDeferredBuffer::getPipeline(Mode mode, const std::string& customFile) {
+gpu::PipelinePointer& DebugDeferredBuffer::getPipeline(Mode mode, const std::string& customFile) {
     if (pipelineNeedsUpdate(mode, customFile)) {
         static_assert(shader::render_utils::program::debug_deferred_buffer != 0, "Validate debug deferred program");
 

--- a/libraries/render-utils/src/DebugDeferredBuffer.h
+++ b/libraries/render-utils/src/DebugDeferredBuffer.h
@@ -107,18 +107,18 @@ private:
 
     struct CustomPipeline {
         gpu::PipelinePointer pipeline;
-        mutable QFileInfo info;
+        QFileInfo info;
     };
     using StandardPipelines = std::array<gpu::PipelinePointer, NumModes>;
     using CustomPipelines = std::unordered_map<std::string, CustomPipeline>;
 
-    bool pipelineNeedsUpdate(Mode mode, const std::string& customFile = std::string()) const;
-    const gpu::PipelinePointer& getPipeline(Mode mode, const std::string& customFile = std::string());
-    std::string getShaderSourceCode(Mode mode, const std::string& customFile = std::string());
+    static bool pipelineNeedsUpdate(Mode mode, const std::string& customFile = std::string());
+    static gpu::PipelinePointer& getPipeline(Mode mode, const std::string& customFile = std::string());
+    static std::string getShaderSourceCode(Mode mode, const std::string& customFile = std::string());
 
     ParametersBuffer _parameters;
-    StandardPipelines _pipelines;
-    CustomPipelines _customPipelines;
+    static StandardPipelines _pipelines;
+    static CustomPipelines _customPipelines;
     int _geometryId{ 0 };
 };
 

--- a/libraries/render-utils/src/FadeEffect.cpp
+++ b/libraries/render-utils/src/FadeEffect.cpp
@@ -17,28 +17,31 @@
 #include "render-utils/ShaderConstants.h"
 #include <PathUtils.h>
 
+gpu::TexturePointer FadeEffect::_maskMap;
+
 FadeEffect::FadeEffect() {
-    auto texturePath = PathUtils::resourcesPath() + "images/fadeMask.png";
-    _maskMap = DependencyManager::get<TextureCache>()->getImageTexture(texturePath, image::TextureUsage::STRICT_TEXTURE);
+    std::once_flag once;
+    std::call_once(once, [] {
+        auto texturePath = PathUtils::resourcesPath() + "images/fadeMask.png";
+        _maskMap = DependencyManager::get<TextureCache>()->getImageTexture(texturePath, image::TextureUsage::STRICT_TEXTURE);
+    });
 }
 
-void FadeEffect::build(render::Task::TaskConcept& task, const task::Varying& editableItems) {
+void FadeEffect::build(JobModel& task, const render::Varying& inputs, render::Varying& outputs) {
     auto editedFadeCategory = task.addJob<FadeJob>("Fade");
-    auto& fadeJob = task._jobs.back();
-    _configurations = fadeJob.get<FadeJob>().getConfigurationBuffer();
 
-    const auto fadeEditInput = FadeEditJob::Input(editableItems, editedFadeCategory).asVarying();
+    const auto fadeEditInput = FadeEditJob::Input(inputs, editedFadeCategory).asVarying();
     task.addJob<FadeEditJob>("FadeEdit", fadeEditInput);
 }
 
-render::ShapePipeline::BatchSetter FadeEffect::getBatchSetter() const {
-    return [this](const render::ShapePipeline& shapePipeline, gpu::Batch& batch, render::Args*) {
+render::ShapePipeline::BatchSetter FadeEffect::getBatchSetter() {
+    return [](const render::ShapePipeline& shapePipeline, gpu::Batch& batch, render::Args*) {
         batch.setResourceTexture(render_utils::slot::texture::FadeMask, _maskMap);
-        batch.setUniformBuffer(render_utils::slot::buffer::FadeParameters, _configurations);
+        batch.setUniformBuffer(render_utils::slot::buffer::FadeParameters, FadeJob::getConfigurationBuffer());
     };
 }
 
-render::ShapePipeline::ItemSetter FadeEffect::getItemUniformSetter() const {
+render::ShapePipeline::ItemSetter FadeEffect::getItemUniformSetter() {
     return [](const render::ShapePipeline& shapePipeline, render::Args* args, const render::Item& item) {
         if (!render::TransitionStage::isIndexInvalid(item.getTransitionId())) {
             const auto& scene = args->_scene;
@@ -70,40 +73,4 @@ render::ShapePipeline::ItemSetter FadeEffect::getItemUniformSetter() const {
             batch->setUniformBuffer(render_utils::slot::buffer::FadeObjectParameters, transitionState.paramsBuffer);
         }
     };
-}
-
-render::ShapePipeline::ItemSetter FadeEffect::getItemStoredSetter() {
-    return [this](const render::ShapePipeline& shapePipeline, render::Args* args, const render::Item& item) {
-        if (!render::TransitionStage::isIndexInvalid(item.getTransitionId())) {
-            auto scene = args->_scene;
-            auto transitionStage = scene->getStage<render::TransitionStage>();
-            auto& transitionState = transitionStage->getTransition(item.getTransitionId());
-            const auto fadeCategory = FadeJob::transitionToCategory[transitionState.eventType];
-
-            _lastCategory = fadeCategory;
-            _lastThreshold = transitionState.threshold;
-            _lastNoiseOffset = transitionState.noiseOffset;
-            _lastBaseOffset = transitionState.baseOffset;
-            _lastBaseInvSize = transitionState.baseInvSize;
-        }
-    };
-}
-
-void FadeEffect::packToAttributes(const int category, const float threshold, const glm::vec3& noiseOffset,
-    const glm::vec3& baseOffset, const glm::vec3& baseInvSize,
-    glm::vec4& packedData1, glm::vec4& packedData2, glm::vec4& packedData3) {
-    packedData1.x = noiseOffset.x;
-    packedData1.y = noiseOffset.y;
-    packedData1.z = noiseOffset.z;
-    packedData1.w = (float)(category+0.1f); // GLSL hack so that casting back from float to int in fragment shader returns the correct value.
-
-    packedData2.x = baseOffset.x;
-    packedData2.y = baseOffset.y;
-    packedData2.z = baseOffset.z;
-    packedData2.w = threshold;
-
-    packedData3.x = baseInvSize.x;
-    packedData3.y = baseInvSize.y;
-    packedData3.z = baseInvSize.z;
-    packedData3.w = 0.f;
 }

--- a/libraries/render-utils/src/FadeEffect.cpp
+++ b/libraries/render-utils/src/FadeEffect.cpp
@@ -43,7 +43,7 @@ render::ShapePipeline::ItemSetter FadeEffect::getItemUniformSetter() const {
         if (!render::TransitionStage::isIndexInvalid(item.getTransitionId())) {
             const auto& scene = args->_scene;
             const auto& batch = args->_batch;
-            auto transitionStage = scene->getStage<render::TransitionStage>(render::TransitionStage::getName());
+            auto transitionStage = scene->getStage<render::TransitionStage>();
             auto& transitionState = transitionStage->getTransition(item.getTransitionId());
 
             if (transitionState.paramsBuffer._size != sizeof(gpu::StructBuffer<FadeObjectParams>)) {
@@ -76,7 +76,7 @@ render::ShapePipeline::ItemSetter FadeEffect::getItemStoredSetter() {
     return [this](const render::ShapePipeline& shapePipeline, render::Args* args, const render::Item& item) {
         if (!render::TransitionStage::isIndexInvalid(item.getTransitionId())) {
             auto scene = args->_scene;
-            auto transitionStage = scene->getStage<render::TransitionStage>(render::TransitionStage::getName());
+            auto transitionStage = scene->getStage<render::TransitionStage>();
             auto& transitionState = transitionStage->getTransition(item.getTransitionId());
             const auto fadeCategory = FadeJob::transitionToCategory[transitionState.eventType];
 

--- a/libraries/render-utils/src/FadeEffect.h
+++ b/libraries/render-utils/src/FadeEffect.h
@@ -11,44 +11,22 @@
 #ifndef hifi_render_utils_FadeEffect_h
 #define hifi_render_utils_FadeEffect_h
 
-#include <DependencyManager.h>
 #include <render/Engine.h>
 
-class FadeEffect : public Dependency {
-    SINGLETON_DEPENDENCY;
-
+class FadeEffect {
 public:
+    using Input = render::ItemBounds;
+    using JobModel = render::Task::ModelI<FadeEffect, render::ItemBounds>;
 
-    void build(render::Task::TaskConcept& task, const task::Varying& editableItems);
+    FadeEffect();
 
-    render::ShapePipeline::BatchSetter getBatchSetter() const;
-    render::ShapePipeline::ItemSetter getItemUniformSetter() const;
-    render::ShapePipeline::ItemSetter getItemStoredSetter();
+    void build(JobModel& task, const render::Varying& inputs, render::Varying& outputs);
 
-    int getLastCategory() const { return _lastCategory; }
-    float getLastThreshold() const { return _lastThreshold; }
-    const glm::vec3& getLastNoiseOffset() const { return _lastNoiseOffset; }
-    const glm::vec3& getLastBaseOffset() const { return _lastBaseOffset; }
-    const glm::vec3& getLastBaseInvSize() const { return _lastBaseInvSize; }
-
-    static void packToAttributes(const int category, const float threshold, const glm::vec3& noiseOffset,
-        const glm::vec3& baseOffset, const glm::vec3& baseInvSize,
-        glm::vec4& packedData1, glm::vec4& packedData2, glm::vec4& packedData3);
+    static render::ShapePipeline::BatchSetter getBatchSetter();
+    static render::ShapePipeline::ItemSetter getItemUniformSetter();
 
 private:
-
-    gpu::BufferView _configurations;
-    gpu::TexturePointer _maskMap;
-
-    // The last fade set through the stored item setter
-    int _lastCategory { 0 };
-    float _lastThreshold { 0.f };
-    glm::vec3 _lastNoiseOffset { 0.f, 0.f, 0.f };
-    glm::vec3 _lastBaseOffset { 0.f, 0.f, 0.f };
-    glm::vec3 _lastBaseInvSize { 1.f, 1.f, 1.f };
-
-    explicit FadeEffect();
-    virtual ~FadeEffect() { }
-
+    static gpu::TexturePointer _maskMap;
 };
+
 #endif // hifi_render_utils_FadeEffect_h

--- a/libraries/render-utils/src/FadeEffectJobs.cpp
+++ b/libraries/render-utils/src/FadeEffectJobs.cpp
@@ -531,6 +531,8 @@ void FadeConfig::load(const QString& configFilePath) {
     }
 }
 
+FadeJob::FadeConfigurationBuffer FadeJob::_configurations;
+
 FadeJob::FadeJob() {
     _previousTime = usecTimestampNow();
 }
@@ -558,6 +560,8 @@ void FadeJob::configure(const Config& config) {
 
 void FadeJob::run(const render::RenderContextPointer& renderContext, FadeJob::Output& output) {
     Config* jobConfig = static_cast<Config*>(renderContext->jobConfig.get());
+    output = (FadeCategory)jobConfig->editedCategory;
+
     auto scene = renderContext->args->_scene;
     auto transitionStage = scene->getStage<render::TransitionStage>();
     uint64_t now = usecTimestampNow();
@@ -565,8 +569,6 @@ void FadeJob::run(const render::RenderContextPointer& renderContext, FadeJob::Ou
     render::Transaction transaction;
     bool isFirstItem = true;
     bool hasTransaction = false;
-    
-    output = (FadeCategory) jobConfig->editedCategory;
 
     // And now update fade effect
     for (auto transitionId : *transitionStage) {

--- a/libraries/render-utils/src/FadeEffectJobs.cpp
+++ b/libraries/render-utils/src/FadeEffectJobs.cpp
@@ -559,7 +559,7 @@ void FadeJob::configure(const Config& config) {
 void FadeJob::run(const render::RenderContextPointer& renderContext, FadeJob::Output& output) {
     Config* jobConfig = static_cast<Config*>(renderContext->jobConfig.get());
     auto scene = renderContext->args->_scene;
-    auto transitionStage = scene->getStage<render::TransitionStage>(render::TransitionStage::getName());
+    auto transitionStage = scene->getStage<render::TransitionStage>();
     uint64_t now = usecTimestampNow();
     const double deltaTime = (int64_t(now) - int64_t(_previousTime)) / double(USECS_PER_SECOND);
     render::Transaction transaction;

--- a/libraries/render-utils/src/FadeEffectJobs.h
+++ b/libraries/render-utils/src/FadeEffectJobs.h
@@ -207,7 +207,7 @@ public:
     void configure(const Config& config);
     void run(const render::RenderContextPointer& renderContext, FadeJob::Output& output);
 
-    gpu::BufferView getConfigurationBuffer() const { return _configurations; }
+    static gpu::BufferView getConfigurationBuffer() { return _configurations; }
 
 private:
 
@@ -219,7 +219,7 @@ private:
     };
     using FadeConfigurationBuffer = gpu::StructBuffer<FadeConfiguration>;
 
-    FadeConfigurationBuffer _configurations;
+    static FadeConfigurationBuffer _configurations;
     float _thresholdScale[FADE_CATEGORY_COUNT];
     uint64_t _previousTime{ 0 };
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -725,9 +725,8 @@ render::ShapePipelinePointer GeometryCache::getShapePipeline(bool textured, bool
 
 render::ShapePipelinePointer GeometryCache::getFadingShapePipeline(bool textured, bool transparent, bool unlit, bool depthBias, bool forward,
         graphics::MaterialKey::CullFaceMode cullFaceMode) {
-    auto fadeEffect = DependencyManager::get<FadeEffect>();
-    auto fadeBatchSetter = fadeEffect->getBatchSetter();
-    auto fadeItemSetter = fadeEffect->getItemUniformSetter();
+    auto fadeBatchSetter = FadeEffect::getBatchSetter();
+    auto fadeItemSetter = FadeEffect::getItemUniformSetter();
     return std::make_shared<render::ShapePipeline>(getSimplePipeline(textured, transparent, unlit, depthBias, true, true, forward, cullFaceMode), nullptr,
         [fadeBatchSetter, fadeItemSetter](const render::ShapePipeline& shapePipeline, gpu::Batch& batch, render::Args* args) {
             batch.setResourceTexture(gr::Texture::MaterialAlbedo, DependencyManager::get<TextureCache>()->getWhiteTexture());

--- a/libraries/render-utils/src/HighlightEffect.cpp
+++ b/libraries/render-utils/src/HighlightEffect.cpp
@@ -156,7 +156,7 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
         _boundsBuffer = std::make_shared<gpu::Buffer>(sizeof(render::ItemBound));
     }
 
-    auto highlightStage = renderContext->_scene->getStage<render::HighlightStage>(render::HighlightStage::getName());
+    auto highlightStage = renderContext->_scene->getStage<render::HighlightStage>();
     auto highlightId = _sharedParameters->_highlightIds[_highlightPassIndex];
 
     if (!inShapes.empty() && !render::HighlightStage::isIndexInvalid(highlightId)) {
@@ -244,7 +244,7 @@ void DrawHighlight::run(const render::RenderContextPointer& renderContext, const
         if (sceneDepthBuffer) {
             auto args = renderContext->args;
 
-            auto highlightStage = renderContext->_scene->getStage<render::HighlightStage>(render::HighlightStage::getName());
+            auto highlightStage = renderContext->_scene->getStage<render::HighlightStage>();
             auto highlightId = _sharedParameters->_highlightIds[_highlightPassIndex];
             if (!render::HighlightStage::isIndexInvalid(highlightId)) {
                 auto& highlight = highlightStage->getHighlight(highlightId);
@@ -408,7 +408,7 @@ gpu::PipelinePointer& DebugHighlight::getDepthPipeline() {
 
 void SelectionToHighlight::run(const render::RenderContextPointer& renderContext, const Inputs& inputs, Outputs& outputs) {
     auto scene = renderContext->_scene;
-    auto highlightStage = scene->getStage<render::HighlightStage>(render::HighlightStage::getName());
+    auto highlightStage = scene->getStage<render::HighlightStage>();
 
     auto outlines = inputs.get0();
     auto framebuffer = inputs.get1();
@@ -570,7 +570,7 @@ void AppendNonMetaOutlines::run(const render::RenderContextPointer& renderContex
 
 void HighlightCleanup::run(const render::RenderContextPointer& renderContext, const Inputs& inputs) {
     auto scene = renderContext->_scene;
-    auto highlightStage = scene->getStage<render::HighlightStage>(render::HighlightStage::getName());
+    auto highlightStage = scene->getStage<render::HighlightStage>();
 
     for (auto index : inputs.get0()) {
         std::string selectionName = highlightStage->getHighlight(index)._selectionName;

--- a/libraries/render-utils/src/HighlightEffect.cpp
+++ b/libraries/render-utils/src/HighlightEffect.cpp
@@ -311,6 +311,8 @@ const gpu::PipelinePointer& DrawHighlight::getPipeline(const render::HighlightSt
     return style.isFilled() ? _pipelineFilled : _pipeline;
 }
 
+gpu::PipelinePointer DebugHighlight::_depthPipeline;
+
 DebugHighlight::DebugHighlight() {
     _geometryDepthId = DependencyManager::get<GeometryCache>()->allocateID();
 }
@@ -396,7 +398,7 @@ void DebugHighlight::initializePipelines() {
     _depthPipeline = gpu::Pipeline::create(program, state);
 }
 
-const gpu::PipelinePointer& DebugHighlight::getDepthPipeline() {
+gpu::PipelinePointer& DebugHighlight::getDepthPipeline() {
     if (!_depthPipeline) {
         initializePipelines();
     }

--- a/libraries/render-utils/src/HighlightEffect.cpp
+++ b/libraries/render-utils/src/HighlightEffect.cpp
@@ -481,8 +481,7 @@ void DrawHighlightTask::build(JobModel& task, const render::Varying& inputs, ren
     std::call_once(once, [] {
         auto state = std::make_shared<gpu::State>();
         state->setColorWriteMask(false, false, false, false);
-        auto fadeEffect = DependencyManager::get<FadeEffect>();
-        initZPassPipelines(*shapePlumber, state, fadeEffect->getBatchSetter(), fadeEffect->getItemUniformSetter());
+        initZPassPipelines(*shapePlumber, state, FadeEffect::getBatchSetter(), FadeEffect::getItemUniformSetter());
     });
     auto sharedParameters = std::make_shared<HighlightSharedParameters>();
 

--- a/libraries/render-utils/src/HighlightEffect.h
+++ b/libraries/render-utils/src/HighlightEffect.h
@@ -186,12 +186,12 @@ public:
 
 private:
 
-    gpu::PipelinePointer _depthPipeline;
+    static gpu::PipelinePointer _depthPipeline;
     int _geometryDepthId{ 0 };
     bool _isDisplayEnabled{ false };
 
-    const gpu::PipelinePointer& getDepthPipeline();
-    void initializePipelines();
+    static gpu::PipelinePointer& getDepthPipeline();
+    static void initializePipelines();
 };
 
 class DrawHighlightTask {

--- a/libraries/render-utils/src/LightClusters.cpp
+++ b/libraries/render-utils/src/LightClusters.cpp
@@ -575,10 +575,9 @@ void LightClusteringPass::run(const render::RenderContextPointer& renderContext,
     config->setNumClusteredLightReferences(clusteringStats.z);
 }
 
-DebugLightClusters::DebugLightClusters() {
-
-}
-
+gpu::PipelinePointer DebugLightClusters::_drawClusterGrid;
+gpu::PipelinePointer DebugLightClusters::_drawClusterFromDepth;
+gpu::PipelinePointer DebugLightClusters::_drawClusterContent;
 
 void DebugLightClusters::configure(const Config& config) {
     doDrawGrid = config.doDrawGrid;
@@ -587,7 +586,7 @@ void DebugLightClusters::configure(const Config& config) {
 
 }
 
-const gpu::PipelinePointer DebugLightClusters::getDrawClusterGridPipeline() {
+gpu::PipelinePointer DebugLightClusters::getDrawClusterGridPipeline() {
     if (!_drawClusterGrid) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::lightClusters_drawGrid);
         auto state = std::make_shared<gpu::State>();
@@ -603,7 +602,7 @@ const gpu::PipelinePointer DebugLightClusters::getDrawClusterGridPipeline() {
     return _drawClusterGrid;
 }
 
-const gpu::PipelinePointer DebugLightClusters::getDrawClusterFromDepthPipeline() {
+gpu::PipelinePointer DebugLightClusters::getDrawClusterFromDepthPipeline() {
     if (!_drawClusterFromDepth) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::lightClusters_drawClusterFromDepth);
         auto state = std::make_shared<gpu::State>();
@@ -617,7 +616,7 @@ const gpu::PipelinePointer DebugLightClusters::getDrawClusterFromDepthPipeline()
     return _drawClusterFromDepth;
 }
 
-const gpu::PipelinePointer DebugLightClusters::getDrawClusterContentPipeline() {
+gpu::PipelinePointer DebugLightClusters::getDrawClusterContentPipeline() {
     if (!_drawClusterContent) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::lightClusters_drawClusterContent);
         auto state = std::make_shared<gpu::State>();

--- a/libraries/render-utils/src/LightClusters.h
+++ b/libraries/render-utils/src/LightClusters.h
@@ -217,23 +217,25 @@ public:
     using Config = DebugLightClustersConfig;
     using JobModel = render::Job::ModelI<DebugLightClusters, Inputs, Config>;
 
-    DebugLightClusters();
+    DebugLightClusters() {}
 
     void configure(const Config& config);
 
     void run(const render::RenderContextPointer& renderContext, const Inputs& inputs);
 
 protected:
+    static gpu::PipelinePointer _drawClusterGrid;
+    static gpu::PipelinePointer _drawClusterFromDepth;
+    static gpu::PipelinePointer _drawClusterContent;
     gpu::BufferPointer _gridBuffer;
-    gpu::PipelinePointer _drawClusterGrid;
-    gpu::PipelinePointer _drawClusterFromDepth;
-    gpu::PipelinePointer _drawClusterContent;
-    const gpu::PipelinePointer getDrawClusterGridPipeline();
-    const gpu::PipelinePointer getDrawClusterFromDepthPipeline();
-    const gpu::PipelinePointer getDrawClusterContentPipeline();
+
     bool doDrawGrid { false };
     bool doDrawClusterFromDepth { false };
     bool doDrawContent { false };
+
+    static gpu::PipelinePointer getDrawClusterGridPipeline();
+    static gpu::PipelinePointer getDrawClusterFromDepthPipeline();
+    static gpu::PipelinePointer getDrawClusterContentPipeline();
 };
 
 #endif

--- a/libraries/render-utils/src/RenderCommonTask.cpp
+++ b/libraries/render-utils/src/RenderCommonTask.cpp
@@ -357,9 +357,8 @@ public:
             state->setDepthTest(true, true, gpu::LESS_EQUAL);
             PrepareStencil::testMaskDrawShape(*state);
 
-            auto fadeEffect = DependencyManager::get<FadeEffect>();
-            initMirrorPipelines(*_forwardPipelines, state, fadeEffect->getBatchSetter(), fadeEffect->getItemUniformSetter(), true);
-            initMirrorPipelines(*_deferredPipelines, state, fadeEffect->getBatchSetter(), fadeEffect->getItemUniformSetter(), false);
+            initMirrorPipelines(*_forwardPipelines, state, FadeEffect::getBatchSetter(), FadeEffect::getItemUniformSetter(), true);
+            initMirrorPipelines(*_deferredPipelines, state, FadeEffect::getBatchSetter(), FadeEffect::getItemUniformSetter(), false);
         });
     }
 

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -256,7 +256,7 @@ void RenderDeferredTask::build(JobModel& task, const render::Varying& input, ren
     const auto toneMappedBuffer = task.addJob<ToneMapAndResample>("ToneMapping", toneMappingInputs);
 
     // Debugging task is happening in the "over" layer after tone mapping and just before HUD
-    { // Debug the bounds of the rendered items, still look at the zbuffer
+    if (depth == 0) { // Debug the bounds of the rendered items, still look at the zbuffer
         const auto extraDebugBuffers = RenderDeferredTaskDebug::ExtraBuffers(linearDepthTarget, surfaceGeometryFramebuffer, ambientOcclusionFramebuffer, ambientOcclusionUniforms, scatteringResource, velocityBuffer);
         const auto debugInputs = RenderDeferredTaskDebug::Input(fetchedItems, shadowTaskOutputs, lightingStageInputs, lightClusters, prepareDeferredOutputs, extraDebugBuffers,
             deferredFrameTransform, jitter, lightingModel).asVarying();

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -101,12 +101,11 @@ void RenderDeferredTask::configure(const Config& config) {
 }
 
 void RenderDeferredTask::build(JobModel& task, const render::Varying& input, render::Varying& output, render::CullFunctor cullFunctor, size_t depth) {
-    static auto fadeEffect = DependencyManager::get<FadeEffect>();
     // Prepare the ShapePipelines
     static ShapePlumberPointer shapePlumber = std::make_shared<ShapePlumber>();
     static std::once_flag once;
     std::call_once(once, [] {
-        initDeferredPipelines(*shapePlumber, fadeEffect->getBatchSetter(), fadeEffect->getItemUniformSetter());
+        initDeferredPipelines(*shapePlumber, FadeEffect::getBatchSetter(), FadeEffect::getItemUniformSetter());
     });
 
     const auto& inputs = input.get<Input>();
@@ -146,7 +145,9 @@ void RenderDeferredTask::build(JobModel& task, const render::Varying& input, ren
         // Shadow Stage Frame
         const auto shadowFrame = shadowTaskOutputs[1];
 
-    fadeEffect->build(task, opaques);
+    if (depth == 0) {
+        task.addJob<FadeEffect>("FadeEffect", opaques);
+    }
 
     const auto jitter = task.addJob<JitterSample>("JitterCam");
 

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -161,8 +161,7 @@ void RenderForwardTask::build(JobModel& task, const render::Varying& input, rend
     task.addJob<DrawLayered3D>("DrawInFrontOpaque", inFrontOpaquesInputs, true);
     task.addJob<DrawLayered3D>("DrawInFrontTransparent", inFrontTransparentsInputs, false);
 
-    {  // Debug the bounds of the rendered items, still look at the zbuffer
-
+    if (depth == 0) {  // Debug the bounds of the rendered items, still look at the zbuffer
         task.addJob<DrawBounds>("DrawMetaBounds", metas);
         task.addJob<DrawBounds>("DrawBounds", opaques);
         task.addJob<DrawBounds>("DrawTransparentBounds", transparents);

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -26,7 +26,6 @@
 #include "render-utils/ShaderConstants.h"
 #include "StencilMaskPass.h"
 #include "ZoneRenderer.h"
-#include "FadeEffect.h"
 #include "ToneMapAndResampleTask.h"
 #include "BackgroundStage.h"
 #include "FramebufferCache.h"
@@ -72,7 +71,6 @@ void RenderForwardTask::build(JobModel& task, const render::Varying& input, rend
     task.addJob<SetRenderMethod>("SetRenderMethodTask", render::Args::FORWARD);
 
     // Prepare the ShapePipelines
-    auto fadeEffect = DependencyManager::get<FadeEffect>();
     static ShapePlumberPointer shapePlumber = std::make_shared<ShapePlumber>();
     static std::once_flag once;
     std::call_once(once, [] {
@@ -111,9 +109,6 @@ void RenderForwardTask::build(JobModel& task, const render::Varying& input, rend
             const auto tonemappingFrame = currentStageFrames[4];
  
         const auto& zones = lightingStageInputs[1];
-
-    // First job, alter faded
-    fadeEffect->build(task, opaques);
 
     // GPU jobs: Start preparing the main framebuffer
     const auto scaledPrimaryFramebuffer = task.addJob<PreparePrimaryFramebufferMSAA>("PreparePrimaryBufferForward");

--- a/libraries/render-utils/src/RenderShadowTask.cpp
+++ b/libraries/render-utils/src/RenderShadowTask.cpp
@@ -50,8 +50,7 @@ void RenderShadowTask::build(JobModel& task, const render::Varying& input, rende
     static ShapePlumberPointer shapePlumber = std::make_shared<ShapePlumber>();
     static std::once_flag once;
     std::call_once(once, [] {
-        auto fadeEffect = DependencyManager::get<FadeEffect>();
-        initZPassPipelines(*shapePlumber, std::make_shared<gpu::State>(), fadeEffect->getBatchSetter(), fadeEffect->getItemUniformSetter());
+        initZPassPipelines(*shapePlumber, std::make_shared<gpu::State>(), FadeEffect::getBatchSetter(), FadeEffect::getItemUniformSetter());
     });
 
     const auto setupOutput = task.addJob<RenderShadowSetup>("ShadowSetup", input);

--- a/libraries/render-utils/src/StencilMaskPass.cpp
+++ b/libraries/render-utils/src/StencilMaskPass.cpp
@@ -17,6 +17,10 @@
 
 using namespace render;
 
+gpu::PipelinePointer PrepareStencil::_meshStencilPipeline;
+gpu::PipelinePointer PrepareStencil::_paintStencilPipeline;
+graphics::MeshPointer PrepareStencil::_mesh;
+
 void PrepareStencil::configure(const Config& config) {
     _maskMode = config.maskMode;
 }

--- a/libraries/render-utils/src/StencilMaskPass.h
+++ b/libraries/render-utils/src/StencilMaskPass.h
@@ -59,14 +59,14 @@ public:
     static void testMaskDrawShapeNoAA(gpu::State& state);
 
 private:
-    gpu::PipelinePointer _meshStencilPipeline;
-    gpu::PipelinePointer getMeshStencilPipeline();
+    static gpu::PipelinePointer _meshStencilPipeline;
+    static gpu::PipelinePointer getMeshStencilPipeline();
 
-    gpu::PipelinePointer _paintStencilPipeline;
-    gpu::PipelinePointer getPaintStencilPipeline();
+    static gpu::PipelinePointer _paintStencilPipeline;
+    static gpu::PipelinePointer getPaintStencilPipeline();
 
-    graphics::MeshPointer _mesh;
-    graphics::MeshPointer getMesh();
+    static graphics::MeshPointer _mesh;
+    static graphics::MeshPointer getMesh();
 
     StencilMaskMode _maskMode { StencilMaskMode::NONE };
 };

--- a/libraries/render-utils/src/SubsurfaceScattering.cpp
+++ b/libraries/render-utils/src/SubsurfaceScattering.cpp
@@ -411,8 +411,8 @@ gpu::TexturePointer SubsurfaceScatteringResource::generateScatteringSpecularBeck
     return beckmannMap;
 }
 
-DebugSubsurfaceScattering::DebugSubsurfaceScattering() {
-}
+gpu::PipelinePointer DebugSubsurfaceScattering::_scatteringPipeline;
+gpu::PipelinePointer DebugSubsurfaceScattering::_showLUTPipeline;
 
 void DebugSubsurfaceScattering::configure(const Config& config) {
 
@@ -427,8 +427,6 @@ void DebugSubsurfaceScattering::configure(const Config& config) {
     _debugParams->setSubData(0, _debugCursorTexcoord);
 }
 
-
-
 gpu::PipelinePointer DebugSubsurfaceScattering::getScatteringPipeline() {
     if (!_scatteringPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::subsurfaceScattering_drawScattering);
@@ -440,8 +438,6 @@ gpu::PipelinePointer DebugSubsurfaceScattering::getScatteringPipeline() {
     return _scatteringPipeline;
 }
 
-gpu::PipelinePointer _showLUTPipeline;
-
 gpu::PipelinePointer DebugSubsurfaceScattering::getShowLUTPipeline() {
     if (!_showLUTPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::gpu::program::drawUnitQuatTextureOpaque);
@@ -452,13 +448,11 @@ gpu::PipelinePointer DebugSubsurfaceScattering::getShowLUTPipeline() {
     return _showLUTPipeline;
 }
 
-
 void DebugSubsurfaceScattering::run(const render::RenderContextPointer& renderContext, const Inputs& inputs) {
     assert(renderContext->args);
     assert(renderContext->args->hasViewFrustum());
 
     RenderArgs* args = renderContext->args;
-
 
     auto& frameTransform = inputs.get0();
     auto& deferredFramebuffer = inputs.get1();
@@ -477,8 +471,6 @@ void DebugSubsurfaceScattering::run(const render::RenderContextPointer& renderCo
     auto scatteringTable = scatteringResource->getScatteringTable();
     auto scatteringSpecular = scatteringResource->getScatteringSpecular();
 
-
-
     auto lightStage = renderContext->_scene->getStage<LightStage>();
     assert(lightStage);
    // const auto light = DependencyManager::get<DeferredLightingEffect>()->getLightStage()->getLight(0);
@@ -490,7 +482,6 @@ void DebugSubsurfaceScattering::run(const render::RenderContextPointer& renderCo
     
     gpu::doInBatch("DebugSubsurfaceScattering::run", args->_context, [=](gpu::Batch& batch) {
         batch.enableStereo(false);
-
 
         auto viewportSize = std::min(args->_viewport.z, args->_viewport.w) >> 1;
         auto offsetViewport = viewportSize * 0.1;

--- a/libraries/render-utils/src/SubsurfaceScattering.h
+++ b/libraries/render-utils/src/SubsurfaceScattering.h
@@ -167,18 +167,19 @@ public:
     using Config = DebugSubsurfaceScatteringConfig;
     using JobModel = render::Job::ModelI<DebugSubsurfaceScattering, Inputs, Config>;
 
-    DebugSubsurfaceScattering();
+    DebugSubsurfaceScattering() {}
 
     void configure(const Config& config);
     void run(const render::RenderContextPointer& renderContext, const Inputs& inputs);
 
 private:
 
-    gpu::PipelinePointer _scatteringPipeline;
-    gpu::PipelinePointer getScatteringPipeline();
+    static gpu::PipelinePointer _scatteringPipeline;
+    static gpu::PipelinePointer getScatteringPipeline();
 
-    gpu::PipelinePointer _showLUTPipeline;
-    gpu::PipelinePointer getShowLUTPipeline();
+    static gpu::PipelinePointer _showLUTPipeline;
+    static gpu::PipelinePointer getShowLUTPipeline();
+
     gpu::BufferPointer _debugParams;
     bool _showProfile{ false };
     bool _showLUT{ false };

--- a/libraries/render-utils/src/SurfaceGeometryPass.cpp
+++ b/libraries/render-utils/src/SurfaceGeometryPass.cpp
@@ -137,9 +137,8 @@ gpu::TexturePointer LinearDepthFramebuffer::getHalfNormalTexture() {
     return _halfNormalTexture;
 }
 
-
-LinearDepthPass::LinearDepthPass() {
-}
+gpu::PipelinePointer LinearDepthPass::_linearDepthPipeline;
+gpu::PipelinePointer LinearDepthPass::_downsamplePipeline;
 
 void LinearDepthPass::configure(const Config& config) {
 }
@@ -179,8 +178,8 @@ void LinearDepthPass::run(const render::RenderContextPointer& renderContext, con
     outputs.edit3() = halfLinearDepthTexture;
     outputs.edit4() = halfNormalTexture;
    
-    auto linearDepthPipeline = getLinearDepthPipeline(renderContext);
-    auto downsamplePipeline = getDownsamplePipeline(renderContext);
+    auto linearDepthPipeline = getLinearDepthPipeline();
+    auto downsamplePipeline = getDownsamplePipeline();
 
     auto depthViewport = args->_viewport;
     auto halfViewport = depthViewport >> 1;
@@ -222,8 +221,7 @@ void LinearDepthPass::run(const render::RenderContextPointer& renderContext, con
     config->setGPUBatchRunTime(_gpuTimer->getGPUAverage(), _gpuTimer->getBatchAverage());
 }
 
-
-const gpu::PipelinePointer& LinearDepthPass::getLinearDepthPipeline(const render::RenderContextPointer& renderContext) {
+const gpu::PipelinePointer& LinearDepthPass::getLinearDepthPipeline() {
     gpu::ShaderPointer program;
     if (!_linearDepthPipeline) {
         program = gpu::Shader::createProgram(shader::render_utils::program::surfaceGeometry_makeLinearDepth);
@@ -243,8 +241,7 @@ const gpu::PipelinePointer& LinearDepthPass::getLinearDepthPipeline(const render
     return _linearDepthPipeline;
 }
 
-
-const gpu::PipelinePointer& LinearDepthPass::getDownsamplePipeline(const render::RenderContextPointer& renderContext) {
+const gpu::PipelinePointer& LinearDepthPass::getDownsamplePipeline() {
     if (!_downsamplePipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::surfaceGeometry_downsampleDepthNormal);
 
@@ -366,6 +363,8 @@ void SurfaceGeometryFramebuffer::setResolutionLevel(int resolutionLevel) {
     }
 }
 
+gpu::PipelinePointer SurfaceGeometryPass::_curvaturePipeline;
+
 SurfaceGeometryPass::SurfaceGeometryPass() :
     _diffusePass(false)
 {
@@ -454,7 +453,7 @@ void SurfaceGeometryPass::run(const render::RenderContextPointer& renderContext,
     outputs.edit2() = curvatureFramebuffer;
     outputs.edit3() = lowCurvatureFramebuffer;
 
-    auto curvaturePipeline = getCurvaturePipeline(renderContext);
+    auto curvaturePipeline = getCurvaturePipeline();
     auto diffuseVPipeline = _diffusePass.getBlurVPipeline();
     auto diffuseHPipeline = _diffusePass.getBlurHPipeline();
 
@@ -532,7 +531,7 @@ void SurfaceGeometryPass::run(const render::RenderContextPointer& renderContext,
     config->setGPUBatchRunTime(_gpuTimer->getGPUAverage(), _gpuTimer->getBatchAverage());
 }
 
-const gpu::PipelinePointer& SurfaceGeometryPass::getCurvaturePipeline(const render::RenderContextPointer& renderContext) {
+const gpu::PipelinePointer& SurfaceGeometryPass::getCurvaturePipeline() {
     if (!_curvaturePipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::surfaceGeometry_makeCurvature);
 

--- a/libraries/render-utils/src/SurfaceGeometryPass.h
+++ b/libraries/render-utils/src/SurfaceGeometryPass.h
@@ -73,21 +73,19 @@ public:
     using Config = LinearDepthPassConfig;
     using JobModel = render::Job::ModelIO<LinearDepthPass, Inputs, Outputs, Config>;
 
-    LinearDepthPass();
+    LinearDepthPass() {}
 
     void configure(const Config& config);
     void run(const render::RenderContextPointer& renderContext, const Inputs& inputs, Outputs& outputs);
     
 private:
-    typedef gpu::BufferView UniformBufferView;
-
     LinearDepthFramebufferPointer _linearDepthFramebuffer;
 
-    const gpu::PipelinePointer& getLinearDepthPipeline(const render::RenderContextPointer& renderContext);
-    gpu::PipelinePointer _linearDepthPipeline;
+    static const gpu::PipelinePointer& getLinearDepthPipeline();
+    static gpu::PipelinePointer _linearDepthPipeline;
 
-    const gpu::PipelinePointer& getDownsamplePipeline(const render::RenderContextPointer& renderContext);
-    gpu::PipelinePointer _downsamplePipeline;
+    static const gpu::PipelinePointer& getDownsamplePipeline();
+    static gpu::PipelinePointer _downsamplePipeline;
 
     gpu::RangeTimerPointer _gpuTimer;
 };
@@ -194,15 +192,13 @@ private:
     };
     gpu::BufferView _parametersBuffer;
 
-
     SurfaceGeometryFramebufferPointer _surfaceGeometryFramebuffer;
 
-    const gpu::PipelinePointer& getCurvaturePipeline(const render::RenderContextPointer& renderContext);
+    static const gpu::PipelinePointer& getCurvaturePipeline();
 
-    gpu::PipelinePointer _curvaturePipeline;
-    
+    static gpu::PipelinePointer _curvaturePipeline;
+
     render::BlurGaussianDepthAware _diffusePass;
-
 
     gpu::RangeTimerPointer _gpuTimer;
 };

--- a/libraries/render-utils/src/ToneMapAndResampleTask.h
+++ b/libraries/render-utils/src/ToneMapAndResampleTask.h
@@ -67,7 +67,6 @@ protected:
     gpu::FramebufferPointer _destinationFrameBuffer;
 
 private:
-    gpu::PipelinePointer _blitLightBuffer;
     float _exposure { 0.0f };
 
     bool _debug { false };

--- a/libraries/render-utils/src/VelocityBufferPass.cpp
+++ b/libraries/render-utils/src/VelocityBufferPass.cpp
@@ -81,8 +81,7 @@ gpu::TexturePointer VelocityFramebuffer::getVelocityTexture() {
     return _velocityTexture;
 }
 
-VelocityBufferPass::VelocityBufferPass() {
-}
+gpu::PipelinePointer VelocityBufferPass::_cameraMotionPipeline;
 
 void VelocityBufferPass::configure(const Config& config) {
 }
@@ -114,7 +113,7 @@ void VelocityBufferPass::run(const render::RenderContextPointer& renderContext, 
     outputs.edit1() = velocityFBO;
     outputs.edit2() = velocityTexture;
    
-    auto cameraMotionPipeline = getCameraMotionPipeline(renderContext);
+    auto cameraMotionPipeline = getCameraMotionPipeline();
 
     auto fullViewport = args->_viewport;
 
@@ -144,7 +143,7 @@ void VelocityBufferPass::run(const render::RenderContextPointer& renderContext, 
 }
 
 
-const gpu::PipelinePointer& VelocityBufferPass::getCameraMotionPipeline(const render::RenderContextPointer& renderContext) {
+const gpu::PipelinePointer& VelocityBufferPass::getCameraMotionPipeline() {
     if (!_cameraMotionPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::velocityBuffer_cameraMotion);
         gpu::StatePointer state = std::make_shared<gpu::State>();

--- a/libraries/render-utils/src/VelocityBufferPass.h
+++ b/libraries/render-utils/src/VelocityBufferPass.h
@@ -69,7 +69,7 @@ public:
     using Config = VelocityBufferPassConfig;
     using JobModel = render::Job::ModelIO<VelocityBufferPass, Inputs, Outputs, Config>;
 
-    VelocityBufferPass();
+    VelocityBufferPass() {}
 
     void configure(const Config& config);
     void run(const render::RenderContextPointer& renderContext, const Inputs& inputs, Outputs& outputs);
@@ -79,8 +79,8 @@ private:
 
     VelocityFramebufferPointer _velocityFramebuffer;
 
-    const gpu::PipelinePointer& getCameraMotionPipeline(const render::RenderContextPointer& renderContext);
-    gpu::PipelinePointer _cameraMotionPipeline;
+    static const gpu::PipelinePointer& getCameraMotionPipeline();
+    static gpu::PipelinePointer _cameraMotionPipeline;
 
     gpu::RangeTimerPointer _gpuTimer;
 };

--- a/libraries/render-utils/src/ZoneRenderer.cpp
+++ b/libraries/render-utils/src/ZoneRenderer.cpp
@@ -93,6 +93,10 @@ void SetupZones::run(const RenderContextPointer& context, const Input& input) {
     ambientOcclusionStage->_currentFrame.pushAmbientOcclusion(INVALID_INDEX);
 }
 
+gpu::PipelinePointer DebugZoneLighting::_keyLightPipeline;
+gpu::PipelinePointer DebugZoneLighting::_ambientPipeline;
+gpu::PipelinePointer DebugZoneLighting::_backgroundPipeline;
+
 const gpu::PipelinePointer& DebugZoneLighting::getKeyLightPipeline() {
     if (!_keyLightPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::zone_drawKeyLight);

--- a/libraries/render-utils/src/ZoneRenderer.h
+++ b/libraries/render-utils/src/ZoneRenderer.h
@@ -83,13 +83,13 @@ public:
 
 protected:
 
-    gpu::PipelinePointer _keyLightPipeline;
-    gpu::PipelinePointer _ambientPipeline;
-    gpu::PipelinePointer _backgroundPipeline;
+    static gpu::PipelinePointer _keyLightPipeline;
+    static gpu::PipelinePointer _ambientPipeline;
+    static gpu::PipelinePointer _backgroundPipeline;
 
-    const gpu::PipelinePointer& getKeyLightPipeline();
-    const gpu::PipelinePointer& getAmbientPipeline();
-    const gpu::PipelinePointer& getBackgroundPipeline();
+    static const gpu::PipelinePointer& getKeyLightPipeline();
+    static const gpu::PipelinePointer& getAmbientPipeline();
+    static const gpu::PipelinePointer& getBackgroundPipeline();
 };
 
 

--- a/libraries/render/src/render/BlurTask.cpp
+++ b/libraries/render/src/render/BlurTask.cpp
@@ -195,6 +195,9 @@ bool BlurInOutResource::updateResources(const gpu::FramebufferPointer& sourceFra
     return true;
 }
 
+gpu::PipelinePointer BlurGaussian::_blurVPipeline;
+gpu::PipelinePointer BlurGaussian::_blurHPipeline;
+
 BlurGaussian::BlurGaussian() {
     _parameters = std::make_shared<BlurParams>();
 }
@@ -294,7 +297,8 @@ void BlurGaussian::run(const RenderContextPointer& renderContext, const Inputs& 
     });
 }
 
-
+gpu::PipelinePointer BlurGaussianDepthAware::_blurVPipeline;
+gpu::PipelinePointer BlurGaussianDepthAware::_blurHPipeline;
 
 BlurGaussianDepthAware::BlurGaussianDepthAware(bool generateOutputFramebuffer, const BlurParamsPointer& params) :
     _inOutResources(generateOutputFramebuffer, 1U),

--- a/libraries/render/src/render/BlurTask.h
+++ b/libraries/render/src/render/BlurTask.h
@@ -129,11 +129,11 @@ protected:
 
     BlurParamsPointer _parameters;
 
-    gpu::PipelinePointer _blurVPipeline;
-    gpu::PipelinePointer _blurHPipeline;
+    static gpu::PipelinePointer _blurVPipeline;
+    static gpu::PipelinePointer _blurHPipeline;
 
-    gpu::PipelinePointer getBlurVPipeline();
-    gpu::PipelinePointer getBlurHPipeline();
+    static gpu::PipelinePointer getBlurVPipeline();
+    static gpu::PipelinePointer getBlurHPipeline();
 
     BlurInOutResource _inOutResources;
 };
@@ -163,12 +163,12 @@ public:
 
     const BlurParamsPointer& getParameters() const { return _parameters; }
  
-    gpu::PipelinePointer getBlurVPipeline();
-    gpu::PipelinePointer getBlurHPipeline();
+    static gpu::PipelinePointer getBlurVPipeline();
+    static gpu::PipelinePointer getBlurHPipeline();
 
 protected:
-    gpu::PipelinePointer _blurVPipeline;
-    gpu::PipelinePointer _blurHPipeline;
+    static gpu::PipelinePointer _blurVPipeline;
+    static gpu::PipelinePointer _blurHPipeline;
 
     BlurInOutResource _inOutResources;
     BlurParamsPointer _parameters;

--- a/libraries/render/src/render/DrawSceneOctree.cpp
+++ b/libraries/render/src/render/DrawSceneOctree.cpp
@@ -30,7 +30,10 @@ gpu::PipelinePointer DrawSceneOctree::_drawItemBoundPipeline;
 gpu::Stream::FormatPointer DrawSceneOctree::_cellBoundsFormat = std::make_shared<gpu::Stream::Format>();
 
 DrawSceneOctree::DrawSceneOctree() {
-    _cellBoundsFormat->setAttribute(0, 0, gpu::Element(gpu::VEC4, gpu::INT32, gpu::XYZW), 0, gpu::Stream::PER_INSTANCE);
+    std::once_flag once;
+    std::call_once(once, [] {
+        _cellBoundsFormat->setAttribute(0, 0, gpu::Element(gpu::VEC4, gpu::INT32, gpu::XYZW), 0, gpu::Stream::PER_INSTANCE);
+    });
 }
 
 const gpu::PipelinePointer DrawSceneOctree::getDrawCellBoundsPipeline() {

--- a/libraries/render/src/render/DrawSceneOctree.cpp
+++ b/libraries/render/src/render/DrawSceneOctree.cpp
@@ -24,6 +24,15 @@
 
 using namespace render;
 
+gpu::PipelinePointer DrawSceneOctree::_drawCellBoundsPipeline;
+gpu::PipelinePointer DrawSceneOctree::_drawLODReticlePipeline;
+gpu::PipelinePointer DrawSceneOctree::_drawItemBoundPipeline;
+gpu::Stream::FormatPointer DrawSceneOctree::_cellBoundsFormat = std::make_shared<gpu::Stream::Format>();
+
+DrawSceneOctree::DrawSceneOctree() {
+    _cellBoundsFormat->setAttribute(0, 0, gpu::Element(gpu::VEC4, gpu::INT32, gpu::XYZW), 0, gpu::Stream::PER_INSTANCE);
+}
+
 const gpu::PipelinePointer DrawSceneOctree::getDrawCellBoundsPipeline() {
     if (!_drawCellBoundsPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render::program::drawCellBounds);
@@ -36,9 +45,6 @@ const gpu::PipelinePointer DrawSceneOctree::getDrawCellBoundsPipeline() {
 
         // Good to go add the brand new pipeline
         _drawCellBoundsPipeline = gpu::Pipeline::create(program, state);
-        _cellBoundsFormat = std::make_shared<gpu::Stream::Format>();
-        _cellBoundsFormat->setAttribute(0, 0, gpu::Element(gpu::VEC4, gpu::INT32, gpu::XYZW), 0, gpu::Stream::PER_INSTANCE);
-        _cellBoundsBuffer = std::make_shared<gpu::Buffer>();
     }
     return _drawCellBoundsPipeline;
 }
@@ -61,7 +67,6 @@ void DrawSceneOctree::configure(const Config& config) {
     _showVisibleCells = config.showVisibleCells;
     _showEmptyCells = config.showEmptyCells;
 }
-
 
 void DrawSceneOctree::run(const RenderContextPointer& renderContext, const ItemSpatialTree::ItemSelection& inSelection) {
     assert(renderContext->args);
@@ -131,6 +136,8 @@ void DrawSceneOctree::run(const RenderContextPointer& renderContext, const ItemS
         }
     });
 }
+
+gpu::PipelinePointer DrawItemSelection::_drawItemBoundPipeline;
 
 const gpu::PipelinePointer DrawItemSelection::getDrawItemBoundPipeline() {
     if (!_drawItemBoundPipeline) {

--- a/libraries/render/src/render/DrawSceneOctree.h
+++ b/libraries/render/src/render/DrawSceneOctree.h
@@ -50,11 +50,11 @@ namespace render {
     };
 
     class DrawSceneOctree {
-        gpu::PipelinePointer _drawCellBoundsPipeline;
-        gpu::PipelinePointer _drawLODReticlePipeline;
-        gpu::PipelinePointer _drawItemBoundPipeline;
-        gpu::BufferPointer _cellBoundsBuffer;
-        gpu::Stream::FormatPointer _cellBoundsFormat;
+        static gpu::PipelinePointer _drawCellBoundsPipeline;
+        static gpu::PipelinePointer _drawLODReticlePipeline;
+        static gpu::PipelinePointer _drawItemBoundPipeline;
+        static gpu::Stream::FormatPointer _cellBoundsFormat;
+        gpu::BufferPointer _cellBoundsBuffer { std::make_shared<gpu::Buffer>() };
 
         bool _showVisibleCells; // initialized by Config
         bool _showEmptyCells; // initialized by Config
@@ -63,14 +63,14 @@ namespace render {
         using Config = DrawSceneOctreeConfig;
         using JobModel = Job::ModelI<DrawSceneOctree, ItemSpatialTree::ItemSelection, Config>;
 
-        DrawSceneOctree() {}
+        DrawSceneOctree();
 
         void configure(const Config& config);
         void run(const RenderContextPointer& renderContext, const ItemSpatialTree::ItemSelection& selection);
 
-        const gpu::PipelinePointer getDrawCellBoundsPipeline();
-        const gpu::PipelinePointer getDrawLODReticlePipeline();
-        const gpu::PipelinePointer getDrawItemBoundPipeline();
+        static const gpu::PipelinePointer getDrawCellBoundsPipeline();
+        static const gpu::PipelinePointer getDrawLODReticlePipeline();
+        static const gpu::PipelinePointer getDrawItemBoundPipeline();
     };
 
 
@@ -105,7 +105,7 @@ namespace render {
     };
 
     class DrawItemSelection {
-        gpu::PipelinePointer _drawItemBoundPipeline;
+        static gpu::PipelinePointer _drawItemBoundPipeline;
         gpu::BufferPointer _boundsBufferInside;
         gpu::BufferPointer _boundsBufferInsideSubcell;
         gpu::BufferPointer _boundsBufferPartial;
@@ -125,7 +125,7 @@ namespace render {
         void configure(const Config& config);
         void run(const RenderContextPointer& renderContext, const ItemSpatialTree::ItemSelection& selection);
 
-        const gpu::PipelinePointer getDrawItemBoundPipeline();
+        static const gpu::PipelinePointer getDrawItemBoundPipeline();
     };
 }
 

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -32,6 +32,10 @@ void DrawStatusConfig::dirtyHelper() {
     emit dirty();
 }
 
+gpu::PipelinePointer DrawStatus::_drawItemBoundsPipeline;
+gpu::PipelinePointer DrawStatus::_drawItemStatusPipeline;
+gpu::Stream::FormatPointer DrawStatus::_vertexFormat;
+
 const gpu::PipelinePointer DrawStatus::getDrawItemBoundsPipeline() {
     if (!_drawItemBoundsPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render::program::drawItemBounds);

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -153,7 +153,7 @@ void DrawStatus::run(const RenderContextPointer& renderContext, const Input& inp
                         // We have a transition. Show this icon.
                         status.setScale(1.0f);
                         // Is this a valid transition ID according to FadeJob?
-                        auto transitionStage = scene->getStage<TransitionStage>(TransitionStage::getName());
+                        auto transitionStage = scene->getStage<TransitionStage>();
                         if (transitionStage) {
                             if (transitionStage->isTransitionUsed(transitionID)) {
                                 // Valid, active transition

--- a/libraries/render/src/render/DrawStatus.h
+++ b/libraries/render/src/render/DrawStatus.h
@@ -52,8 +52,8 @@ namespace render {
         void configure(const Config& config);
         void run(const RenderContextPointer& renderContext, const Input& input);
 
-        const gpu::PipelinePointer getDrawItemBoundsPipeline();
-        const gpu::PipelinePointer getDrawItemStatusPipeline();
+        static const gpu::PipelinePointer getDrawItemBoundsPipeline();
+        static const gpu::PipelinePointer getDrawItemStatusPipeline();
 
         void setStatusIconMap(const gpu::TexturePointer& map);
         const gpu::TexturePointer getStatusIconMap() const;
@@ -63,13 +63,12 @@ namespace render {
         bool _showNetwork { false }; // initialized by Config
         bool _showFade { false }; // initialized by Config
 
-        gpu::Stream::FormatPointer _drawItemFormat;
-        gpu::PipelinePointer _drawItemBoundsPipeline;
-        gpu::PipelinePointer _drawItemStatusPipeline;
+        static gpu::PipelinePointer _drawItemBoundsPipeline;
+        static gpu::PipelinePointer _drawItemStatusPipeline;
+        static gpu::Stream::FormatPointer _vertexFormat;
 
         gpu::BufferPointer _boundsBuffer;
         gpu::BufferPointer _instanceBuffer;
-        gpu::Stream::FormatPointer _vertexFormat;
         gpu::TexturePointer _statusIconMap;
     };
 }

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -155,6 +155,8 @@ void DrawLight::run(const RenderContextPointer& renderContext, const ItemBounds&
     config->setNumDrawn((int)inLights.size());
 }
 
+gpu::PipelinePointer DrawBounds::_boundsPipeline;
+
 const gpu::PipelinePointer DrawBounds::getPipeline() {
     if (!_boundsPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render::program::drawItemBounds);

--- a/libraries/render/src/render/DrawTask.h
+++ b/libraries/render/src/render/DrawTask.h
@@ -63,8 +63,8 @@ public:
         const Inputs& items);
 
 private:
-    const gpu::PipelinePointer getPipeline();
-    gpu::PipelinePointer _boundsPipeline;
+    static const gpu::PipelinePointer getPipeline();
+    static gpu::PipelinePointer _boundsPipeline;
     gpu::BufferPointer _drawBuffer;
     gpu::BufferPointer _paramsBuffer;
 };

--- a/libraries/render/src/render/Scene.cpp
+++ b/libraries/render/src/render/Scene.cpp
@@ -382,7 +382,7 @@ void Scene::updateItems(const Transaction::Updates& transactions) {
 }
 
 void Scene::resetTransitionItems(const Transaction::TransitionResets& transactions) {
-    auto transitionStage = getStage<TransitionStage>(TransitionStage::getName());
+    auto transitionStage = getStage<TransitionStage>();
 
     if (!transitionStage) {
         return;
@@ -425,7 +425,7 @@ void Scene::removeTransitionItems(const Transaction::TransitionRemoves& transact
 }
 
 void Scene::queryTransitionItems(const Transaction::TransitionQueries& transactions) {
-    auto transitionStage = getStage<TransitionStage>(TransitionStage::getName());
+    auto transitionStage = getStage<TransitionStage>();
 
     if (!transitionStage) {
         return;
@@ -467,7 +467,7 @@ void Scene::resetTransitionFinishedOperator(const Transaction::TransitionFinishe
 }
 
 void Scene::resetHighlights(const Transaction::HighlightResets& transactions) {
-    auto outlineStage = getStage<HighlightStage>(HighlightStage::getName());
+    auto outlineStage = getStage<HighlightStage>();
     if (outlineStage) {
         for (auto& transaction : transactions) {
             const auto& selectionName = std::get<0>(transaction);
@@ -484,7 +484,7 @@ void Scene::resetHighlights(const Transaction::HighlightResets& transactions) {
 }
 
 void Scene::removeHighlights(const Transaction::HighlightRemoves& transactions) {
-    auto outlineStage = getStage<HighlightStage>(HighlightStage::getName());
+    auto outlineStage = getStage<HighlightStage>();
     if (outlineStage) {
         for (auto& selectionName : transactions) {
             auto outlineId = outlineStage->getHighlightIdBySelection(selectionName);
@@ -497,7 +497,7 @@ void Scene::removeHighlights(const Transaction::HighlightRemoves& transactions) 
 }
 
 void Scene::queryHighlights(const Transaction::HighlightQueries& transactions) {
-    auto outlineStage = getStage<HighlightStage>(HighlightStage::getName());
+    auto outlineStage = getStage<HighlightStage>();
     if (outlineStage) {
         for (auto& transaction : transactions) {
             const auto& selectionName = std::get<0>(transaction);
@@ -551,7 +551,7 @@ void Scene::setItemTransition(ItemID itemId, Index transitionId) {
 }
 
 void Scene::removeItemTransition(ItemID itemId) {
-    auto transitionStage = getStage<TransitionStage>(TransitionStage::getName());
+    auto transitionStage = getStage<TransitionStage>();
     if (!transitionStage) {
         return;
     }

--- a/libraries/task/src/task/Task.h
+++ b/libraries/task/src/task/Task.h
@@ -332,7 +332,7 @@ public:
         void run(const ContextPointer& jobContext) override {
             auto config = std::static_pointer_cast<C>(Concept::_config);
             if (config->isEnabled()) {
-                for (auto job : TaskConcept::_jobs) {
+                for (auto& job : TaskConcept::_jobs) {
                     job.run(jobContext);
                     if (jobContext->taskFlow.doAbortTask()) {
                         jobContext->taskFlow.reset();

--- a/scripts/developer/utilities/lib/jet/jet.js
+++ b/scripts/developer/utilities/lib/jet/jet.js
@@ -100,7 +100,6 @@ function job_print_functor(printout, showProps, showInOuts, maxDepth) {
             }
         }
         if (showInOuts) {
-            printout("jsdkfkjdskflj")
             var inouts = job_inoutKeys(job);
             for (var p=0; p < inouts.length;p++) {
                 var prop = job[inouts[p]]


### PR DESCRIPTION
closes #1180 

I tried a bunch of things before figuring this out.  I've left them in because they all have a small perf/memory improvement.

1. make all pipelines used during rendering static.  this reduces duplicate compilation as with mirrors, we now have a lot of duplicate jobs for each depth level
2. disable some debug views in mirrors.  luci only triggers the top level debug views, so these other ones weren't actually used and only added complexity to the engine tree.
3. and the actual fix, only trigger the FadeEffect job for the top level depth.  relatedly, I refactored FadeEffect from a global dependency to use more static members, which also simplified a lot of things.  the FadeEffect job doesn't actually render the fade, it was enqueuing a bunch of transactions on the scene, which is what was slowing things down.  it only needs to happen once per render