### PR TITLE
Places App: Addressing ugly image "broken link" in Place Details

### DIFF
--- a/scripts/system/places/places.html
+++ b/scripts/system/places/places.html
@@ -4,7 +4,7 @@
 //  places.html
 //
 //  Created by Alezia Kurdis, January 1st, 2022.
-//  Copyright 2022 Overte e.V.
+//  Copyright 2022-2025 Overte e.V.
 //
 //  html for the ui of the Places application.
 //
@@ -107,7 +107,7 @@
         <div id="placeDetail" class="overlay">
           <a href="javascript:void(0)" class="closebtn" onclick="closeDetail();">&times;</a>
           <div class="overlay-content">
-                <img id="placeDetail-image" onclick="closeDetail();" draggable="false">
+                <div id="placeDetail-image" onclick="closeDetail();" draggable="false"></div>
                 <div id="placeDetail-placeName"></div>
                 <table width='100%'>
                     <tr valign='top'>
@@ -751,12 +751,17 @@
                     }
                 }
 
-                document.getElementById("placeDetail-image").src = "";
+                var pictureUrl = "";
                 if (placeDetail.thumbnail === "") {
-                    document.getElementById("placeDetail-image").src = "icons/placeholder_" + placeDetail.metaverseRegion + ".jpg";
+                    pictureUrl = "icons/placeholder_" + placeDetail.metaverseRegion + ".jpg";
                 } else {
-                    document.getElementById("placeDetail-image").src = placeDetail.thumbnail;
+                    pictureUrl = placeDetail.thumbnail;
                 }
+                document.getElementById("placeDetail-image").style.backgroundImage = "url(" + pictureUrl + ")";
+                document.getElementById("placeDetail-image").style.backgroundRepeat = "no-repeat"; 
+                document.getElementById("placeDetail-image").style.backgroundPosition = "center center"; 
+                document.getElementById("placeDetail-image").style.backgroundSize = "cover";
+
                 document.getElementById("placeDetail-placeName").innerHTML = placeDetail.name;
                 document.getElementById("placeDetail-managers").innerHTML = "By <br>&nbsp;&nbsp;&nbsp;&nbsp;" + placeDetail.managers;
                 document.getElementById("placeDetail-description").innerHTML = placeDetail.description;


### PR DESCRIPTION
This PR addresses the ugly image "broken link" in Place Details.

If for any reason the places thumbnail went not available,
it was displaying a broken image in the Place Detail (cause it was using an "img" element)

![image](https://github.com/user-attachments/assets/43a912f0-175c-47dd-b665-0fb5f0b7fdff)

To fix this I simply replace the  "img" element by a div element with a backgroundImage property. 
Which doesn't output a broken image but instead render no image:

![image](https://github.com/user-attachments/assets/6726e5ed-48ef-400c-9fd1-3fb0a52e7766)


