### PR TITLE
Add a setting to hide the Graphics icon

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -969,6 +969,7 @@ const bool DEFAULT_DESKTOP_TABLET_BECOMES_TOOLBAR = true;
 const bool DEFAULT_HMD_TABLET_BECOMES_TOOLBAR = false;
 const bool DEFAULT_PREFER_STYLUS_OVER_LASER = false;
 const bool DEFAULT_PREFER_AVATAR_FINGER_OVER_STYLUS = false;
+const bool DEFAULT_SHOW_GRAPHICS_ICON = true;
 const QString DEFAULT_CURSOR_NAME = "SYSTEM";
 const bool DEFAULT_MINI_TABLET_ENABLED = false;
 const bool DEFAULT_AWAY_STATE_WHEN_FOCUS_LOST_IN_VR_ENABLED = true;
@@ -1010,6 +1011,7 @@ Application::Application(
     _hmdTabletBecomesToolbarSetting("hmdTabletBecomesToolbar", DEFAULT_HMD_TABLET_BECOMES_TOOLBAR),
     _preferStylusOverLaserSetting("preferStylusOverLaser", DEFAULT_PREFER_STYLUS_OVER_LASER),
     _preferAvatarFingerOverStylusSetting("preferAvatarFingerOverStylus", DEFAULT_PREFER_AVATAR_FINGER_OVER_STYLUS),
+    _showGraphicsIconSetting("showGraphicsIcon", DEFAULT_SHOW_GRAPHICS_ICON),
     _constrainToolbarPosition("toolbar/constrainToolbarToCenterX", true),
     _awayStateWhenFocusLostInVREnabled("awayStateWhenFocusLostInVREnabled", DEFAULT_AWAY_STATE_WHEN_FOCUS_LOST_IN_VR_ENABLED),
     _preferredCursor("preferredCursor", DEFAULT_CURSOR_NAME),
@@ -3839,6 +3841,11 @@ void Application::setPreferStylusOverLaser(bool value) {
 
 void Application::setPreferAvatarFingerOverStylus(bool value) {
     _preferAvatarFingerOverStylusSetting.set(value);
+}
+
+void Application::setShowGraphicsIcon(bool value) {
+    _showGraphicsIconSetting.set(value);
+    DependencyManager::get< MessagesClient >()->sendLocalMessage("Overte-ShowGraphicsIconChanged", "");
 }
 
 void Application::setPreferredCursor(const QString& cursorName) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -263,6 +263,9 @@ public:
     bool getPreferAvatarFingerOverStylus() { return _preferAvatarFingerOverStylusSetting.get(); }
     void setPreferAvatarFingerOverStylus(bool value);
 
+    bool getShowGraphicsIcon() { return _showGraphicsIconSetting.get(); }
+    void setShowGraphicsIcon(bool value);
+
     bool getMiniTabletEnabled() { return _miniTabletEnabledSetting.get(); }
     void setMiniTabletEnabled(bool enabled);
 
@@ -723,6 +726,7 @@ private:
     Setting::Handle<bool> _hmdTabletBecomesToolbarSetting;
     Setting::Handle<bool> _preferStylusOverLaserSetting;
     Setting::Handle<bool> _preferAvatarFingerOverStylusSetting;
+    Setting::Handle<bool> _showGraphicsIconSetting;
     Setting::Handle<bool> _constrainToolbarPosition;
     Setting::Handle<bool> _awayStateWhenFocusLostInVREnabled;
     Setting::Handle<QString> _preferredCursor;

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -225,6 +225,12 @@ void setupPreferences() {
         preferences->addPreference(delaySlider);
     }
 
+    {
+        auto getter = []() -> bool { return qApp->getShowGraphicsIcon(); };
+        auto setter = [](bool value) { qApp->setShowGraphicsIcon(value); };
+        preferences->addPreference(new CheckPreference(UI_CATEGORY, "Show Graphics icon on tablet and toolbar", getter, setter));
+    }
+
     static const QString VIEW_CATEGORY{ "View" };
     {
         auto getter = [myAvatar]()->float { return myAvatar->getRealWorldFieldOfView(); };


### PR DESCRIPTION
Adds a setting to hide Graphics icon from toolbar and tablet, since it's also accessible through Settings menu.