### PR TITLE
Fixed Camera Sensitivity setting not saving

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -75,6 +75,8 @@
 #include "WarningsSuppression.h"
 #include "ScriptPermissions.h"
 
+#include "Application.h"
+
 using namespace std;
 
 const float DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES = 30.0f;
@@ -226,6 +228,7 @@ MyAvatar::MyAvatar(QThread* thread) :
     _scaleSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "scale", _targetScale),
     _yawSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "yawSpeed", _yawSpeed),
     _hmdYawSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "hmdYawSpeed", _hmdYawSpeed),
+    _cameraSensitivitySetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "cameraSensitivity", qApp->getCamera().getSensitivity()),
     _pitchSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "pitchSpeed", _pitchSpeed),
     _fullAvatarURLSetting(QStringList() << SETTINGS_FULL_PRIVATE_GROUP_NAME << AVATAR_SETTINGS_GROUP_NAME << "fullAvatarURL",
                           AvatarData::defaultFullAvatarModelUrl()),
@@ -1324,6 +1327,7 @@ void MyAvatar::saveData() {
     _scaleSetting.set(_targetScale);
     _yawSpeedSetting.set(_yawSpeed);
     _hmdYawSpeedSetting.set(_hmdYawSpeed);
+    _cameraSensitivitySetting.set(getCameraSensitivity());
     _pitchSpeedSetting.set(_pitchSpeed);
 
     // only save the fullAvatarURL if it has not been overwritten on command line
@@ -2084,6 +2088,7 @@ void MyAvatar::loadData() {
 
     _yawSpeed = _yawSpeedSetting.get(_yawSpeed);
     _hmdYawSpeed = _hmdYawSpeedSetting.get(_hmdYawSpeed);
+    setCameraSensitivity(_cameraSensitivitySetting.get(getCameraSensitivity()));
     _pitchSpeed = _pitchSpeedSetting.get(_pitchSpeed);
 
     _prefOverrideAnimGraphUrl.set(_animGraphURLSetting.get().toString());
@@ -7001,4 +7006,12 @@ void MyAvatar::resetPointAt() {
         _skeletonModel->getRig().setDirectionalBlending(POINT_BLEND_DIRECTIONAL_ALPHA_NAME, glm::vec3(),
                                                         POINT_BLEND_LINEAR_ALPHA_NAME, POINT_ALPHA_BLENDING);
     }
+}
+
+float MyAvatar::getCameraSensitivity() const {
+    return qApp->getCamera().getSensitivity();
+}
+
+void MyAvatar::setCameraSensitivity(float cameraSensitivity) {
+    qApp->getCamera().setSensitivity(cameraSensitivity);
 }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1407,6 +1407,9 @@ public:
     float getHMDYawSpeed() const { return _hmdYawSpeed; }
     void setHMDYawSpeed(float speed) { _hmdYawSpeed = speed; }
 
+    float getCameraSensitivity() const;
+    void setCameraSensitivity(float cameraSensitivity);
+
     static const float ZOOM_MIN;
     static const float ZOOM_MAX;
     static const float ZOOM_DEFAULT;
@@ -3007,6 +3010,7 @@ private:
     Setting::Handle<float> _scaleSetting;
     Setting::Handle<float> _yawSpeedSetting;
     Setting::Handle<float> _hmdYawSpeedSetting;
+    Setting::Handle<float> _cameraSensitivitySetting;
     Setting::Handle<float> _pitchSpeedSetting;
     Setting::Handle<QUrl> _fullAvatarURLSetting;
     Setting::Handle<QUrl> _fullAvatarModelNameSetting;


### PR DESCRIPTION
Camera Sensitivity setting would not save. Test by going to Settings > Controls > Camera Sensitivity. With this fix, the setting should save and load upon restarting the interface.