### PR TITLE
Initial fix for blurry/noisy transparencies on TAA

### DIFF
--- a/libraries/render-utils/src/DeferredBufferWrite.slh
+++ b/libraries/render-utils/src/DeferredBufferWrite.slh
@@ -73,10 +73,10 @@ void packDeferredFragmentTranslucent(vec4 prevPositionCS, vec3 normal, float alp
         discard;
     }
     _albedoMetallic = vec4(albedo.rgb, alpha);
-    _normalRoughness = vec4(packNormal(normal), clamp(roughness, 0.0, 1.0));
-    _scatteringEmissiveOcclusion = vec4(vec3(0.0), 1.0);
-    _velocity = vec4(packVelocity(prevPositionCS), 0.0, 0.0);
-    _lighting = vec4(0.0);
+    //_normalRoughness = vec4(packNormal(normal), clamp(roughness, 0.0, 1.0));
+    //_scatteringEmissiveOcclusion = vec4(vec3(0.0), 1.0);
+    //_velocity = vec4(packVelocity(prevPositionCS), 0.0, 0.0);
+    //_lighting = vec4(0.0);
 }
 
 void packDeferredFragmentTranslucentUnlit(vec4 prevPositionCS, vec3 normal, float alpha, vec3 color) {
@@ -84,10 +84,10 @@ void packDeferredFragmentTranslucentUnlit(vec4 prevPositionCS, vec3 normal, floa
         discard;
     }
     _albedoMetallic = vec4(color, alpha);
-    _normalRoughness = vec4(packNormal(normal), 1.0);
-    _scatteringEmissiveOcclusion = vec4(vec3(0.0), 1.0);
-    _velocity = vec4(packVelocity(prevPositionCS), 0.0, 0.0);
-    _lighting = vec4(color, 1.0);
+    //_normalRoughness = vec4(packNormal(normal), 1.0);
+    //_scatteringEmissiveOcclusion = vec4(vec3(0.0), 1.0);
+    //_velocity = vec4(packVelocity(prevPositionCS), 0.0, 0.0);
+    //_lighting = vec4(color, 1.0);
 }
 
 <@endif@>

--- a/libraries/render-utils/src/DeferredBufferWrite.slh
+++ b/libraries/render-utils/src/DeferredBufferWrite.slh
@@ -72,22 +72,18 @@ void packDeferredFragmentTranslucent(vec4 prevPositionCS, vec3 normal, float alp
     if (alpha <= 0.0) {
         discard;
     }
+    // There's only one attachment here, and _albedoMetallic is actually _lighting,
+    // since transparencies are drawn using forward rendering, not deferred.
     _albedoMetallic = vec4(albedo.rgb, alpha);
-    //_normalRoughness = vec4(packNormal(normal), clamp(roughness, 0.0, 1.0));
-    //_scatteringEmissiveOcclusion = vec4(vec3(0.0), 1.0);
-    //_velocity = vec4(packVelocity(prevPositionCS), 0.0, 0.0);
-    //_lighting = vec4(0.0);
 }
 
 void packDeferredFragmentTranslucentUnlit(vec4 prevPositionCS, vec3 normal, float alpha, vec3 color) {
     if (alpha <= 0.0) {
         discard;
     }
+    // There's only one attachment here, and _albedoMetallic is actually _lighting,
+    // since transparencies are drawn using forward rendering, not deferred.
     _albedoMetallic = vec4(color, alpha);
-    //_normalRoughness = vec4(packNormal(normal), 1.0);
-    //_scatteringEmissiveOcclusion = vec4(vec3(0.0), 1.0);
-    //_velocity = vec4(packVelocity(prevPositionCS), 0.0, 0.0);
-    //_lighting = vec4(color, 1.0);
 }
 
 <@endif@>

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -44,7 +44,7 @@ protected:
 
 class RenderTransparentDeferred {
 public:
-    using Inputs = render::VaryingSet7<render::ItemBounds, HazeStage::FramePointer, LightStage::FramePointer, LightingModelPointer, LightClustersPointer, LightStage::ShadowFramePointer, DeferredFrameTransformPointer>;
+    using Inputs = render::VaryingSet8<render::ItemBounds, HazeStage::FramePointer, LightStage::FramePointer, LightingModelPointer, LightClustersPointer, LightStage::ShadowFramePointer, DeferredFrameTransformPointer, DeferredFramebufferPointer>;
     using Config = RenderTransparentDeferredConfig;
     using JobModel = render::Job::ModelI<RenderTransparentDeferred, Inputs, Config>;
 


### PR DESCRIPTION
This fixes https://github.com/overte-org/overte/issues/1328
I need advice on if this could break something.
What is the function of `packDeferredFragmentTranslucent` if we render transparencies in forward mode and deferred framebuffers are not set there?