### PR TITLE
Graphics App: adding a setting to hide or display the app in the tablet/toolbar

### DIFF
--- a/scripts/system/graphicsSettings.js
+++ b/scripts/system/graphicsSettings.js
@@ -1,15 +1,20 @@
 //
 //  graphicsSettings.js
 //
-//  Created by Kalila L. on 8/5/2020
+//  Created by Kalila L. on August 5th, 2020
 //  Copyright 2020 Vircadia contributors.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
 (function() { // BEGIN LOCAL_SCOPE
-
+    var channelComm = "Overte-ShowGraphicsIconChanged";
+    var appStatus = false;
+    var GRAPHICS_HIDE_AND_SHOW_SETTING_KEY = "showGraphicsIcon";
+    var GRAPHICS_HIDE_AND_SHOW_DEFAULT_VALUE = true;
+    
     var AppUi = Script.require('appUi');
     
     // cellphone-cog MDI
@@ -49,22 +54,49 @@
     }
 
     function startup() {
-        ui = new AppUi({
-            buttonName: BUTTON_NAME,
-            sortOrder: 8,
-            normalButton: getIcon(),
-            activeButton: getIcon().replace('white', 'black'),
-            home: GRAPHICS_QML_SOURCE
-        });
+        if (!appStatus) {
+            ui = new AppUi({
+                buttonName: BUTTON_NAME,
+                sortOrder: 8,
+                normalButton: getIcon(),
+                activeButton: getIcon().replace('white', 'black'),
+                home: GRAPHICS_QML_SOURCE
+            });
+        }
+        appStatus = true;
     }
 
     function shutdown() {
+        if (appStatus) {
+            ui.onScriptEnding();
+            appStatus = false;
+        }
+    }
+
+    function cleanup() {
+        Messages.messageReceived.disconnect(onMessageReceived);
+        Messages.unsubscribe(channelComm);
+    }
+
+    function onMessageReceived(channel, message, sender, localOnly) {
+        if (channel === channelComm && localOnly) {
+            if (Settings.getValue(GRAPHICS_HIDE_AND_SHOW_SETTING_KEY, GRAPHICS_HIDE_AND_SHOW_DEFAULT_VALUE)) {
+                startup();
+            } else {
+                shutdown();
+            }
+        }
     }
 
     //
     // Run the functions.
     //
-    startup();
-    Script.scriptEnding.connect(shutdown);
+    if (Settings.getValue(GRAPHICS_HIDE_AND_SHOW_SETTING_KEY, GRAPHICS_HIDE_AND_SHOW_DEFAULT_VALUE)) {
+        startup();
+    }
+    Messages.subscribe(channelComm);
+    Messages.messageReceived.connect(onMessageReceived);
+    
+    Script.scriptEnding.connect(cleanup);
 
 }()); // END LOCAL_SCOPE


### PR DESCRIPTION
This make the tablet app to be launched or not based on new setting that control its present in the tablet/toolbar. It also make it able to discard or restore itself on the tablet/toolbar if the option is checked in the Setting menu. (See PR 1274 for the new setting)

By default the app will be visible.

**TESTING:**
This app must be tested once the **PR 1274** will be present in the code.
_(It hasn't  been tested yet)_

- Test if the app is **visible and functional** if the setting is find to **true** at **startup**.
- Test if the app is **not visible** if the setting is find to **false** at **startup**.
- Test if the app get **visible and functional** if the setting **is changed** to **true** at **runtime**.
- Test if the app get **not visible** if the setting **is changed** to **false** at **runtime**.
