### PR TITLE
ability to specify texture samplers

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -347,7 +347,7 @@ protected:
     void setupStereoSide(int side);
 #endif
 
-    virtual void setResourceTexture(unsigned int slot, const TexturePointer& resourceTexture);
+    virtual void setResourceTexture(unsigned int slot, const TexturePointer& resourceTexture, const Sampler& sampler);
     virtual void setFramebuffer(const FramebufferPointer& framebuffer);
     virtual void initInput() final;
     virtual void killInput() final;
@@ -530,7 +530,7 @@ protected:
 
     // Helper function that provides common code used by do_setResourceTexture and
     // do_setResourceTextureTable (in non-bindless mode)
-    void bindResourceTexture(uint32_t slot, const TexturePointer& texture);
+    void bindResourceTexture(uint32_t slot, const TexturePointer& texture, const Sampler& sampler);
 
     // update resource cache and do the gl unbind call with the current gpu::Texture cached at slot s
     void releaseResourceTexture(uint32_t slot);
@@ -539,7 +539,8 @@ protected:
 
     struct ResourceStageState {
         struct TextureState {
-            TextureReference _texture{};
+            TextureReference _texture {};
+            Sampler _sampler {};
             GLenum _target;
         };
         std::array<BufferReference, MAX_NUM_RESOURCE_BUFFERS> _buffers{};

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTexture.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTexture.h
@@ -168,7 +168,7 @@ public:
 
 protected:
     virtual void generateMips() const = 0;
-    virtual void syncSampler() const = 0;
+    virtual void syncSampler(const Sampler& sampler) const = 0;
 
     virtual void copyTextureMipsInGPUMem(GLuint srcId, GLuint destId, uint16_t srcMipOffset, uint16_t destMipOffset, uint16_t populatedMips) {} // Only relevant for Variable Allocation textures
 
@@ -183,7 +183,7 @@ public:
 protected:
     GLExternalTexture(const std::weak_ptr<gl::GLBackend>& backend, const Texture& texture, GLuint id);
     void generateMips() const override {}
-    void syncSampler() const override {}
+    void syncSampler(const Sampler& sampler) const override {}
     Size copyMipFaceLinesFromTexture(uint16_t mip, uint8_t face, const uvec3& size, uint32_t yOffset, GLenum internalFormat, GLenum format, GLenum type, Size sourceSize, const void* sourcePointer) const override { return 0;}
 
     Size size() const override { return 0; }

--- a/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41Backend.h
@@ -58,7 +58,7 @@ public:
         GL41Texture(const std::weak_ptr<GLBackend>& backend, const Texture& texture);
         void generateMips() const override;
         Size copyMipFaceLinesFromTexture(uint16_t mip, uint8_t face, const uvec3& size, uint32_t yOffset, GLenum internalFormat, GLenum format, GLenum type, Size sourceSize, const void* sourcePointer) const override;
-        void syncSampler() const override;
+        void syncSampler(const Sampler& sampler) const override;
 
         void withPreservedTexture(std::function<void()> f) const;
     };
@@ -78,7 +78,7 @@ public:
     protected:
         Size size() const override { return _size; }
         void allocateStorage() const;
-        void syncSampler() const override;
+        void syncSampler(const Sampler& sampler) const override;
         const Size _size { 0 };
     };
 
@@ -109,7 +109,7 @@ public:
         ~GL41VariableAllocationTexture();
 
         void allocateStorage(uint16 allocatedMip);
-        void syncSampler() const override;
+        void syncSampler(const Sampler& sampler) const override;
         size_t promote() override;
         size_t demote() override;
         void populateTransferQueue(TransferQueue& pendingTransfers) override;

--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -63,7 +63,7 @@ public:
         GL45Texture(const std::weak_ptr<GLBackend>& backend, const Texture& texture);
         void generateMips() const override;
         Size copyMipFaceLinesFromTexture(uint16_t mip, uint8_t face, const uvec3& size, uint32_t yOffset, GLenum internalFormat, GLenum format, GLenum type, Size sourceSize, const void* sourcePointer) const override;
-        void syncSampler() const override;
+        void syncSampler(const Sampler& sampler) const override;
 
 #if GPU_BINDLESS_TEXTURES
         bool isBindless() const {
@@ -99,7 +99,7 @@ public:
         static Sampler getInvalidSampler();
 
         // This stores the texture handle (64 bits) in xy, the min mip available in z, and the sampler ID in w
-        mutable Sampler _cachedSampler{ getInvalidSampler() };
+        mutable Sampler _cachedSampler { getInvalidSampler() };
     };
 
 #if GPU_BINDLESS_TEXTURES
@@ -137,7 +137,7 @@ public:
         Size size() const override { return _size; }
 
         void allocateStorage() const;
-        void syncSampler() const override;
+        void syncSampler(const Sampler& sampler) const override;
         const Size _size{ 0 };
     };
 
@@ -189,7 +189,7 @@ public:
     protected:
         GL45ResourceTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture);
 
-        void syncSampler() const override;
+        void syncSampler(const Sampler& sampler) const override;
         size_t promote() override;
         size_t demote() override;
         void populateTransferQueue(TransferQueue& pendingTransfers) override;

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -97,7 +97,7 @@ GL45ResourceTexture::GL45ResourceTexture(const std::weak_ptr<GLBackend>& backend
 
     allocateStorage(allocatedMip);
     copyMipsFromTexture();
-    syncSampler();
+    syncSampler(texture.getSampler());
 }
 
 void GL45ResourceTexture::allocateStorage(uint16 allocatedMip) {
@@ -129,8 +129,8 @@ Size GL45ResourceTexture::copyMipsFromTexture() {
     return amount;
 }
 
-void GL45ResourceTexture::syncSampler() const {
-    Parent::syncSampler();
+void GL45ResourceTexture::syncSampler(const Sampler& sampler) const {
+    Parent::syncSampler(sampler);
 #if GPU_BINDLESS_TEXTURES
     if (!isBindless()) {
         glTextureParameteri(_id, GL_TEXTURE_BASE_LEVEL, _populatedMip - _allocatedMip);
@@ -178,7 +178,7 @@ size_t GL45ResourceTexture::promote() {
 
     // Update sampler
     _cachedSampler = getInvalidSampler();
-    syncSampler();
+    syncSampler(_gpuObject.getSampler());
 
     // update the memory usage
     Backend::textureResourceGPUMemSize.update(oldSize, 0);
@@ -220,7 +220,7 @@ size_t GL45ResourceTexture::demote() {
 
     // Update sampler
     _cachedSampler = getInvalidSampler();
-    syncSampler();
+    syncSampler(_gpuObject.getSampler());
 
     // update the memory usage
     Backend::textureResourceGPUMemSize.update(oldSize, 0);
@@ -285,7 +285,7 @@ void GL45ResourceTexture::populateTransferQueue(TransferQueue& pendingTransfers)
             _populatedMip = sourceMip;
             incrementPopulatedSize(_gpuObject.evalMipSize(sourceMip));
             sanityCheck();
-            syncSampler();
+            syncSampler(_gpuObject.getSampler());
         }));
     } while (sourceMip != _allocatedMip);
 }
@@ -384,7 +384,7 @@ GL45SparseResourceTexture::GL45SparseResourceTexture(const std::weak_ptr<GLBacke
     _pageBytes = (uint32_t)(_pageBytes * SPARSE_PAGE_SIZE_OVERHEAD_ESTIMATE);
 
     //allocateStorage();
-    syncSampler();
+    syncSampler(texture.getSampler());
 }
 
 GL45SparseResourceTexture::~GL45SparseResourceTexture() {
@@ -625,7 +625,7 @@ void GL45Texture::stripToMip(uint16_t newMinMip) {
     }
 
     // Re-sync the sampler to force access to the new mip level
-    syncSampler();
+    syncSampler(_gpuObject.getSampler());
     updateSize();
 }
 

--- a/libraries/gpu/src/gpu/Batch.h
+++ b/libraries/gpu/src/gpu/Batch.h
@@ -478,6 +478,7 @@ public:
     typedef Cache<BufferPointer>::Vector BufferCaches;
     typedef Cache<TexturePointer>::Vector TextureCaches;
     typedef Cache<TextureTablePointer>::Vector TextureTableCaches;
+    typedef Cache<Sampler>::Vector SamplerCaches;
     typedef Cache<Stream::FormatPointer>::Vector StreamFormatCaches;
     typedef Cache<Transform>::Vector TransformCaches;
     typedef Cache<PipelinePointer>::Vector PipelineCaches;
@@ -531,6 +532,7 @@ public:
     BufferCaches _buffers;
     TextureCaches _textures;
     TextureTableCaches _textureTables;
+    SamplerCaches _samplers;
     StreamFormatCaches _streamFormats;
     TransformCaches _transforms;
     PipelineCaches _pipelines;

--- a/libraries/gpu/src/gpu/FrameIOKeys.h
+++ b/libraries/gpu/src/gpu/FrameIOKeys.h
@@ -104,6 +104,7 @@ constexpr const char*  texelFormat = "texelFormat";
 constexpr const char*  texture = "texture";
 constexpr const char*  textureTables = "textureTables";
 constexpr const char*  textures = "textures";
+constexpr const char*  samplers = "samplers";
 constexpr const char*  transforms = "transforms";
 constexpr const char*  type = "type";
 constexpr const char*  usageType = "usageType";

--- a/libraries/gpu/src/gpu/FrameReader.cpp
+++ b/libraries/gpu/src/gpu/FrameReader.cpp
@@ -746,6 +746,23 @@ BatchPointer Deserializer::readBatch(const json& node) {
     readOptional(batch._drawcallUniformReset, node, keys::drawcallUniformReset);
     readPointerCache(batch._textures, node, keys::textures, textures);
     readPointerCache(batch._textureTables, node, keys::textureTables, textureTables);
+    {
+        auto transform = [](const json& node) -> Sampler {
+            Sampler::Desc desc;
+            desc._borderColor = readVec4(node["borderColor"]);
+            desc._maxAnisotropy = node["maxAnisotropy"];
+            desc._filter = node["filter"];
+            desc._comparisonFunc = node["comparisonFunc"];
+            desc._wrapModeU = node["wrapModeU"];
+            desc._wrapModeV = node["wrapModeV"];
+            desc._wrapModeW = node["wrapModeW"];
+            desc._mipOffset = node["mipOffset"];
+            desc._minMip = node["minMip"];
+            desc._maxMip = node["maxMip"];
+            return Sampler(desc);
+        };
+        readBatchCacheTransformed<Sampler, Sampler>(batch._samplers, node, keys::samplers, transform);
+    }
     readPointerCache(batch._buffers, node, keys::buffers, buffers);
     readPointerCache(batch._pipelines, node, keys::pipelines, pipelines);
     readPointerCache(batch._streamFormats, node, keys::formats, formats);

--- a/libraries/gpu/src/gpu/FrameWriter.cpp
+++ b/libraries/gpu/src/gpu/FrameWriter.cpp
@@ -236,6 +236,24 @@ json Serializer::writeBatch(const Batch& batch) {
     if (0 != batch._textureTables.size()) {
         batchNode[keys::textureTables] = serializePointerCache(batch._textureTables, textureTableMap);
     }
+    if (0 != batch._samplers.size()) {
+        auto transform = [](const Sampler& object) -> json {
+            json result = json::object();
+            const Sampler::Desc& desc = object.getDesc();
+            result["borderColor"] = writeVec4(desc._borderColor);
+            result["maxAnisotropy"] = desc._maxAnisotropy;
+            result["filter"] = desc._filter;
+            result["comparisonFunc"] = desc._comparisonFunc;
+            result["wrapModeU"] = desc._wrapModeU;
+            result["wrapModeV"] = desc._wrapModeV;
+            result["wrapModeW"] = desc._wrapModeW;
+            result["mipOffset"] = desc._mipOffset;
+            result["minMip"] = desc._minMip;
+            result["maxMip"] = desc._maxMip;
+            return result;
+        };
+        batchNode[keys::samplers] = serializeDataCache<Sampler, json>(batch._samplers, transform);
+    }
     if (0 != batch._buffers.size()) {
         batchNode[keys::buffers] = serializePointerCache(batch._buffers, bufferMap);
     }

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -16,6 +16,7 @@
 #include <glm/gtx/component_wise.hpp>
 #include <glm/gtc/packing.hpp>
 
+#include "QJsonObject"
 #include <QtCore/QDebug>
 #include <QtCore/QThread>
 #include <Trace.h>
@@ -927,6 +928,19 @@ bool TextureSource::isDefined() const {
     return _gpuTexture && _gpuTexture->isDefined();
 }
 
+void TextureSource::setSampler(const gpu::Sampler& sampler) {
+    if (_gpuTextureOperator && !_locked) {
+        _locked = true;
+        auto gpuTexture = _gpuTextureOperator();
+        _locked = false;
+        if (gpuTexture) {
+            gpuTexture->setSampler(sampler);
+        }
+    } else if (_gpuTexture) {
+        _gpuTexture->setSampler(sampler);
+    }
+}
+
 bool Texture::setMinMip(uint16 newMinMip) {
     uint16 oldMinMip = _minMip;
     _minMip = std::min(std::max(_minMip, newMinMip), getMaxMip());
@@ -972,4 +986,111 @@ Texture::ExternalUpdates Texture::getUpdates() const {
 
 void Texture::setStorage(std::unique_ptr<Storage>& newStorage) {
     _storage.swap(newStorage);
+}
+
+Sampler Sampler::parseSampler(const QJsonObject& object) {
+    gpu::Sampler::Desc samplerDesc;
+
+    auto filterItr = object.constFind("filter");
+    if (filterItr != object.constEnd() && filterItr->isString()) {
+        auto filterStr = filterItr->toString();
+        if (filterStr == "point") {
+            samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_MAG_POINT;
+        } else if (filterStr == "linear") {
+            samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_MAG_LINEAR;
+        }
+    } else {
+        auto minFilterItr = object.constFind("minFilter");
+        auto magFilterItr = object.constFind("magFilter");
+        if (minFilterItr != object.constEnd() && minFilterItr->isString() && magFilterItr != object.constEnd() &&
+            magFilterItr->isString()) {
+            auto minFilterStr = minFilterItr->toString();
+            auto magFilterStr = magFilterItr->toString();
+            if (magFilterStr == "point") {
+                if (minFilterStr == "point") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_MAG_POINT;
+                } else if (minFilterStr == "linear") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_LINEAR_MAG_POINT;
+                } else if (minFilterStr == "mipmapPoint") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_MAG_MIP_POINT;
+                } else if (minFilterStr == "mipmapLinear") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_MAG_POINT_MIP_LINEAR;
+                } else if (minFilterStr == "linearMipmapPoint") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_LINEAR_MAG_MIP_POINT;
+                } else if (minFilterStr == "linearMipmapLinear") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR;
+                }
+            } else if (magFilterStr == "linear") {
+                if (minFilterStr == "point") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_POINT_MAG_LINEAR;
+                } else if (minFilterStr == "linear") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_MAG_LINEAR;
+                } else if (minFilterStr == "mipmapPoint") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
+                } else if (minFilterStr == "mipmapLinear") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_POINT_MAG_MIP_LINEAR;
+                } else if (minFilterStr == "linearMipmapPoint") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_MAG_LINEAR_MIP_POINT;
+                } else if (minFilterStr == "linearMipmapLinear") {
+                    samplerDesc._filter = gpu::Sampler::Filter::FILTER_MIN_MAG_MIP_LINEAR;
+                }
+            }
+        }
+    }
+
+    auto wrapItr = object.constFind("wrap");
+    if (wrapItr != object.constEnd() && wrapItr->isString()) {
+        auto wrapStr = wrapItr->toString();
+        if (wrapStr == "repeat") {
+            samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_REPEAT;
+        } else if (wrapStr == "mirror") {
+            samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_MIRROR;
+        } else if (wrapStr == "clamp") {
+            samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_CLAMP;
+        } else if (wrapStr == "border") {
+            samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_BORDER;
+        } else if (wrapStr == "mirrorOnce") {
+            samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_MIRROR_ONCE;
+        }
+        samplerDesc._wrapModeV = samplerDesc._wrapModeU;
+    } else {
+        auto wrapSItr = object.constFind("wrapS");
+        if (wrapSItr != object.constEnd() && wrapSItr->isString()) {
+            auto wrapSStr = wrapSItr->toString();
+            if (wrapSStr == "repeat") {
+                samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_REPEAT;
+            } else if (wrapSStr == "mirror") {
+                samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_MIRROR;
+            } else if (wrapSStr == "clamp") {
+                samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_CLAMP;
+            } else if (wrapSStr == "border") {
+                samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_BORDER;
+            } else if (wrapSStr == "mirrorOnce") {
+                samplerDesc._wrapModeU = gpu::Sampler::WrapMode::WRAP_MIRROR_ONCE;
+            }
+        }
+
+        auto wrapTItr = object.constFind("wrapT");
+        if (wrapTItr != object.constEnd() && wrapTItr->isString()) {
+            auto wrapTStr = wrapTItr->toString();
+            if (wrapTStr == "repeat") {
+                samplerDesc._wrapModeV = gpu::Sampler::WrapMode::WRAP_REPEAT;
+            } else if (wrapTStr == "mirror") {
+                samplerDesc._wrapModeV = gpu::Sampler::WrapMode::WRAP_MIRROR;
+            } else if (wrapTStr == "clamp") {
+                samplerDesc._wrapModeV = gpu::Sampler::WrapMode::WRAP_CLAMP;
+            } else if (wrapTStr == "border") {
+                samplerDesc._wrapModeV = gpu::Sampler::WrapMode::WRAP_BORDER;
+            } else if (wrapTStr == "mirrorOnce") {
+                samplerDesc._wrapModeV = gpu::Sampler::WrapMode::WRAP_MIRROR_ONCE;
+            }
+        }
+    }
+
+    auto borderColorItr = object.constFind("borderColor");
+    if (borderColorItr != object.constEnd()) {
+        samplerDesc._borderColor = vec4FromVariant(borderColorItr->toVariant());
+    }
+
+    return Sampler(samplerDesc);
 }

--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -219,6 +219,9 @@ public:
     bool operator!=(const Sampler& other) const {
         return !(*this == other);
     }
+
+    static Sampler parseSampler(const QJsonObject& object);
+
 protected:
     Desc _desc;
 
@@ -784,6 +787,8 @@ public:
 
     bool isDefined() const;
     std::function<gpu::TexturePointer()> getTextureOperator() const { return _gpuTextureOperator; }
+
+    void setSampler(const gpu::Sampler& sampler);
 
 protected:
     gpu::TexturePointer _gpuTexture;

--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -86,6 +86,7 @@ Material::Material(const Material& material) :
     _materialParams(material._materialParams),
     _cullFaceMode(material._cullFaceMode),
     _textureMaps(material._textureMaps),
+    _samplers(material._samplers),
     _defaultFallthrough(material._defaultFallthrough),
     _propertyFallthroughs(material._propertyFallthroughs)
 {
@@ -109,6 +110,7 @@ Material& Material::operator=(const Material& material) {
     _materialParams = material._materialParams;
     _cullFaceMode = material._cullFaceMode;
     _textureMaps = material._textureMaps;
+    _samplers = material._samplers;
 
     _defaultFallthrough = material._defaultFallthrough;
     _propertyFallthroughs = material._propertyFallthroughs;

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -22,6 +22,7 @@
 #include <Extents.h>
 #include <Transform.h>
 
+#include <gpu/Texture.h>
 #include <graphics/Geometry.h>
 #include <graphics/Material.h>
 
@@ -143,7 +144,9 @@ public:
     int texcoordSet;
     QString texcoordSetName;
 
-    bool isBumpmap{ false };
+    bool isBumpmap { false };
+
+    gpu::Sampler sampler;
 
     bool isNull() const { return name.isEmpty() && filename.isEmpty() && content.isEmpty(); }
 };

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -40,7 +40,7 @@ const size_t MAX_PROCEDURAL_TEXTURE_CHANNELS{ 4 };
  *     If a procedural material contains a vertex shader, the bounding box of the material entity is used to cull the object to which the material is applied.
  * @property {string} fragmentShaderURL - A link to a fragment shader.  Currently, only GLSL shaders are supported.  The shader must implement a different method depending on the version.
  *     <code>shaderUrl</code> is an alias.
- * @property {string[]} channels=[] - An array of input texture URLs or entity IDs.  Currently, up to 4 are supported.  An entity ID may be that of an Image or Web entity.
+ * @property {string[]|Entities.Texture[]} channels=[] - An array of input textures or entity IDs.  Currently, up to 4 are supported.  An entity ID may be that of an Image or Web entity.
  * @property {ProceduralUniforms} uniforms={} - A {@link ProceduralUniforms} object containing all the custom uniforms to be passed to the shader.
  */
 
@@ -188,6 +188,7 @@ protected:
     // Rendering objects
     UniformLambdas _uniforms;
     NetworkTexturePointer _channels[MAX_PROCEDURAL_TEXTURE_CHANNELS];
+    gpu::Sampler _samplers[MAX_PROCEDURAL_TEXTURE_CHANNELS];
     std::unordered_map<std::string, std::string> _vertexReplacements;
     std::unordered_map<std::string, std::string> _fragmentReplacements;
     std::unordered_map<std::string, size_t> _slotMap;

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.h
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.h
@@ -224,9 +224,6 @@ public:
     static ParsedMaterials parseJSONMaterials(const QJsonDocument& materialJSON, const QUrl& baseUrl);
     static ParsedMaterials parseMaterialForUUID(const QJsonValue& entityIDJSON);
     static std::pair<std::string, std::shared_ptr<NetworkMaterial>> parseJSONMaterial(const QJsonValue& materialJSONValue, const QUrl& baseUrl = QUrl());
-
-private:
-    static bool parseJSONColor(const QJsonValue& array, glm::vec3& color, bool& isSRGB);
 };
 
 using NetworkMaterialResourcePointer = QSharedPointer<NetworkMaterialResource>;

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -533,6 +533,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
     multiMaterial.resetReferenceTexturesAndMaterials();
     multiMaterial.setisMToon(!multiMaterial.empty() && multiMaterial.top().material && multiMaterial.top().material->isMToon());
     multiMaterial.resetOutline();
+    multiMaterial.resetSamplers();
 
     // The total list of things we need to look for
     static std::set<uint> allFlags;
@@ -643,6 +644,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 if (itr->second->isDefined()) {
                                     material->resetOpacityMap();
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialAlbedo, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::ALBEDO_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -665,6 +667,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialMetallic, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::METALLIC_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -685,6 +688,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialRoughness, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::ROUGHNESS_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -705,6 +709,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialNormal, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::NORMAL_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -725,6 +730,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialOcclusion, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::OCCLUSION_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -745,6 +751,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialScattering, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::SCATTERING_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -766,6 +773,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialEmissiveLightmap, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::EMISSIVE_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -789,6 +797,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialEmissiveLightmap, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::LIGHT_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -873,6 +882,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 if (itr->second->isDefined()) {
                                     material->resetOpacityMap();
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialAlbedo, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::ALBEDO_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -895,6 +905,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialNormal, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::NORMAL_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -916,6 +927,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialEmissiveLightmap, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler(graphics::MaterialKey::EMISSIVE_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -993,6 +1005,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialShade, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler((graphics::Material::MapChannel) NetworkMToonMaterial::SHADE_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -1013,6 +1026,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialShadingShift, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler((graphics::Material::MapChannel) NetworkMToonMaterial::SHADING_SHIFT_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -1033,6 +1047,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialMatcap, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler((graphics::Material::MapChannel) NetworkMToonMaterial::MATCAP_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -1053,6 +1068,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialRim, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler((graphics::Material::MapChannel) NetworkMToonMaterial::RIM_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -1073,6 +1089,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             if (itr != textureMaps.end()) {
                                 if (itr->second->isDefined()) {
                                     drawMaterialTextures->setTexture(gr::Texture::MaterialUVAnimationMask, itr->second->getTextureView());
+                                    multiMaterial.addSamplerFunc([=] () { material->applySampler((graphics::Material::MapChannel) NetworkMToonMaterial::UV_ANIMATION_MASK_MAP); });
                                     if (itr->second->getTextureView().isReference()) {
                                         multiMaterial.addReferenceTexture(itr->second->getTextureView().getTextureOperator());
                                     }
@@ -1288,6 +1305,8 @@ bool RenderPipelines::bindMaterials(graphics::MultiMaterial& multiMaterial, gpu:
     if (multiMaterial.isMToon()) {
         multiMaterial.setMToonTime();
     }
+
+    multiMaterial.applySamplers();
 
     auto textureCache = DependencyManager::get<TextureCache>();
 


### PR DESCRIPTION
closes #145 

when specifying a material JSON, you can optionally provide more information about textures.  initially, this just includes a sampler, but next it will also be used for tex coords and more.

![Serverless_ file____~_serverless_tutorial json (Directory Services_ Not Logged In) - Overte - Build dev 4_4_2025 11_50_00 PM](https://github.com/user-attachments/assets/5831e7a2-7479-416a-b06a-439587f484f6)

where before you would do:
```
"albedoMap": <some texture URL>
```

you can now do e.g:
```
"albedoMap": {
  "url": <some texture URL>,
  "sampler": {
    "filter": "point",
    "wrap": "mirror"
  }
}
```

in addition to material JSONs (including textures for procedural shaders), samplers are also properly applied from GLTF files now

the full options are specified in the documentation

## Funding

This project is funded through [NGI Zero Core](https://nlnet.nl/core), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Overte-visualscripting).

[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/core)