### PR TITLE
Remove an assert referencing checkLightId, which seems not to exist anywhere

### DIFF
--- a/libraries/render-utils/src/LightStage.cpp
+++ b/libraries/render-utils/src/LightStage.cpp
@@ -73,7 +73,7 @@ LightStage::Shadow::Schema::Schema() {
     maxDistance = 20.0f;
 }
 
-LightStage::Shadow::Cascade::Cascade() : 
+LightStage::Shadow::Cascade::Cascade() :
     _frustum{ std::make_shared<ViewFrustum>() },
     _minDistance{ 0.0f },
     _maxDistance{ 20.0f } {
@@ -89,7 +89,7 @@ const glm::mat4& LightStage::Shadow::Cascade::getProjection() const {
 
 float LightStage::Shadow::Cascade::computeFarDistance(const ViewFrustum& viewFrustum, const Transform& shadowViewInverse,
                                                       float left, float right, float bottom, float top, float viewMaxShadowDistance) const {
-    // Far distance should be extended to the intersection of the infinitely extruded shadow frustum 
+    // Far distance should be extended to the intersection of the infinitely extruded shadow frustum
     // with the view frustum side planes. To do so, we generate 10 triangles in shadow space which are the result of
     // tesselating the side and far faces of the view frustum and clip them with the 4 side planes of the
     // shadow frustum. The resulting clipped triangle vertices with the farthest Z gives the desired
@@ -122,7 +122,7 @@ float LightStage::Shadow::Cascade::computeFarDistance(const ViewFrustum& viewFru
     return far;
 }
 
-LightStage::Shadow::Shadow(graphics::LightPointer light, unsigned int cascadeCount) : 
+LightStage::Shadow::Shadow(graphics::LightPointer light, unsigned int cascadeCount) :
     _light{ light } {
     cascadeCount = std::min(cascadeCount, (unsigned int)SHADOW_CASCADE_MAX_COUNT);
     Schema schema;
@@ -388,8 +388,6 @@ void LightStage::updateLightArrayBuffer(Index lightId) {
     if (!_lightArrayBuffer) {
         _lightArrayBuffer = std::make_shared<gpu::Buffer>(lightSize);
     }
-
-    assert(checkLightId(lightId));
 
     if (lightId > (Index)_lightArrayBuffer->getNumTypedElements<graphics::Light::LightSchema>()) {
         _lightArrayBuffer->resize(lightSize * (lightId + 10));


### PR DESCRIPTION
This one is confusing me greatly.

It's a line from 8 years ago, and apparently this hasn't been blowing up for anyone else?
```
/home/dale/git/overte/overte/libraries/render-utils/src/LightStage.cpp: In member function ‘void LightStage::updateLightArrayBuffer(render::Stage::Index)’:
/home/dale/git/overte/overte/libraries/render-utils/src/LightStage.cpp:392:12: error: ‘checkLightId’ was not declared in this scope
  392 |     assert(checkLightId(lightId));
      |            ^~~~~~~~~~~~
```

There appear to be no references to this function in the source.