### PR TITLE
Always show "Load Defaults" in "Running Scripts", not just when the developer menu is enabled.

### DIFF
--- a/interface/resources/qml/hifi/dialogs/RunningScripts.qml
+++ b/interface/resources/qml/hifi/dialogs/RunningScripts.qml
@@ -208,8 +208,6 @@ Windows.ScrollingWindow {
                 HifiControls.Button {
                     text: "Load Defaults"
                     color: hifi.buttons.black
-                    height: 26
-                    visible: root.developerMenuEnabled;
                     onClicked: loadDefaults()
                 }
             }


### PR DESCRIPTION
Works on my machine.™

Technically, it makes sense to hide it, since one should never have to reload the defaults; But in practice we run into bugs where the defaults go missing. Also, there is space for three buttons there, so there is nothing won by hiding one.

This PR also fixes the button being slightly slimmer than all the others.