### PR TITLE
ArmoredChat notifications on join and leave

### DIFF
--- a/scripts/communityScripts/armored-chat/armored_chat.js
+++ b/scripts/communityScripts/armored-chat/armored_chat.js
@@ -14,6 +14,7 @@
     var settings = {
         external_window: false,
         maximum_messages: 200,
+        join_notification: true
     };
 
     // Global vars
@@ -147,17 +148,16 @@
                 _sendMessage(event.message, event.channel);
                 break;
             case "setting_change":
+                // Set the setting value, and save the config
                 settings[event.setting] = event.value; // Update local settings
                 _saveSettings(); // Save local settings
 
+                // Extra actions to preform. 
                 switch (event.setting) {
                     case "external_window":
                         chatOverlayWindow.presentationMode = event.value
                             ? Desktop.PresentationMode.NATIVE
                             : Desktop.PresentationMode.VIRTUAL;
-                        break;
-                    case "maximum_messages":
-                        // Do nothing
                         break;
                 }
 
@@ -230,13 +230,15 @@
             message.message = `${displayName} ${type}`;
 
             // Show new message on screen
-            Messages.sendLocalMessage(
-                "Floof-Notif",
-                JSON.stringify({
-                    sender: displayName,
-                    text: type,
-                })
-            );
+            if (settings.join_notification){
+                Messages.sendLocalMessage(
+                    "Floof-Notif",
+                    JSON.stringify({
+                        sender: displayName,
+                        text: type,
+                    })
+                );
+            }
 
             _emitEvent({ type: "notification", ...message });
         }, 1500);

--- a/scripts/communityScripts/armored-chat/armored_chat.js
+++ b/scripts/communityScripts/armored-chat/armored_chat.js
@@ -115,6 +115,7 @@
         // Update qml view of to new message
         _emitEvent({ type: "show_message", ...message });
 
+        // Show new message on screen
         Messages.sendLocalMessage(
             "Floof-Notif",
             JSON.stringify({
@@ -227,6 +228,15 @@
             // Format the packet
             let message = {};
             message.message = `${displayName} ${type}`;
+
+            // Show new message on screen
+            Messages.sendLocalMessage(
+                "Floof-Notif",
+                JSON.stringify({
+                    sender: displayName,
+                    text: type,
+                })
+            );
 
             _emitEvent({ type: "notification", ...message });
         }, 1500);

--- a/scripts/communityScripts/armored-chat/armored_chat.qml
+++ b/scripts/communityScripts/armored-chat/armored_chat.qml
@@ -337,6 +337,31 @@ Rectangle {
                         }
                     }
                 }
+
+
+                // Join notification
+                Rectangle {
+                    width: parent.width
+                    height: 40
+                    color: "transparent"
+
+                    Text{
+                        text: "Join notification"
+                        color: "white"
+                        font.pointSize: 12
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    CheckBox{
+                        id: s_join_notification
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        onCheckedChanged: {
+                            toScript({type: 'setting_change', setting: 'join_notification', value: checked})
+                        }
+                    }
+                }
             }
         }
 
@@ -561,6 +586,7 @@ Rectangle {
             case "initial_settings":
                 if (message.settings.external_window) s_external_window.checked = true;
                 if (message.settings.maximum_messages) s_maximum_messages.value = message.settings.maximum_messages;
+                if (message.settings.join_notification) s_join_notification.checked = true;
                 break;
         }
     }


### PR DESCRIPTION
Adds an optional notification to join and leave notifications powered by notification core.

![image](https://github.com/user-attachments/assets/9175d91a-ff8b-4ae7-9484-9707d6681078)


Closes #1197 