### PR TITLE
Add .cache to gitignore for VSCode builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ local.properties
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+.cache
 # Workspace
 *.code-workspace
 


### PR DESCRIPTION
This adds the .cache folder to the .gitignore file to prevent committing build cache files to the repository that are created from vscode CMake tools. 

I am unsure if this will cause some kind of compatibility issue that I have not foreseen. 