### PR TITLE
Add a label to the Pal application 'displayname' field

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -1039,6 +1039,14 @@ Rectangle {
         anchors.top: pal.top;
         anchors.topMargin: 10;
         anchors.left: pal.left;
+        RalewayRegular {
+            text: " Display Name";
+            size: hifi.fontSizes.tabularData;
+            anchors.left: parent.left;
+
+            color: hifi.colors.baseGrayHighlight;
+            verticalAlignment: Text.AlignTop;
+        }
         // This NameCard refers to the current user's NameCard (the one above the nearbyTable)
         NameCard {
             id: myCard;
@@ -1054,7 +1062,7 @@ Rectangle {
             width: myCardWidth;
             height: parent.height;
             // Anchors
-            anchors.top: parent.top
+            anchors.top: parent.children[0].bottom
             anchors.left: parent.left;
         }
         Item {
@@ -1066,7 +1074,7 @@ Rectangle {
 
             RalewayRegular {
                 id: availabilityText;
-                text: "set availability";
+                text: "Availability";
                 // Text size
                 size: hifi.fontSizes.tabularData;
                 // Anchors

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -1062,7 +1062,7 @@ Rectangle {
             width: myCardWidth;
             height: parent.height;
             // Anchors
-            anchors.top: parent.children[0].bottom
+            anchors.top: parent.children[0].bottom;
             anchors.left: parent.left;
         }
         Item {


### PR DESCRIPTION
This adds a label to the pal application display name field which is mostly just to make sure the two fields, display name and availability are level. This also changes language from "Set X" to simply "X".

Before and after:
![before](https://github.com/user-attachments/assets/7562e87b-196f-4392-b670-d20ce42edd2b)
![after](https://github.com/user-attachments/assets/3360367e-a779-4d9d-a024-8f293d6e5a9e)
