### PR TITLE
Fix failure of Node build due to deprecated distutils

### DIFF
--- a/cmake/ports/node/portfile.cmake
+++ b/cmake/ports/node/portfile.cmake
@@ -31,6 +31,7 @@ else ()
         REF v18.20.2
         SHA512 10d3637c26274677d137f76bbb648d0e7851c994634a16c89858c3a13094a0692ea2cb9a787c6463c3001abd71dab0d83123127bc305171d097c48d21d691678
         HEAD_REF v18.20.2
+        PATCHES replace-distutils.patch replace-distutils2.patch
     )
     # node cannot configure out of source, which VCPKG expects. So we copy the source to the configure directory.
     file(COPY ${SOURCE_PATH}/ DESTINATION "${CURRENT_BUILDTREES_DIR}")

--- a/cmake/ports/node/replace-distutils.patch
+++ b/cmake/ports/node/replace-distutils.patch
@@ -1,0 +1,50 @@
+commit 95534ad82f4e33f53fd50efe633d43f8da70cba6
+Author: Luigi Pinca <luigipinca@gmail.com>
+Date:   Wed Nov 8 21:20:53 2023 +0100
+
+    build: fix build with Python 3.12
+    
+    Replace `distutils.version.StrictVersion` with
+    `packaging.version.Version`.
+    
+    Refs: https://github.com/nodejs/node/pull/50209#issuecomment-1795852539
+    PR-URL: https://github.com/nodejs/node/pull/50582
+    Reviewed-By: Richard Lau <rlau@redhat.com>
+    Reviewed-By: Chengzhong Wu <legendecas@gmail.com>
+
+diff --git a/configure.py b/configure.py
+index 33671a0342..be95decd56 100755
+--- a/configure.py
++++ b/configure.py
+@@ -14,8 +14,6 @@ import bz2
+ import io
+ from pathlib import Path
+ 
+-from distutils.version import StrictVersion
+-
+ # If not run from node/, cd to node/.
+ os.chdir(Path(__file__).parent)
+ 
+@@ -30,6 +28,7 @@ tools_path = Path('tools')
+ 
+ sys.path.insert(0, str(tools_path / 'gyp' / 'pylib'))
+ from gyp.common import GetFlavor
++from packaging.version import Version
+ 
+ # imports in tools/configure.d
+ sys.path.insert(0, str(tools_path / 'configure.d'))
+@@ -1566,10 +1565,10 @@ def configure_openssl(o):
+     # supported asm compiler for AVX2. See https://github.com/openssl/openssl/
+     # blob/OpenSSL_1_1_0-stable/crypto/modes/asm/aesni-gcm-x86_64.pl#L52-L69
+     openssl110_asm_supported = \
+-      ('gas_version' in variables and StrictVersion(variables['gas_version']) >= StrictVersion('2.23')) or \
+-      ('xcode_version' in variables and StrictVersion(variables['xcode_version']) >= StrictVersion('5.0')) or \
+-      ('llvm_version' in variables and StrictVersion(variables['llvm_version']) >= StrictVersion('3.3')) or \
+-      ('nasm_version' in variables and StrictVersion(variables['nasm_version']) >= StrictVersion('2.10'))
++      ('gas_version' in variables and Version(variables['gas_version']) >= Version('2.23')) or \
++      ('xcode_version' in variables and Version(variables['xcode_version']) >= Version('5.0')) or \
++      ('llvm_version' in variables and Version(variables['llvm_version']) >= Version('3.3')) or \
++      ('nasm_version' in variables and Version(variables['nasm_version']) >= Version('2.10'))
+ 
+     if is_x86 and not openssl110_asm_supported:
+       error('''Did not find a new enough assembler, install one or build with

--- a/cmake/ports/node/replace-distutils2.patch
+++ b/cmake/ports/node/replace-distutils2.patch
@@ -1,0 +1,21 @@
+diff -ru node/tools/gyp/pylib/gyp/input.py node.patched/tools/gyp/pylib/gyp/input.py
+--- node/tools/gyp/pylib/gyp/input.py	2024-04-10 14:12:07.000000000 +0200
++++ node.patched/tools/gyp/pylib/gyp/input.py	2025-02-27 21:58:01.579193906 +0100
+@@ -16,7 +16,7 @@
+ import sys
+ import threading
+ import traceback
+-from distutils.version import StrictVersion
++from packaging.version import Version
+ from gyp.common import GypError
+ from gyp.common import OrderedSet
+ 
+@@ -1190,7 +1190,7 @@
+         else:
+             ast_code = compile(cond_expr_expanded, "<string>", "eval")
+             cached_conditions_asts[cond_expr_expanded] = ast_code
+-        env = {"__builtins__": {}, "v": StrictVersion}
++        env = {"__builtins__": {}, "v": Version}
+         if eval(ast_code, env, variables):
+             return true_dict
+         return false_dict


### PR DESCRIPTION
This fixes the failed Node built on recent distros due to the distutils Python module being deprecated.