### PR TITLE
Change ArmoredChat timestamps to use real timestamps

### DIFF
--- a/scripts/communityScripts/armored-chat/armored_chat.js
+++ b/scripts/communityScripts/armored-chat/armored_chat.js
@@ -97,20 +97,26 @@
         if (channel !== "chat") return;
         message = JSON.parse(message);
 
+        // Get the message data
+        const currentTimestamp = _getTimestamp();
+        const timeArray = _formatTimestamp(currentTimestamp);
+
         if (!message.channel) message.channel = "domain"; // We don't know where to put this message. Assume it is a domain wide message.
         if (message.forApp) return; // Floofchat
 
         // Floofchat compatibility hook
         message = floofChatCompatibilityConversion(message);
-        message.channel = message.channel.toLowerCase(); // Make sure the "local", "domain", etc. is formatted consistently
+        message.channel = message.channel.toLowerCase();
 
-        if (!channels.includes(message.channel)) return; // Check the channel
-        if (
-            message.channel == "local" &&
-            Vec3.distance(MyAvatar.position, message.position) >
-                maxLocalDistance
-        )
-            return; // If message is local, and if player is too far away from location, don't do anything
+        // Check the channel. If the channel is not one we have, do nothing.
+        if (!channels.includes(message.channel)) return;
+
+        // If message is local, and if player is too far away from location, do nothing.
+        if (message.channel == "local" && isCloseEnough(message.position)) return; 
+
+        // Format the timestamp 
+        message.timeString = timeArray[0];
+        message.dateString = timeArray[1];
 
         // Update qml view of to new message
         _emitEvent({ type: "show_message", ...message });
@@ -125,20 +131,25 @@
 
         // Save message to history
         let savedMessage = message;
+
+        // Remove unnecessary data.
         delete savedMessage.position;
-        savedMessage.timeString = new Date().toLocaleTimeString(undefined, {
-            hour12: false,
-        });
-        savedMessage.dateString = new Date().toLocaleDateString(undefined, {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-        });
+        delete savedMessage.timeString;
+        delete savedMessage.dateString;
+        delete savedMessage.action;
+
+        savedMessage.timestamp = currentTimestamp;
+
         messageHistory.push(savedMessage);
         while (messageHistory.length > settings.maximum_messages) {
             messageHistory.shift();
         }
         Settings.setValue("ArmoredChat-Messages", messageHistory);
+
+        // Check to see if the message is close enough to the user
+        function isCloseEnough(messagePosition) {
+            return Vec3.distance(MyAvatar.position, messagePosition) > maxLocalDistance;
+        }
     }
     function fromQML(event) {
         switch (event.type) {
@@ -214,9 +225,7 @@
 
             // Get the display name of the user
             let displayName = "";
-            displayName =
-                AvatarManager.getPalData([sessionId])?.data[0]
-                    ?.sessionDisplayName || null;
+            displayName = AvatarManager.getPalData([sessionId])?.data[0]?.sessionDisplayName || null;
             if (displayName == null) {
                 for (let i = 0; i < palData.length; i++) {
                     if (palData[i].sessionUUID == sessionId) {
@@ -227,6 +236,9 @@
 
             // Format the packet
             let message = {};
+            const timeArray = _formatTimestamp(_getTimestamp());
+            message.timeString = timeArray[0];
+            message.dateString = timeArray[1];
             message.message = `${displayName} ${type}`;
 
             _emitEvent({ type: "notification", ...message });
@@ -238,7 +250,9 @@
         if (messageHistory) {
             // Load message history
             messageHistory.forEach((message) => {
-                delete message.action;
+                const timeArray = _formatTimestamp(_getTimestamp());
+                message.timeString = timeArray[0];
+                message.dateString = timeArray[1];
                 _emitEvent({ type: "show_message", ...message });
             });
         }
@@ -249,6 +263,24 @@
     function _saveSettings() {
         console.log("Saving config");
         Settings.setValue("ArmoredChat-Config", settings);
+    }
+    function _getTimestamp(){
+        return Date.now();
+    }
+    function _formatTimestamp(timestamp){
+        let timeArray = [];
+
+        timeArray.push(new Date().toLocaleTimeString(undefined, {
+            hour12: false,
+        }));
+
+        timeArray.push(new Date(timestamp).toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+        }));
+
+        return timeArray;
     }
 
     /**

--- a/scripts/communityScripts/armored-chat/armored_chat.js
+++ b/scripts/communityScripts/armored-chat/armored_chat.js
@@ -112,7 +112,7 @@
         if (!channels.includes(message.channel)) return;
 
         // If message is local, and if player is too far away from location, do nothing.
-        if (message.channel == "local" && isCloseEnough(message.position)) return; 
+        if (message.channel == "local" && isTooFar(message.position)) return; 
 
         // Format the timestamp 
         message.timeString = timeArray[0];
@@ -147,7 +147,7 @@
         Settings.setValue("ArmoredChat-Messages", messageHistory);
 
         // Check to see if the message is close enough to the user
-        function isCloseEnough(messagePosition) {
+        function isTooFar(messagePosition) {
             return Vec3.distance(MyAvatar.position, messagePosition) > maxLocalDistance;
         }
     }

--- a/scripts/communityScripts/armored-chat/armored_chat.qml
+++ b/scripts/communityScripts/armored-chat/armored_chat.qml
@@ -562,15 +562,13 @@ Rectangle {
 
     // Messages from script
     function fromScript(message) {
-        let time = new Date().toLocaleTimeString(undefined, { hour12: false });
-        let date = new Date().toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric", });
 
         switch (message.type){
             case "show_message":
-                addMessage(message.displayName, message.message, `[ ${message.timeString || time} - ${message.dateString || date} ]`, message.channel, "chat");
+                addMessage(message.displayName, message.message, `[ ${message.timeString} - ${message.dateString} ]`, message.channel, "chat");
                 break;
             case "notification":
-                addMessage("SYSTEM", message.message, `[ ${time} - ${date} ]`, "domain", "notification");
+                addMessage("SYSTEM", message.message, `[ ${message.timeString} - ${message.dateString} ]`, "domain", "notification");
                 break;
             case "clear_messages":
                 local.clear();


### PR DESCRIPTION
This changes the time saving method to just timestamps provided by Date.now() instead of saving formatted strings. This will allow for easily changing the displayed timestamp to match proper locales in the future.

This also prevents saving some unneeded data in the interface.json file.  