### PR TITLE
fix material inspector not grabbing correct material sometimes

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1957,10 +1957,23 @@ scriptable::ScriptableModelBase Avatar::getScriptableModel() {
     }
     auto result = _skeletonModel->getScriptableModel();
     result.objectID = getSessionUUID().isNull() ? AVATAR_SELF_ID : getSessionUUID();
+
+    std::unordered_map<std::string, graphics::MultiMaterial> materials;
     {
         std::lock_guard<std::mutex> lock(_materialsLock);
-        result.appendMaterials(_materials);
+        materials = _materials;
     }
+
+    for (auto& multiMaterial : materials) {
+        while (!multiMaterial.second.empty()) {
+            auto shapeIDs = _skeletonModel->getMeshIDsAndMaterialNamesFromMaterialID(multiMaterial.first.c_str());
+            for (const auto& shapeID : shapeIDs) {
+                result.appendMaterial(multiMaterial.second.top(), shapeID.first, shapeID.second);
+            }
+            multiMaterial.second.pop();
+        }
+    }
+
     return result;
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -987,10 +987,23 @@ scriptable::ScriptableModelBase render::entities::ModelEntityRenderer::getScript
 
     auto result = model->getScriptableModel();
     result.objectID = getEntity()->getID();
+
+    std::unordered_map<std::string, graphics::MultiMaterial> materials;
     {
         std::lock_guard<std::mutex> lock(_materialsLock);
-        result.appendMaterials(_materials);
+        materials = _materials;
     }
+
+    for (auto& multiMaterial : materials) {
+        while (!multiMaterial.second.empty()) {
+            auto shapeIDs = model->getMeshIDsAndMaterialNamesFromMaterialID(multiMaterial.first.c_str());
+            for (const auto& shapeID : shapeIDs) {
+                result.appendMaterial(multiMaterial.second.top(), shapeID.first, shapeID.second);
+            }
+            multiMaterial.second.pop();
+        }
+    }
+
     return result;
 }
 

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
@@ -257,8 +257,9 @@ void scriptable::ScriptableModelBase::append(const ScriptableMeshBase& mesh) {
 }
 
 void scriptable::ScriptableModelBase::appendMaterial(const graphics::MaterialLayer& materialLayer, int shapeID, std::string materialName) {
-    materialLayers[QString::number(shapeID)].push_back(ScriptableMaterialLayer(materialLayer));
-    materialLayers["mat::" + QString::fromStdString(materialName)].push_back(ScriptableMaterialLayer(materialLayer));
+    ScriptableMaterialLayer layer = ScriptableMaterialLayer(materialLayer);
+    materialLayers[QString::number(shapeID)].push_back(layer);
+    materialLayers["mat::" + QString::fromStdString(materialName)].push_back(layer);
 }
 
 void scriptable::ScriptableModelBase::appendMaterials(const std::unordered_map<std::string, graphics::MultiMaterial>& materialsToAppend) {

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -371,6 +371,8 @@ public:
 
     void setBlendshapeCoefficients(const QVector<float>& coefficients) { _blendshapeCoefficients = coefficients; }
 
+    std::set<std::pair<uint, std::string>> getMeshIDsAndMaterialNamesFromMaterialID(QString parentMaterialName);
+
 public slots:
     void loadURLFinished(bool success);
 
@@ -521,8 +523,6 @@ private:
     std::function<float()> _loadingPriorityOperator { []() { return 0.0f; } };
 
     void calculateTextureInfo();
-
-    std::set<unsigned int> getMeshIDsFromMaterialID(QString parentMaterialName);
 };
 
 Q_DECLARE_METATYPE(ModelPointer)


### PR DESCRIPTION
closes #1028 

testing:

create a material entity (priority > 0) and parent it to a model.  try targeting a single mesh part by index, then multiple indices, then material(s) by name.  in all cases, when you open the material inspector via luci > tools > material > click on the model, the inspector should show the correct material

## Funding

This project is funded through [NGI Zero Core](https://nlnet.nl/core), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Overte-visualscripting).

[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/core)