### PR TITLE
warning when avatar bookmarks JSON is malformed

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1741,17 +1741,19 @@ void Application::idle() {
 #endif
 
 #ifdef Q_OS_WIN
-    // If tracing is enabled then monitor the CPU in a separate thread
-    static std::once_flag once;
-    std::call_once(once, [&] {
-        if (trace_app().isDebugEnabled()) {
-            QThread* cpuMonitorThread = new QThread(qApp);
-            cpuMonitorThread->setObjectName("cpuMonitorThread");
-            QObject::connect(cpuMonitorThread, &QThread::started, [this] { setupCpuMonitorThread(); });
-            QObject::connect(qApp, &QCoreApplication::aboutToQuit, cpuMonitorThread, &QThread::quit);
-            cpuMonitorThread->start();
-        }
-    });
+    {
+        // If tracing is enabled then monitor the CPU in a separate thread
+        static std::once_flag once;
+        std::call_once(once, [&] {
+            if (trace_app().isDebugEnabled()) {
+                QThread* cpuMonitorThread = new QThread(qApp);
+                cpuMonitorThread->setObjectName("cpuMonitorThread");
+                QObject::connect(cpuMonitorThread, &QThread::started, [this] { setupCpuMonitorThread(); });
+                QObject::connect(qApp, &QCoreApplication::aboutToQuit, cpuMonitorThread, &QThread::quit);
+                cpuMonitorThread->start();
+            }
+        });
+    }
 #endif
 
     auto displayPlugin = getActiveDisplayPlugin();
@@ -1880,6 +1882,16 @@ void Application::idle() {
     _overlayConductor.update(secondsSinceLastUpdate);
 
     _gameLoopCounter.increment();
+
+    {
+        static std::once_flag once;
+        std::call_once(once, [] {
+            const QString& bookmarksError = DependencyManager::get<AvatarBookmarks>()->getBookmarkError();
+            if (!bookmarksError.isEmpty()) {
+                OffscreenUi::asyncWarning("Avatar Bookmarks Error", "JSON parse error: " + bookmarksError, QMessageBox::Ok, QMessageBox::Ok);
+            }
+        });
+    }
 }
 
 void Application::update(float deltaTime) {

--- a/interface/src/Bookmarks.cpp
+++ b/interface/src/Bookmarks.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by David Rowe on 13 Jan 2015.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -24,10 +25,6 @@
 #include "Menu.h"
 #include "InterfaceLogging.h"
 
-Bookmarks::Bookmarks() :
-_isMenuSorted(false)
-{
-}
 void Bookmarks::deleteBookmark() {
     QStringList bookmarkList;
     QList<QAction*> menuItems = _bookmarksMenu->actions();
@@ -154,8 +151,14 @@ void Bookmarks::readFromFile() {
     }
 
     QByteArray data = loadFile.readAll();
-    QJsonDocument json(QJsonDocument::fromJson(data));
-    _bookmarks = json.object().toVariantMap();
+    QJsonParseError error;
+    QJsonDocument json = QJsonDocument::fromJson(data, &error);
+
+    if (json.isNull()) {
+        _bookmarkError = error.errorString();
+    } else {
+        _bookmarks = json.object().toVariantMap();
+    }
 }
 
 void Bookmarks::persistToFile() {

--- a/interface/src/Bookmarks.h
+++ b/interface/src/Bookmarks.h
@@ -4,6 +4,7 @@
 //
 //  Created by David Rowe on 13 Jan 2015.
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -25,11 +26,13 @@ class Bookmarks: public QObject {
     Q_OBJECT
 
 public:
-    Bookmarks();
+    Bookmarks() : _isMenuSorted(false) {}
 
     virtual void setupMenus(Menu* menubar, MenuWrapper* menu) = 0;
     void insert(const QString& name, const QVariant& address);  // Overwrites any existing entry with same name.
     QString addressForBookmark(const QString& name) const;
+
+    const QString& getBookmarkError() const { return _bookmarkError; }
 
 protected:
     void deleteBookmark(const QString& bookmarkName);
@@ -45,6 +48,7 @@ protected:
     void remove(const QString& name);
 
     QVariantMap _bookmarks;  // { name: url, ... }
+    QString _bookmarkError;
     QPointer<MenuWrapper> _bookmarksMenu;
     QPointer<QAction> _deleteBookmarksAction;
     QString _bookmarksFilename;


### PR DESCRIPTION
closes #192 

testing:

edit "...AppData\Roaming\Overte - dev\Interface\avatarbookmarks.json" to contain invalid JSON.  when you load interface, it should show a warning.

## Funding

This project is funded through [NGI Zero Core](https://nlnet.nl/core), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Overte-visualscripting).

[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/core)