### PR TITLE
Fix Armored Chat always scrolling on a new message

### DIFF
--- a/scripts/communityScripts/armored-chat/armored_chat.qml
+++ b/scripts/communityScripts/armored-chat/armored_chat.qml
@@ -78,6 +78,7 @@ Rectangle {
                         anchors.fill: parent
                         onClicked: {
                             pageVal = "local";
+                            load_scroll_timer.bypassDistanceCheck = true;
                             load_scroll_timer.running = true;
                         }
                     }
@@ -106,7 +107,8 @@ Rectangle {
                     MouseArea {
                         anchors.fill: parent
                         onClicked: {
-                            pageVal = "domain"
+                            pageVal = "domain";
+                            load_scroll_timer.bypassDistanceCheck = true;
                             load_scroll_timer.running = true;
                         }
                     }

--- a/scripts/communityScripts/armored-chat/armored_chat.qml
+++ b/scripts/communityScripts/armored-chat/armored_chat.qml
@@ -21,6 +21,7 @@ Rectangle {
         repeat: false
         onTriggered: {
             toScript({type: "initialized"});
+            load_scroll_timer.bypassDistanceCheck = true
             load_scroll_timer.running = true
         }
     }
@@ -29,8 +30,12 @@ Rectangle {
         interval: 100
         running: false
         repeat: false
+
+        property bool bypassDistanceCheck: false    // One time event. Whether we should bypass the distance check, and scroll to the bottom regardless or not.
+
         onTriggered: {
-           scrollToBottom(true);
+           scrollToBottom(bypassDistanceCheck);
+           bypassDistanceCheck = false;             // Set the property to false, this was a one time event!
         }
     }
 


### PR DESCRIPTION
AC would always scroll to the bottom to the most recent message when a new one was received. This was not the intention. This makes it so that AC will only scroll to the bottom when the window opens. 