### PR TITLE
Replaced libnode with V8

### DIFF
--- a/cmake/macros/TargetV8.cmake
+++ b/cmake/macros/TargetV8.cmake
@@ -7,6 +7,11 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 macro(TARGET_V8)
-    find_package(libnode REQUIRED)
-    target_link_libraries(${TARGET_NAME} libnode::libnode)
+    find_package(v8 REQUIRED)
+    target_link_libraries(${TARGET_NAME} v8::v8)
+
+    if (WIN32)
+        target_link_libraries(${TARGET_NAME} Dbghelp)
+    endif()
+
 endmacro()

--- a/conanfile.py
+++ b/conanfile.py
@@ -59,7 +59,7 @@ class Overte(ConanFile):
         self.requires("gli/cci.20210515")
         self.requires("glslang/11.7.0")
         self.requires("liblo/0.30@overte/stable")
-        self.requires("libnode/18.20.6@overte/stable")
+        self.requires("v8/10.2@overte/stable")
         self.requires("nlohmann_json/3.11.2")
         self.requires("nvidia-texture-tools/2023.01@overte/stable")
         self.requires("onetbb/2021.10.0")

--- a/libraries/script-engine/src/v8/FastScriptValueUtils.cpp
+++ b/libraries/script-engine/src/v8/FastScriptValueUtils.cpp
@@ -57,7 +57,7 @@ bool qBytearrayFromScriptValue(const ScriptValue& object, QByteArray &qByteArray
     }
     v8::Local<v8::ArrayBuffer> arrayBuffer = v8::Local<v8::ArrayBuffer>::Cast(v8Value);
     qByteArray.resize((int)arrayBuffer->ByteLength());
-    memcpy(qByteArray.data(), arrayBuffer->Data(), arrayBuffer->ByteLength());
+    memcpy(qByteArray.data(), arrayBuffer->GetBackingStore()->Data(), arrayBuffer->ByteLength());
     return true;
 }
 


### PR DESCRIPTION
This pr replaces libnode with https://github.com/bnoordhuis/v8-cmake
This should improve build times for the dependencies 

**Todo**

- [x] Test on Windows 
- [ ] Test on Linux 