### PR TITLE
Places App.: Larger display and no more blurry effect in Places List.

### DIFF
--- a/scripts/system/places/places.css
+++ b/scripts/system/places/places.css
@@ -3,7 +3,7 @@
 //  places.css
 //
 //  Created by Alezia Kurdis, January 1st, 2022.
-//  Copyright 2022 Overte e.V.
+//  Copyright 2022-2025 Overte e.V.
 //
 //  css for the ui of the Places application.
 //
@@ -489,6 +489,10 @@ div.placeEntry {
 
 div.placeEntryLargeSize {
     height: 220px;
+}
+
+div.placeEntryMediumSize {
+    height: 100px;
 }
 
 div.addMsEntry {

--- a/scripts/system/places/places.html
+++ b/scripts/system/places/places.html
@@ -4,7 +4,7 @@
 //  places.html
 //
 //  Created by Alezia Kurdis, January 1st, 2022.
-//  Copyright 2022 Overte e.V.
+//  Copyright 2022-2025 Overte e.V.
 //
 //  html for the ui of the Places application.
 //
@@ -421,6 +421,9 @@
                                         }
                                         
                                         var maxCharNumber = 55;
+                                        if (currentListFormat === "PLACES" && placeRecords[i].category === "A") {
+                                            maxCharNumber = 110;
+                                        }
                                         if (currentListFormat === "PLACES" && i === 0) {
                                             maxCharNumber = 180;
                                         }
@@ -441,6 +444,11 @@
                                         var promoted = "";
                                         var placeTitlePromoted = "";
                                         var prompotionDescHeight = "";
+                                        if (currentListFormat === "PLACES" && placeRecords[i].category === "A") {
+                                            promoted = " placeEntryMediumSize";
+                                            promotedblur = " promotedblur";
+                                            prompotionDescHeight = " style='height: 60px; '";
+                                        }
                                         if (currentListFormat === "PLACES" && i === 0) {
                                             promotedblur = " promotedblur";
                                             promoted = " placeEntryLargeSize";


### PR DESCRIPTION
This PR make the display of the places larger and without the blurry effect in Places List.

The height increases from 60px to 100px . 
The blurry effect has been removed (on the place list only) 
Description show now 100 char instead of 55 before getting truncate with "..."

![image](https://github.com/user-attachments/assets/6b8046e9-2d14-4352-8c75-87a199e5c32d)
