### PR TITLE
fix web entities not accepting keyboard focus

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -171,7 +171,7 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
         _dpi = entity->getDpi();
         _color = entity->getColor();
         _alpha = entity->getAlpha();
-        _wantsKeyboardFocus = entity->wantsKeyboardFocus();
+        _wantsKeyboardFocus = entity->getWantsKeyboardFocus();
         _pulseProperties = entity->getPulseProperties();
 
         if (_contentType == ContentType::NoContent) {

--- a/libraries/entities/src/EntityItem.h.in
+++ b/libraries/entities/src/EntityItem.h.in
@@ -397,7 +397,6 @@ public:
     QUuid getOwningAvatarIDForProperties() const;
 
     virtual bool wantsHandControllerPointerEvents() const { return false; }
-    virtual bool wantsKeyboardFocus() const { return false; }
     virtual void setProxyWindow(QWindow* proxyWindow) {}
     virtual QObject* getEventHandler() { return nullptr; }
 


### PR DESCRIPTION
closes #1184 

what happened here was:

- EntityItem had a (virtual) method called `wantsKeyboardFocus` which always returned false
- WebEntityItem had a method called `wantsKeyboardFocus` that was used as the getter for the property
- RenderableEntityItem also has a (virtual) method called `wantsKeyboardFocus` which always returned false, which is overridden by RenderableWebEntityItem to return the value it copies from WebEntityItem
- RenderableWebEntityItem performs the copy by calling `_wantsKeyboardFocus = entity->wantsKeyboardFocus();`
- BUT in #1098, the WebEntityItem getter was sneakily renamed to getWantsKeyboardFocus, so the copy was accidentally always copying `false` from EntityItem