### PR TITLE
Support multiple accounts in domain web UI

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -326,26 +326,42 @@
       "restart": false,
       "settings": [
         {
-          "name": "http_username",
-          "label": "HTTP Username",
-          "help": "Username used for basic HTTP authentication.",
-          "backup": false
-        },
-        {
-          "name": "http_password",
-          "label": "HTTP Password",
-          "type": "password",
-          "help": "Password used for basic HTTP authentication. Leave this alone if you do not want to change it.",
-          "password_placeholder": "******",
-          "value-hidden": true,
-          "backup": false
-        },
-        {
-          "name": "verify_http_password",
-          "label": "Verify HTTP Password",
-          "type": "password",
-          "help": "Must match the password entered above for change to be saved.",
-          "value-hidden": true
+          "name": "http_authentication",
+          "type": "table",
+          "caption": "Authorized Users for HTTP Basic authentication",
+          "help": "These are accounts that are authorized to sign in to the web interface.",
+          "can_add_new_categories": false,
+          "can_add_new_rows": true,
+          "new_category_placeholder": "Add new user",
+          "columns": [
+            {
+              "name": "http_username",
+              "label": "Username",
+              "hidden": false,
+              "backup": false,
+              "readonly": false,
+              "editable": true
+            },
+            {
+              "name": "http_password",
+              "label": "Password",
+              "type": "password",
+              "password_placeholder": "******",
+              "value-hidden": true,
+              "hidden": false,
+              "backup": false,
+              "readonly": false,
+              "editable": true
+            },
+            {
+              "name": "http_password_verify",
+              "label": "Verify Password",
+              "type": "password",
+              "backup": false,
+              "readonly": false,
+              "editable": true
+            }
+          ]
         },
         {
           "name": "approved_safe_urls",

--- a/domain-server/resources/web/js/base-settings.js
+++ b/domain-server/resources/web/js/base-settings.js
@@ -473,6 +473,7 @@ function makeTable(setting, keypath, setting_value) {
 
   var html = "";
 
+  // Apply the "help" block above the table.
   if (setting.help) {
     html += "<span class='help-block'>" + setting.help + "</span>"
   }
@@ -480,11 +481,13 @@ function makeTable(setting, keypath, setting_value) {
   var nonDeletableRowKey = setting["non-deletable-row-key"];
   var nonDeletableRowValues = setting["non-deletable-row-values"];
 
+  // Initialize the table.
   html += "<table class='table table-bordered' " +
                  "data-short-name='" + setting.name + "' name='" + keypath + "' " +
                  "id='" + (!_.isUndefined(setting.html_id) ? setting.html_id : keypath) + "' " +
                  "data-setting-type='" + (isArray ? 'array' : 'hash') + "'>";
 
+  // Add a caption (if provided).
   if (setting.caption) {
     html += "<caption>" + setting.caption + "</caption>"
   }
@@ -508,10 +511,12 @@ function makeTable(setting, keypath, setting_value) {
   // Column names
   html += "<tr class='headers'>"
 
+  // Add a number column (If enabled)
   if (setting.numbered === true) {
     html += "<td class='number'><strong>#</strong></td>" // Row number
   }
 
+  // Add a key column (If enabled)
   if (setting.key) {
     html += "<td class='key'><strong>" + setting.key.label + "</strong></td>" // Key
   }
@@ -584,6 +589,12 @@ function makeTable(setting, keypath, setting_value) {
             "<td class='" + Settings.DATA_COL_CLASS + "'name='" + col.name + "'>" +
               "<input type='checkbox' class='form-control table-checkbox' " +
                      "name='" + colName + "'" + (colValue ? " checked" : "") + "/>" +
+            "</td>";
+        } else if (isArray && col.type === "password" && col.editable) {
+          html +=
+            "<td class='" + Settings.DATA_COL_CLASS + "' " + (col.hidden ? "style='display: none;'" : "") +
+                "name='" + colName + "'>" +
+              "<input class='form-control' type='password' name='" + colName + "' value='"+ (colValue ? colValue : "") + "'/>" +
             "</td>";
         } else if (isArray && col.type === "time" && col.editable) {
           html +=


### PR DESCRIPTION
This adds support for multiple user accounts in the domain web UI using HTTP basic authentication.

TODO:
- [ ] Prohibit empty usernames
- [ ] Prohibit duplicate usernames
- [ ] No account ("open access") support
- [ ] Create update path for existing configs
- [ ] UI detect when attempting to change password to easily allow updating.
   (The UI does not yet detect when the password fields have been changed, so another setting has to be toggled to give the option to save the new values) 

Closes #734 