### PR TITLE
Add check to see if hudRayPick intersects.

### DIFF
--- a/scripts/system/controllers/controllerModules/farGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farGrabEntity.js
@@ -357,11 +357,14 @@ Script.include("/~/system/libraries/controllers.js");
         };
 
         this.notPointingAtEntity = function (controllerData) {
+            if (!hudRayPick.intersects) return;
+            
             var intersection = controllerData.rayPicks[this.hand];
             var entityProperty = Entities.getEntityProperties(intersection.objectID, "type");
             var entityType = entityProperty.type;
             var hudRayPick = controllerData.hudRayPicks[this.hand];
             var point2d = this.calculateNewReticlePosition(hudRayPick.intersection);
+
             if ((intersection.type === Picks.INTERSECTED_ENTITY && entityType === "Web") ||
                 intersection.type === Picks.INTERSECTED_OVERLAY || Window.isPointOnDesktopWindow(point2d)) {
                 return true;


### PR DESCRIPTION
This adds a check to see if the hudRayPick has a valid intersection. If it does not, it will not continue.
Fix taken from inEditMode, so I am assuming this should also work without breaking anything. https://github.com/overte-org/overte/blob/371eb74723951b06d8b62eb4aed21bd3dfc69f15/scripts/system/controllers/controllerModules/inEditMode.js#L111-L128 
I have not tested this, as my current VR setup is not workable. 
Fixes #1376 