### PR TITLE
Add support for base64 images in image entity URLs

### DIFF
--- a/libraries/entities/src/EntityItemPropertiesDocs.cpp
+++ b/libraries/entities/src/EntityItemPropertiesDocs.cpp
@@ -935,7 +935,9 @@
  *
  * @typedef {object} Entities.EntityProperties-Image
  * @property {Vec3} dimensions=0.1,0.1,0.01 - The dimensions of the entity.
- * @property {string} imageURL="" - The URL of the image to use.
+ * @property {string} imageURL="" - The URL of the image to use. It can also contain a base64 encoded image, in the same format as glTF.
+ *     For network transmitted entities there's about 1000-character limit for the length of this field. For base64 image
+ *     the property string needs to begin with `data:image/png;base64,`, `data:image/jpeg;base64,` or `data:image/webp;base64,`.
  * @property {boolean} emissive=false - <code>true</code> if the image should be emissive (unlit), <code>false</code> if it
  *     shouldn't.
  * @property {boolean} keepAspectRatio=true - <code>true</code> if the image should maintain its aspect ratio,

--- a/libraries/material-networking/src/material-networking/TextureCache.cpp
+++ b/libraries/material-networking/src/material-networking/TextureCache.cpp
@@ -256,9 +256,9 @@ NetworkTexturePointer TextureCache::getTexture(const QUrl& url, image::TextureUs
     }
 
     QString urlString = url.toString();
-    if (content.isEmpty() && (urlString.contains("data:image/jpeg;base64,")
-                              || urlString.contains("data:image/png;base64,")
-                              || urlString.contains("data:image/webp;base64,"))) {
+    if (content.isEmpty() && (urlString.startsWith("data:image/jpeg;base64,")
+                              || urlString.startsWith("data:image/png;base64,")
+                              || urlString.startsWith("data:image/webp;base64,"))) {
         QString binaryUrl = urlString.split(",")[1];
         auto decodedContent = binaryUrl.isEmpty() ? QByteArray() : QByteArray::fromBase64(binaryUrl.toUtf8());
         if (!decodedContent.isEmpty()) {

--- a/libraries/material-networking/src/material-networking/TextureCache.cpp
+++ b/libraries/material-networking/src/material-networking/TextureCache.cpp
@@ -254,6 +254,18 @@ NetworkTexturePointer TextureCache::getTexture(const QUrl& url, image::TextureUs
     if (url.scheme() == RESOURCE_SCHEME) {
         return getResourceTexture(url);
     }
+
+    QString urlString = url.toString();
+    if (content.isEmpty() && (urlString.contains("data:image/jpeg;base64,")
+                              || urlString.contains("data:image/png;base64,")
+                              || urlString.contains("data:image/webp;base64,"))) {
+        QString binaryUrl = urlString.split(",")[1];
+        auto decodedContent = binaryUrl.isEmpty() ? QByteArray() : QByteArray::fromBase64(binaryUrl.toUtf8());
+        if (!decodedContent.isEmpty()) {
+            return getTexture(url, type, decodedContent, maxNumPixels, sourceChannel);
+        }
+    }
+
     QString decodedURL = QUrl::fromPercentEncoding(url.toEncoded());
     if (decodedURL.startsWith("{")) {
         return getTextureByUUID(decodedURL);

--- a/libraries/model-serializers/src/GLTFSerializer.cpp
+++ b/libraries/model-serializers/src/GLTFSerializer.cpp
@@ -1335,7 +1335,7 @@ HFMTexture GLTFSerializer::getHFMTexture(const cgltf_texture *texture) {
             hfmTex.filename = textureUrl.toEncoded().append(QString::number(imageIndex).toUtf8());
         }
 
-        if (url.contains("data:image/jpeg;base64,") || url.contains("data:image/png;base64,") || url.contains("data:image/webp;base64,")) {
+        if (url.startsWith("data:image/jpeg;base64,") || url.startsWith("data:image/png;base64,") || url.startsWith("data:image/webp;base64,")) {
             hfmTex.content = requestEmbeddedData(url);
         }
     }


### PR DESCRIPTION
It supports the same standard URL scheme as glTF files for their base64 textures embedded in URLs.
Example URL:
```
data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9TpSIVByuIOGSoDmKXKuKoVShChVArtOpgcukXNGlIUlwcBdeCgx+LVQcXZ10dXAVB8APE2cFJ0UVK/F9SaBHjwXE/3t173L0DhEaFaVbXLKDptplOJsRsblUMvSKMCAYRx7jMLGNOklLwHV/3CPD1Lsaz/M/9OfrUvMWAgEg8ywzTJt4gnt60Dc77xBFWklXic+IJky5I/Mh1xeM3zkWXBZ4ZMTPpeeIIsVjsYKWDWcnUiKeIo6qmU76Q9VjlvMVZq9RY6578heG8vrLMdZojSGIRS5AgQkENZVRgI0arToqFNO0nfPzDrl8il0KuMhg5FlCFBtn1g//B726twmTcSwongO4Xx/kYBUK7QLPuON/HjtM8AYLPwJXe9lcbwMwn6fW2Fj0C+reBi+u2puwBlzvA0JMhm7IrBWkKhQLwfkbflAMGboHeNa+31j5OH4AMdZW6AQ4OgbEiZa/7vLuns7d/z7T6+wEIF3LiWsAO7gAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAAd0SU1FB+gMFBU6ABMMoWQAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAATUlEQVQ4y2P8//8/A9kAWTORbDhggsvBVUAk0NhoaiCACdMtjIyMyGxkLhpgwuMRZCdgBSy4bP7//z8eO6EqKQltJgYKwKjmUc3DVTMAN4JB9I3iT2YAAAAASUVORK5CYII=
```
![overte-snap-by-X74hc595-on-2024-12-20_23-23-01](https://github.com/user-attachments/assets/fd1c8aea-861e-41ac-933e-bc89491473d1)

For local entities bigger files are supported too:

![overte-snap-by-X74hc595-on-2024-12-20_23-43-30](https://github.com/user-attachments/assets/ccd1d204-1c27-4eca-9dfd-315d618f20f8)
