### PR TITLE
Fix ShowRecieveStats in the Developer > Avatar menu

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -994,9 +994,9 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& view, const
 
         QString statsFormat = QString("(%1 Kbps, %2 Hz)");
         if (!renderedDisplayName.isEmpty()) {
-            statsFormat.prepend(" - ");
+            statsFormat.append("\n");
         }
-        renderedDisplayName += statsFormat.arg(QString::number(kilobitsPerSecond, 'f', 2)).arg(getReceiveRate());
+        renderedDisplayName = statsFormat.arg(QString::number(kilobitsPerSecond, 'f', 2)).arg(getReceiveRate())  + renderedDisplayName;
     }
 
     // Compute display name extent/position offset
@@ -1020,8 +1020,7 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& view, const
 
         // Display name and background colors
         glm::vec4 textColor(0.93f, 0.93f, 0.93f, _displayNameAlpha);
-        glm::vec4 backgroundColor(0.2f, 0.2f, 0.2f,
-                                  (_displayNameAlpha / DISPLAYNAME_ALPHA) * DISPLAYNAME_BACKGROUND_ALPHA);
+        glm::vec4 backgroundColor(0.2f, 0.2f, 0.2f,(_displayNameAlpha / DISPLAYNAME_ALPHA) * DISPLAYNAME_BACKGROUND_ALPHA);
 
         // Compute display name transform
         auto textTransform = calculateDisplayNameTransform(view, textPosition);
@@ -1029,12 +1028,11 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& view, const
         textTransform.postScale(1.0f / height);
         batch.setModelTransform(textTransform);
 
-        {
-            PROFILE_RANGE_BATCH(batch, __FUNCTION__":renderBevelCornersRect");
-            DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, true, true, true, forward);
-            DependencyManager::get<GeometryCache>()->renderBevelCornersRect(batch, left, bottom, width, height,
-                bevelDistance, backgroundColor, _nameRectGeometryID);
-        }
+        // {
+        //     PROFILE_RANGE_BATCH(batch, __FUNCTION__":renderBevelCornersRect");
+        //     DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, false, true, true, true, forward);
+        //     DependencyManager::get<GeometryCache>()->renderBevelCornersRect(batch, left, bottom, width, height, bevelDistance, backgroundColor, _nameRectGeometryID);
+        // }
 
         // Render actual name
         QByteArray nameUTF8 = renderedDisplayName.toLocal8Bit();
@@ -1044,7 +1042,7 @@ void Avatar::renderDisplayName(gpu::Batch& batch, const ViewFrustum& view, const
         batch.setModelTransform(textTransform);
         {
             PROFILE_RANGE_BATCH(batch, __FUNCTION__":renderText");
-            displayNameRenderer->draw(batch, { nameUTF8.data(), textColor, { text_x, -text_y }, glm::vec2(-1.0f), forward });
+            displayNameRenderer->draw(batch, { nameUTF8.data(), textColor, { text_x, -text_y }, glm::vec2(10.0f), forward, TextAlignment::CENTER });
         }
     }
 }

--- a/libraries/render-utils/src/text/Font.h
+++ b/libraries/render-utils/src/text/Font.h
@@ -71,8 +71,9 @@ public:
                   bool forward, bool mirror) :
             str(str), color(color), effectColor(effectColor), origin(origin), bounds(bounds), scale(scale), effectThickness(effectThickness),
             effect(effect), alignment(alignment), verticalAlignment(verticalAlignment), unlit(unlit), forward(forward), mirror(mirror) {}
-        DrawProps(const QString& str, const glm::vec4& color, const glm::vec2& origin, const glm::vec2& bounds, bool forward) :
-            str(str), color(color), origin(origin), bounds(bounds), forward(forward) {}
+            
+        DrawProps(const QString& str, const glm::vec4& color, const glm::vec2& origin, const glm::vec2& bounds, bool forward, TextAlignment alignment) :
+            str(str), color(color), origin(origin), bounds(bounds), forward(forward), alignment(alignment) {}
 
         const QString& str;
         const glm::vec4& color;


### PR DESCRIPTION
This is an attempt at fixing, or at least making this feature operational, ShowRecieveStats setting. 
This renders a users display name along with their networking statistics.

While functional this pull creates a hell of a lot of compiler warnings. While not blocking this is annoying. Until I can quiet down its pleaful cries, this won't be ready to merge.

![image](https://github.com/user-attachments/assets/fb41bd8f-18fe-40aa-9beb-1f560ac6eb92)
