### PR TITLE
show tofu character on missing character

### DIFF
--- a/libraries/render-utils/src/sdf_text3D.slf
+++ b/libraries/render-utils/src/sdf_text3D.slf
@@ -48,7 +48,9 @@ layout(location=RENDER_UTILS_ATTR_NORMAL_WS) in vec3 _normalWS;
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
 #define _texCoord0 _texCoord01.xy
 #define _texCoord1 _texCoord01.zw
-layout(location=RENDER_UTILS_ATTR_FADE1) flat in vec4 _glyphBounds; // we're reusing the fade texcoord locations here
+ // we're reusing the fade texcoord locations here:
+layout(location=RENDER_UTILS_ATTR_FADE1) flat in vec4 _glyphBounds;
+layout(location=RENDER_UTILS_ATTR_FADE2) flat in float _isTofu;
 
 <@if HIFI_USE_MIRROR@>
     <@include graphics/ShaderConstants.h@>
@@ -57,7 +59,7 @@ layout(location=RENDER_UTILS_ATTR_FADE1) flat in vec4 _glyphBounds; // we're reu
 <@endif@>
 
 void main() {
-    vec4 color = evalSDFSuperSampled(_texCoord0, _positionMS, _glyphBounds);
+    vec4 color = evalSDFSuperSampled(_texCoord0, _positionMS, _glyphBounds, _isTofu);
 
 <@if HIFI_USE_TRANSLUCENT or HIFI_USE_FORWARD@>
     color.a *= params.color.a;

--- a/libraries/render-utils/src/sdf_text3D.slh
+++ b/libraries/render-utils/src/sdf_text3D.slh
@@ -60,8 +60,14 @@ vec2 evalSDF(vec2 texCoord) {
     return vec2(opacity, msdf.a);
 }
 
-vec4 evalSDFColor(vec2 texCoord, vec4 glyphBounds) {
+vec4 evalSDFColor(vec2 texCoord, vec4 glyphBounds, float isTofu) {
     vec3 color = params.color.rgb;
+
+    if (isTofu > 0.0f) {
+        const float OUTLINE_WIDTH = 0.1;
+        return vec4(color, any(greaterThan(abs(texCoord - vec2(0.5)), vec2(0.5 - OUTLINE_WIDTH, 0.5 - (glyphBounds.z / glyphBounds.w) * OUTLINE_WIDTH))));
+    }
+
     vec2 sdf = evalSDF(texCoord);
 
     // Outline
@@ -95,14 +101,14 @@ vec4 evalSDFColor(vec2 texCoord, vec4 glyphBounds) {
     return vec4(color, sdf.x);
 }
 
-vec4 evalSDFSuperSampled(vec2 texCoord, vec2 positionMS, vec4 glyphBounds) {
+vec4 evalSDFSuperSampled(vec2 texCoord, vec2 positionMS, vec4 glyphBounds, float isTofu) {
     // Clip to edges. Note: We don't need to check the top edge.
     if ((params.bounds.z > 0.0 && (positionMS.x < params.bounds.x || positionMS.x > (params.bounds.x + params.bounds.z))) ||
         (params.bounds.w > 0.0 && (positionMS.y < params.bounds.y - params.bounds.w))) {
         return vec4(0.0);
     }
 
-    vec4 color = evalSDFColor(texCoord, glyphBounds);
+    vec4 color = evalSDFColor(texCoord, glyphBounds, isTofu);
 
     // Rely on TAA for anti-aliasing but smooth transition when minification
     // to help filtering

--- a/libraries/render-utils/src/sdf_text3D.slv
+++ b/libraries/render-utils/src/sdf_text3D.slv
@@ -30,12 +30,15 @@ layout(location=RENDER_UTILS_ATTR_POSITION_MS) out vec2 _positionMS;
 <@endif@>
 layout(location=RENDER_UTILS_ATTR_NORMAL_WS) out vec3 _normalWS;
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) out vec4 _texCoord01;
-layout(location=RENDER_UTILS_ATTR_FADE1) flat out vec4 _glyphBounds; // we're reusing the fade texcoord locations here
+// we're reusing the fade texcoord locations here:
+layout(location=RENDER_UTILS_ATTR_FADE1) flat out vec4 _glyphBounds;
+layout(location=RENDER_UTILS_ATTR_FADE2) flat out float _isTofu;
 
 void main() {
     _positionMS = inPosition.xy;
     _texCoord01 = vec4(inTexCoord0.st, 0.0, 0.0);
     _glyphBounds = inTexCoord1;
+    _isTofu = inTexCoord2.x;
 
     vec4 position = inPosition;
     // if we're in shadow mode, we need to move each subsequent quad slightly forward so it doesn't z-fight

--- a/libraries/render-utils/src/text/Font.h
+++ b/libraries/render-utils/src/text/Font.h
@@ -117,6 +117,7 @@ private:
     // we declare the hash as mutable in order to avoid such
     // copies
     mutable QHash<QChar, Glyph> _glyphs;
+    Glyph _tofuGlyph;
 
     // Font characteristics
     QString _family;

--- a/libraries/render-utils/src/text/Glyph.h
+++ b/libraries/render-utils/src/text/Glyph.h
@@ -26,6 +26,7 @@ struct Glyph {
     vec2 size;
     vec2 offset;
     float d;  // xadvance - adjusts character positioning
+    bool isTofu { false };
 
     // We adjust bounds because offset is the bottom left corner of the font but the top left corner of a QRect
     QRectF bounds() const;


### PR DESCRIPTION
closes #1133 

the tofu glyph is the same size as the "?" glyph if it exists in the font, otherwise we try to guess-timate a reasonable glyph size (2 * width of the space glyph for the x, full ascent for the y)

testing:

create a text entity and copy/paste in some characters that are not found in the selected font.  you should see tofu characters replacing those glyphs.  try some different fonts and make sure the tofu character looks reasonable

## Funding

This project is funded through [NGI Zero Core](https://nlnet.nl/core), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Overte-visualscripting).

[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/core)