### PR TITLE
Property and dev menu option to disable hiding avatar head in first person

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -595,9 +595,9 @@ Menu::Menu() {
             avatar->setProperty("lookAtSnappingEnabled", isOptionChecked(MenuOption::EnableLookAtSnapping));
         });
 
-    action = addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::PreventHeadClipping, 0, true);
+    action = addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::HideHeadMesh, 0, true);
     connect(action, &QAction::triggered, [this, avatar] {
-        avatar->setProperty("preventHeadClipping", isOptionChecked(MenuOption::PreventHeadClipping));
+        avatar->setProperty("hideHeadMesh", isOptionChecked(MenuOption::HideHeadMesh));
     });
 
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::FixGaze, 0, false);

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -595,6 +595,11 @@ Menu::Menu() {
             avatar->setProperty("lookAtSnappingEnabled", isOptionChecked(MenuOption::EnableLookAtSnapping));
         });
 
+    action = addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::PreventHeadClipping, 0, true);
+    connect(action, &QAction::triggered, [this, avatar] {
+        avatar->setProperty("preventHeadClipping", isOptionChecked(MenuOption::PreventHeadClipping));
+    });
+
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::FixGaze, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawBaseOfSupport, 0, false,
         avatar.get(), SLOT(setEnableDebugDrawBaseOfSupport(bool)));

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -207,6 +207,7 @@ namespace MenuOption {
     const QString ShowOtherLookAtVectors = "Show Other Eye Vectors";
     const QString ShowOtherLookAtTarget = "Show Other Look-At Target";
     const QString EnableLookAtSnapping = "Enable LookAt Snapping";
+    const QString PreventHeadClipping = "Prevent Head Clipping";
     const QString ShowRealtimeEntityStats = "Show Realtime Entity Stats";
     const QString SimulateEyeTracking = "Simulate";
     const QString SMIEyeTracking = "SMI Eye Tracking";

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -207,7 +207,7 @@ namespace MenuOption {
     const QString ShowOtherLookAtVectors = "Show Other Eye Vectors";
     const QString ShowOtherLookAtTarget = "Show Other Look-At Target";
     const QString EnableLookAtSnapping = "Enable LookAt Snapping";
-    const QString PreventHeadClipping = "Prevent Head Clipping";
+    const QString HideHeadMesh = "Hide Head Mesh";
     const QString ShowRealtimeEntityStats = "Show Realtime Entity Stats";
     const QString SimulateEyeTracking = "Simulate";
     const QString SMIEyeTracking = "SMI Eye Tracking";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -206,6 +206,7 @@ MyAvatar::MyAvatar(QThread* thread) :
     _eyeContactTarget(LEFT_EYE),
     _realWorldFieldOfView("realWorldFieldOfView",
                           DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES),
+    _headClipping("headClipping", true),
     _useAdvancedMovementControls("advancedMovementForHandControllersIsChecked", true),
     _showPlayArea("showPlayArea", true),
     _smoothOrientationTimer(std::numeric_limits<float>::max()),

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -206,6 +206,7 @@ MyAvatar::MyAvatar(QThread* thread) :
     _eyeContactTarget(LEFT_EYE),
     _realWorldFieldOfView("realWorldFieldOfView",
                           DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES),
+    _headClipping("headClipping", true),
     _useAdvancedMovementControls("advancedMovementForHandControllersIsChecked", true),
     _showPlayArea("showPlayArea", true),
     _smoothOrientationTimer(std::numeric_limits<float>::max()),
@@ -3224,7 +3225,8 @@ bool MyAvatar::shouldRenderHead(const RenderArgs* renderArgs) const {
     bool overrideAnim = _skeletonModel ? _skeletonModel->getRig().isPlayingOverrideAnimation() : false;
     bool isInMirror = renderArgs->_mirrorDepth > 0;
     bool insideHead = cameraInsideHead(renderArgs->getViewFrustum().getPosition());
-    return !defaultMode || isInMirror || (!firstPerson && !insideHead) || (overrideAnim && !insideHead);
+    bool forceDisabled = !getHeadClippingEnabled();
+    return forceDisabled || !defaultMode || isInMirror || (!firstPerson && !insideHead) || (overrideAnim && !insideHead);
 }
 
 void MyAvatar::setRotationRecenterFilterLength(float length) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -206,7 +206,7 @@ MyAvatar::MyAvatar(QThread* thread) :
     _eyeContactTarget(LEFT_EYE),
     _realWorldFieldOfView("realWorldFieldOfView",
                           DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES),
-    _headClipping("headClipping", true),
+    _hideHeadMesh("hideHeadMesh", true),
     _useAdvancedMovementControls("advancedMovementForHandControllersIsChecked", true),
     _showPlayArea("showPlayArea", true),
     _smoothOrientationTimer(std::numeric_limits<float>::max()),
@@ -3225,7 +3225,7 @@ bool MyAvatar::shouldRenderHead(const RenderArgs* renderArgs) const {
     bool overrideAnim = _skeletonModel ? _skeletonModel->getRig().isPlayingOverrideAnimation() : false;
     bool isInMirror = renderArgs->_mirrorDepth > 0;
     bool insideHead = cameraInsideHead(renderArgs->getViewFrustum().getPosition());
-    return !_preventHeadClipping || !defaultMode || isInMirror || (!firstPerson && !insideHead) || (overrideAnim && !insideHead);
+    return !_hideHeadMesh.get() || !defaultMode || isInMirror || (!firstPerson && !insideHead) || (overrideAnim && !insideHead);
 }
 
 void MyAvatar::setRotationRecenterFilterLength(float length) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -206,7 +206,6 @@ MyAvatar::MyAvatar(QThread* thread) :
     _eyeContactTarget(LEFT_EYE),
     _realWorldFieldOfView("realWorldFieldOfView",
                           DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES),
-    _headClipping("headClipping", true),
     _useAdvancedMovementControls("advancedMovementForHandControllersIsChecked", true),
     _showPlayArea("showPlayArea", true),
     _smoothOrientationTimer(std::numeric_limits<float>::max()),
@@ -3225,8 +3224,7 @@ bool MyAvatar::shouldRenderHead(const RenderArgs* renderArgs) const {
     bool overrideAnim = _skeletonModel ? _skeletonModel->getRig().isPlayingOverrideAnimation() : false;
     bool isInMirror = renderArgs->_mirrorDepth > 0;
     bool insideHead = cameraInsideHead(renderArgs->getViewFrustum().getPosition());
-    bool forceDisabled = !getHeadClippingEnabled();
-    return forceDisabled || !defaultMode || isInMirror || (!firstPerson && !insideHead) || (overrideAnim && !insideHead);
+    return !_preventHeadClipping || !defaultMode || isInMirror || (!firstPerson && !insideHead) || (overrideAnim && !insideHead);
 }
 
 void MyAvatar::setRotationRecenterFilterLength(float length) {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -644,6 +644,13 @@ public:
     void setRealWorldFieldOfView(float realWorldFov) { _realWorldFieldOfView.set(realWorldFov); }
 
     /*@jsdoc
+     * Sets whether the avatar's head should be hidden in first-person mode.
+     * @function MyAvatar.setHeadClippingEnabled
+     * @param {boolean} enable - <code>true</code> will scale the avatar's head in first person to hide it; <code>false</code> will leave the head full and visible in first person, which may have visible near-Z clipping or obstruct the player's view.
+     */
+    Q_INVOKABLE void setHeadClippingEnabled(bool enable) { _headClipping.set(enable); }
+
+    /*@jsdoc
      * Gets the position in world coordinates of the point directly between your avatar's eyes assuming your avatar was in its
      * default pose. This is a reference position; it does not change as your avatar's head moves relative to the avatar
      * position.
@@ -656,6 +663,13 @@ public:
     Q_INVOKABLE glm::vec3 getDefaultEyePosition() const;
 
     float getRealWorldFieldOfView() { return _realWorldFieldOfView.get(); }
+
+    /*@jsdoc
+     * Gets whether the avatar's head mesh will be hidden in first person mode.
+     * @function MyAvatar.getHeadClippingEnabled
+     * @returns {boolean} Whether head clipping is enabled.
+     */
+    Q_INVOKABLE bool getHeadClippingEnabled() const { return _headClipping.get(); }
 
     /*@jsdoc
      * Overrides the default avatar animations.
@@ -2645,6 +2659,7 @@ private:
     bool _isPointTargetValid { true };
 
     Setting::Handle<float> _realWorldFieldOfView;
+    Setting::Handle<bool> _headClipping;
     Setting::Handle<bool> _useAdvancedMovementControls;
     Setting::Handle<bool> _showPlayArea;
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -271,7 +271,7 @@ class MyAvatar : public Avatar {
      *     See also: <code>getUserRecenterModel</code> and <code>setUserRecenterModel</code>.</p>
      * @property {boolean} allowTeleporting - <code>true</code> if teleporting is enabled in the Interface settings,
      *     <code>false</code> if it isn't. <em>Read-only.</em>
-     * @property {boolean} preventHeadClipping - <code>true</code> will hide the avatar's head in first person; <code>false</code> will leave the head visible in first person, which may have visible near-Z clipping or obstruct the player's view.
+     * @property {boolean} hideHeadMesh - <code>true</code> will hide the avatar's head in first person; <code>false</code> will leave the head visible in first person, which may have visible near-Z clipping or obstruct the player's view.
      * @property {number} cameraBoomLength - The third-person camera distance. Limited to between 0.5 and 25. Below 0.5 the camera will be put into first-person mode. Changing this property has no effect unless the camera is already in third-person mode. See {@link Camera.mode}.
      *
      * @borrows Avatar.getDomainMinScale as getDomainMinScale
@@ -365,7 +365,7 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(bool characterControllerEnabled READ getCharacterControllerEnabled WRITE setCharacterControllerEnabled)
     Q_PROPERTY(bool useAdvancedMovementControls READ useAdvancedMovementControls WRITE setUseAdvancedMovementControls)
     Q_PROPERTY(bool showPlayArea READ getShowPlayArea WRITE setShowPlayArea)
-    Q_PROPERTY(bool preventHeadClipping MEMBER _preventHeadClipping)
+    Q_PROPERTY(bool hideHeadMesh READ getHideHeadMesh WRITE setHideHeadMesh)
 
     Q_PROPERTY(float yawSpeed MEMBER _yawSpeed)
     Q_PROPERTY(float hmdYawSpeed MEMBER _hmdYawSpeed)
@@ -647,10 +647,17 @@ public:
 
     /*@jsdoc
      * Sets whether the avatar's head should be hidden in first-person mode.
-     * @function MyAvatar.setHeadClippingEnabled
+     * @function MyAvatar.setHideHeadMesh
      * @param {boolean} enable - <code>true</code> will scale the avatar's head in first person to hide it; <code>false</code> will leave the head full and visible in first person, which may have visible near-Z clipping or obstruct the player's view.
      */
-    Q_INVOKABLE void setHeadClippingEnabled(bool enable) { _headClipping.set(enable); }
+    Q_INVOKABLE void setHideHeadMesh(bool enable) { _hideHeadMesh.set(enable); }
+
+    /*@jsdoc
+     * Gets whether the avatar's head mesh will be hidden in first person mode.
+     * @function MyAvatar.getHideHeadMesh
+     * @returns {boolean} <code>true</code> will scale the avatar's head in first person to hide it; <code>false</code> will leave the head full and visible in first person, which may have visible near-Z clipping or obstruct the player's view.
+     */
+    Q_INVOKABLE bool getHideHeadMesh() const { return _hideHeadMesh.get(); }
 
     /*@jsdoc
      * Gets the position in world coordinates of the point directly between your avatar's eyes assuming your avatar was in its
@@ -665,13 +672,6 @@ public:
     Q_INVOKABLE glm::vec3 getDefaultEyePosition() const;
 
     float getRealWorldFieldOfView() { return _realWorldFieldOfView.get(); }
-
-    /*@jsdoc
-     * Gets whether the avatar's head mesh will be hidden in first person mode.
-     * @function MyAvatar.getHeadClippingEnabled
-     * @returns {boolean} Whether head clipping is enabled.
-     */
-    Q_INVOKABLE bool getHeadClippingEnabled() const { return _headClipping.get(); }
 
     /*@jsdoc
      * Overrides the default avatar animations.
@@ -2659,10 +2659,9 @@ private:
     float _firstPersonSteadyHeadTimer { 0.0f };
     bool _pointAtActive { false };
     bool _isPointTargetValid { true };
-    bool _preventHeadClipping { true };
 
     Setting::Handle<float> _realWorldFieldOfView;
-    Setting::Handle<bool> _headClipping;
+    Setting::Handle<bool> _hideHeadMesh;
     Setting::Handle<bool> _useAdvancedMovementControls;
     Setting::Handle<bool> _showPlayArea;
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -271,6 +271,7 @@ class MyAvatar : public Avatar {
      *     See also: <code>getUserRecenterModel</code> and <code>setUserRecenterModel</code>.</p>
      * @property {boolean} allowTeleporting - <code>true</code> if teleporting is enabled in the Interface settings,
      *     <code>false</code> if it isn't. <em>Read-only.</em>
+     * @property {boolean} preventHeadClipping - <code>true</code> will hide the avatar's head in first person; <code>false</code> will leave the head visible in first person, which may have visible near-Z clipping or obstruct the player's view.
      * @property {number} cameraBoomLength - The third-person camera distance. Limited to between 0.5 and 25. Below 0.5 the camera will be put into first-person mode. Changing this property has no effect unless the camera is already in third-person mode. See {@link Camera.mode}.
      *
      * @borrows Avatar.getDomainMinScale as getDomainMinScale
@@ -364,6 +365,7 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(bool characterControllerEnabled READ getCharacterControllerEnabled WRITE setCharacterControllerEnabled)
     Q_PROPERTY(bool useAdvancedMovementControls READ useAdvancedMovementControls WRITE setUseAdvancedMovementControls)
     Q_PROPERTY(bool showPlayArea READ getShowPlayArea WRITE setShowPlayArea)
+    Q_PROPERTY(bool preventHeadClipping MEMBER _preventHeadClipping)
 
     Q_PROPERTY(float yawSpeed MEMBER _yawSpeed)
     Q_PROPERTY(float hmdYawSpeed MEMBER _hmdYawSpeed)
@@ -2657,6 +2659,7 @@ private:
     float _firstPersonSteadyHeadTimer { 0.0f };
     bool _pointAtActive { false };
     bool _isPointTargetValid { true };
+    bool _preventHeadClipping { true };
 
     Setting::Handle<float> _realWorldFieldOfView;
     Setting::Handle<bool> _headClipping;

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -263,11 +263,6 @@ void setupPreferences() {
         auto setter = [](bool value) { qApp->setCameraClippingEnabled(value); };
         preferences->addPreference(new CheckPreference(VIEW_CATEGORY, "Enable 3rd Person Camera Clipping?", getter, setter));
     }
-    {
-        auto getter = [myAvatar]()->bool { return myAvatar->getHeadClippingEnabled(); };
-        auto setter = [myAvatar](bool value) { myAvatar->setHeadClippingEnabled(value); };
-        preferences->addPreference(new CheckPreference(VIEW_CATEGORY, "Hide Head in 1st Person", getter, setter));
-    }
 
     // Snapshots
     static const QString SNAPSHOTS { "Snapshots" };

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -263,6 +263,11 @@ void setupPreferences() {
         auto setter = [](bool value) { qApp->setCameraClippingEnabled(value); };
         preferences->addPreference(new CheckPreference(VIEW_CATEGORY, "Enable 3rd Person Camera Clipping?", getter, setter));
     }
+    {
+        auto getter = [myAvatar]()->bool { return myAvatar->getHeadClippingEnabled(); };
+        auto setter = [myAvatar](bool value) { myAvatar->setHeadClippingEnabled(value); };
+        preferences->addPreference(new CheckPreference(VIEW_CATEGORY, "Hide Head in 1st Person", getter, setter));
+    }
 
     // Snapshots
     static const QString SNAPSHOTS { "Snapshots" };


### PR DESCRIPTION
Adds `MyAvatar.hideHeadMesh` and `Developer > Avatar > Hide Head Mesh` to disable the automatic head-hiding logic in first person and when the camera is too close to the avatar's head in other camera modes.