### PR TITLE
Increase minimum height of tabsPropertiesPage in Create app

### DIFF
--- a/scripts/system/html/css/tabs.css
+++ b/scripts/system/html/css/tabs.css
@@ -3,6 +3,7 @@
 //
 //  Created by Alezia Kurdis on 27 Feb 2020
 //  Copyright 2020 Vircadia contributors.
+//  Copyright 2025 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -72,6 +73,6 @@ td.tabsPropertiesFrame {
 }
 
 div.tabsPropertiesPage {
-    min-height: 352px;
+    min-height: 400px;
     display: block;
 }


### PR DESCRIPTION
This just increases the minimum height for the Create app properties page so that it can fit all of the options provided by the "Shape" properties.

![image](https://github.com/user-attachments/assets/d93bde2a-735b-48f7-b076-48c3695eea36)

Fixes #188.
Hopefully benefits #1354.