### PR TITLE
fix domain entity lifetime in serverless mode

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -705,10 +705,11 @@ void EntityTree::deleteEntitiesByID(const std::vector<EntityItemID>& ids, bool f
                     entity = _entityMap.value(id);
                 }
                 if (entity) {
-                    if (entity->isDomainEntity()) {
+                    bool isServerless = isServerlessMode();
+                    if (entity->isDomainEntity() && !isServerless) {
                         // domain-entity deletes must round-trip through entity-server
                         domainEntitiesIDs.push_back(id);
-                    } else if (force || entity->isLocalEntity() || entity->isMyAvatarEntity()) {
+                    } else if (force || entity->isLocalEntity() || entity->isMyAvatarEntity() || isServerless) {
                         entitiesToDelete.push_back(entity);
                         entity->collectChildrenForDelete(entitiesToDelete, sessionID);
                     }

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -186,10 +186,10 @@ void PhysicalEntitySimulation::processDeadEntities() {
         if (motionState) {
             _entitiesToRemoveFromPhysics.insert(entity);
         }
-        if (entity->isDomainEntity()) {
+        if (entity->isDomainEntity() && !getEntityTree()->isServerlessMode()) {
             // interface-client can't delete domainEntities outright, they must roundtrip through the entity-server
             _entityPacketSender->queueEraseEntityMessage(entity->getID());
-        } else if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
+        } else {
             entitiesToDeleteImmediately.push_back(entity);
             entity->collectChildrenForDelete(entitiesToDeleteImmediately, sessionID);
         }


### PR DESCRIPTION
fix #1303 

in serverless mode, we were still trying to call `queueEraseEntityMessage`, which obviously wouldn't do anything

[this test script](https://gist.github.com/HifiExperiments/da8b931001bcdd2c5f8fd221f9b50685/raw/72744798ba19f12e0edf28fc4ee0de7dccffeb84/LifetimeTest.js) will create 1 domain, 1 avatar, and 1 local entity in front of you.  in both serverless and a normal domain, they should all disappear after 5 seconds (in the domain, the times might not be exactly equal since we round trip to the server)