### PR TITLE
Downgrade CMake on Windows Runners.

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -158,10 +158,12 @@ jobs:
           echo "  done"
         fi
 
-    - name: Override NSIS
+    - name: Override Windows package versions
       shell: pwsh
       if: startsWith(matrix.os, 'windows')
-      run: choco install nsis --allow-downgrade --version=3.06.1
+      run: |
+        choco install nsis --allow-downgrade --version=3.06.1
+        choco install cmake --allow-downgrade --version=3.31.6  # Our dependencies don't support CMake 4.0 yet.
 
     - name: Install Python modules
       if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -213,10 +213,12 @@ jobs:
         fi
 
 
-    - name: Override NSIS
+    - name: Override Windows package versions
       shell: pwsh
       if: startsWith(matrix.os, 'Windows')
-      run: choco install nsis --allow-downgrade --version=3.06.1
+      run: |
+        choco install nsis --allow-downgrade --version=3.06.1
+        choco install cmake --allow-downgrade --version=3.31.6  # Our dependencies don't support CMake 4.0 yet.
 
     - name: Install Python modules
       if: startsWith(matrix.os, 'Windows') || startsWith(matrix.os, 'macOS')

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -83,10 +83,12 @@ jobs:
         submodules: false
         fetch-depth: 1
 
-    - name: Override NSIS
+    - name: Override Windows package versions
       shell: pwsh
       if: startsWith(matrix.os, 'windows')
-      run: choco install nsis --allow-downgrade --version=3.06.1
+      run: |
+        choco install nsis --allow-downgrade --version=3.06.1
+        choco install cmake --allow-downgrade --version=3.31.6  # Our dependencies don't support CMake 4.0 yet.
 
     - name: Install Python modules
       if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')


### PR DESCRIPTION
This should make the Windows CI pipeline complete again.