### PR TITLE
support specifying per-texture texCoord set

### DIFF
--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -87,6 +87,7 @@ Material::Material(const Material& material) :
     _cullFaceMode(material._cullFaceMode),
     _textureMaps(material._textureMaps),
     _samplers(material._samplers),
+    _texCoordSets(material._texCoordSets),
     _defaultFallthrough(material._defaultFallthrough),
     _propertyFallthroughs(material._propertyFallthroughs)
 {
@@ -111,6 +112,7 @@ Material& Material::operator=(const Material& material) {
     _cullFaceMode = material._cullFaceMode;
     _textureMaps = material._textureMaps;
     _samplers = material._samplers;
+    _texCoordSets = material._texCoordSets;
 
     _defaultFallthrough = material._defaultFallthrough;
     _propertyFallthroughs = material._propertyFallthroughs;
@@ -211,6 +213,22 @@ void Material::applySampler(MapChannel channel) {
     auto textureMapsItr = _textureMaps.find(channel);
     if (samplerItr != _samplers.end() && textureMapsItr != _textureMaps.end() && textureMapsItr->second->getTextureSource()) {
         textureMapsItr->second->getTextureSource()->setSampler(samplerItr->second);
+    }
+}
+
+void Material::setTexCoordSet(MapChannel channel, int texCoordSet) {
+    std::lock_guard<std::recursive_mutex> locker(_textureMapsMutex);
+    _texCoordSets[channel] = texCoordSet;
+}
+
+int Material::getTexCoordSet(MapChannel channel) {
+    std::lock_guard<std::recursive_mutex> locker(_textureMapsMutex);
+
+    auto result = _texCoordSets.find(channel);
+    if (result != _texCoordSets.end()) {
+        return (result->second);
+    } else {
+        return 0;
     }
 }
 

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -344,6 +344,7 @@ public:
     typedef MaterialKey::MapChannel MapChannel;
     typedef std::unordered_map<MapChannel, TextureMapPointer> TextureMaps;
     typedef std::unordered_map<MapChannel, gpu::Sampler> SamplerMap;
+    typedef std::unordered_map<MapChannel, int> TexCoordSetMap;
 
     Material();
     Material(const Material& material);
@@ -399,6 +400,9 @@ public:
 
     void setSampler(MapChannel channel, const gpu::Sampler& sampler);
     void applySampler(MapChannel channel);
+
+    void setTexCoordSet(MapChannel channel, int texCoordSet);
+    int getTexCoordSet(MapChannel channel);
 
     // Albedo maps cannot have opacity detected until they are loaded
     // This method allows const changing of the key/schemaBuffer without touching the map
@@ -499,6 +503,7 @@ private:
     MaterialKey::CullFaceMode _cullFaceMode { DEFAULT_CULL_FACE_MODE };
     TextureMaps _textureMaps;
     SamplerMap _samplers;
+    TexCoordSetMap _texCoordSets;
 
     bool _defaultFallthrough { false };
     std::unordered_map<uint, bool> _propertyFallthroughs { NUM_TOTAL_FLAGS };
@@ -575,10 +580,18 @@ public:
 
         glm::vec2 _lightmapParams { 0.0, 1.0 };
 
+        uint32_t _texCoordSets { 0 };
+
         Schema() {
             for (auto& transform : _texcoordTransforms) {
                 transform = glm::mat4();
             }
+        }
+
+        void setTexCoordSet(int channel, int texCoordSet) {
+            // We currently only support two texCoord sets (0 and 1), but eventually we want to support 4, so we use 2 bits
+            const int MAX_TEX_COORD_SET = 1;
+            _texCoordSets |= std::min(texCoordSet, MAX_TEX_COORD_SET) << (2 * channel);
         }
     };
 
@@ -615,10 +628,18 @@ public:
         // y: 1 for texture repeat, 0 for discard outside of 0 - 1
         glm::vec2 _materialParams { 0.0, 1.0 };
 
+        uint32_t _texCoordSets { 0 };
+
         MToonSchema() {
             for (auto& transform : _texcoordTransforms) {
                 transform = glm::mat4();
             }
+        }
+
+        void setTexCoordSet(int channel, int texCoordSet) {
+            // We currently only support two texCoord sets (0 and 1), but eventually we want to support 4, so we use 2 bits
+            const int MAX_TEX_COORD_SET = 1;
+            _texCoordSets |= std::min(texCoordSet, MAX_TEX_COORD_SET) << (2 * channel);
         }
     };
 

--- a/libraries/graphics/src/graphics/Material.slh
+++ b/libraries/graphics/src/graphics/Material.slh
@@ -23,6 +23,7 @@ struct TexMapArray {
 <@if not HIFI_USE_MTOON@>
     vec2 _lightmapParams;
 <@endif@>
+    uint _texCoordSets;
 };
 
 <@func declareMaterialTexMapArrayBuffer()@>
@@ -77,6 +78,11 @@ Material getMaterial() {
 }
 TexMapArray getTexMapArray() {
     return _texMapArray;
+}
+vec2 evalTexCoordSet(mat2 uvs, int channel) {
+    // We support up to 4 texCoord sets (0 - 3, 2 bits per channel), but currently we only use 0 and 1 (see setTexCoordSet in Material.h)
+    const int MAX_TEX_COORD_SET = 3;
+    return uvs[(_texMapArray._texCoordSets >> (2 * channel)) & MAX_TEX_COORD_SET];
 }
 
 <@if not HIFI_USE_MTOON@>

--- a/libraries/graphics/src/graphics/MaterialTextures.slh
+++ b/libraries/graphics/src/graphics/MaterialTextures.slh
@@ -96,7 +96,8 @@ TextureTable(0, matTex);
 
 <@if withAlbedo@>
 #define albedoMap 0
-vec4 fetchAlbedoMap(vec2 uv) {
+vec4 fetchAlbedoMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_ALBEDO);
     // Should take into account TAA_TEXTURE_LOD_BIAS?
     return tableTexValue(matTex, albedoMap, uv);
 }
@@ -104,7 +105,8 @@ vec4 fetchAlbedoMap(vec2 uv) {
 
 <@if withNormal@>
 #define normalMap 1
-vec3 fetchNormalMap(vec2 uv) {
+vec3 fetchNormalMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_NORMAL);
     // Should take into account TAA_TEXTURE_LOD_BIAS?
     return tableTexValue(matTex, normalMap, uv).xyz;
 }
@@ -112,7 +114,8 @@ vec3 fetchNormalMap(vec2 uv) {
 
 <@if withMetallic@>
 #define metallicMap 2
-float fetchMetallicMap(vec2 uv) {
+float fetchMetallicMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_METALLIC);
     // Should take into account TAA_TEXTURE_LOD_BIAS?
     return tableTexValue(matTex, metallicMap, uv).r;
 }
@@ -120,7 +123,8 @@ float fetchMetallicMap(vec2 uv) {
 
 <@if withEmissive@>
 #define emissiveMap 3
-vec3 fetchEmissiveMap(vec2 uv) {
+vec3 fetchEmissiveMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP);
     // Should take into account TAA_TEXTURE_LOD_BIAS?
     return tableTexValue(matTex, emissiveMap, uv).rgb;
 }
@@ -128,7 +132,8 @@ vec3 fetchEmissiveMap(vec2 uv) {
 
 <@if withRoughness@>
 #define roughnessMap 4
-float fetchRoughnessMap(vec2 uv) {
+float fetchRoughnessMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_ROUGHNESS);
     // Should take into account TAA_TEXTURE_LOD_BIAS?
     return tableTexValue(matTex, roughnessMap, uv).r;
 }
@@ -136,14 +141,16 @@ float fetchRoughnessMap(vec2 uv) {
 
 <@if withOcclusion@>
 #define occlusionMap 5
-float fetchOcclusionMap(vec2 uv) {
+float fetchOcclusionMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_OCCLUSION);
     return tableTexValue(matTex, occlusionMap, uv).r;
 }
 <@endif@>
 
 <@if withScattering@>
 #define scatteringMap 6
-float fetchScatteringMap(vec2 uv) {
+float fetchScatteringMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_SCATTERING);
     float scattering = texture(tableTex(matTex, scatteringMap), uv).r; // boolean scattering for now
     return max(((scattering - 0.1) / 0.9), 0.0);
     return tableTexValue(matTex, scatteringMap, uv).r; // boolean scattering for now
@@ -154,14 +161,16 @@ float fetchScatteringMap(vec2 uv) {
 
 <@if withAlbedo@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_ALBEDO) uniform sampler2D albedoMap;
-vec4 fetchAlbedoMap(vec2 uv) {
+vec4 fetchAlbedoMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_ALBEDO);
     return texture(albedoMap, uv, TAA_TEXTURE_LOD_BIAS);
 }
 <@endif@>
 
 <@if withNormal@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_NORMAL) uniform sampler2D normalMap;
-vec3 fetchNormalMap(vec2 uv) {
+vec3 fetchNormalMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_NORMAL);
     // unpack normal, swizzle to get into hifi tangent space with Y axis pointing out
     vec2 t = 2.0 * (texture(normalMap, uv, TAA_TEXTURE_LOD_BIAS).rg - vec2(0.5, 0.5));
     vec2 t2 = t*t;
@@ -171,35 +180,40 @@ vec3 fetchNormalMap(vec2 uv) {
 
 <@if withMetallic@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_METALLIC) uniform sampler2D metallicMap;
-float fetchMetallicMap(vec2 uv) {
+float fetchMetallicMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_METALLIC);
     return (texture(metallicMap, uv, TAA_TEXTURE_LOD_BIAS).r);
 }
 <@endif@>
 
 <@if withEmissive@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP) uniform sampler2D emissiveMap;
-vec3 fetchEmissiveMap(vec2 uv) {
+vec3 fetchEmissiveMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP);
     return texture(emissiveMap, uv, TAA_TEXTURE_LOD_BIAS).rgb;
 }
 <@endif@>
 
 <@if withRoughness@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_ROUGHNESS) uniform sampler2D roughnessMap;
-float fetchRoughnessMap(vec2 uv) {
+float fetchRoughnessMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_ROUGHNESS);
     return (texture(roughnessMap, uv, TAA_TEXTURE_LOD_BIAS).r);
 }
 <@endif@>
 
 <@if withOcclusion@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_OCCLUSION) uniform sampler2D occlusionMap;
-float fetchOcclusionMap(vec2 uv) {
+float fetchOcclusionMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_OCCLUSION);
     return texture(occlusionMap, uv).r;
 }
 <@endif@>
 
 <@if withScattering@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_SCATTERING) uniform sampler2D scatteringMap;
-float fetchScatteringMap(vec2 uv) {
+float fetchScatteringMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_SCATTERING);
     float scattering = texture(scatteringMap, uv, TAA_TEXTURE_LOD_BIAS).r; // boolean scattering for now
     return max(((scattering - 0.1) / 0.9), 0.0);
     return texture(scatteringMap, uv).r; // boolean scattering for now
@@ -210,31 +224,50 @@ float fetchScatteringMap(vec2 uv) {
 
 <@endfunc@>
 
-<@func fetchMaterialTexturesCoord0(matKey, texcoord0, albedo, roughness, normal, metallic, emissive, scattering)@>
-    if (getTexMapArray()._materialParams.y != 1.0 && clamp(<$texcoord0$>, vec2(0.0), vec2(1.0)) != <$texcoord0$>) {
+<@func declareMaterialLightmap()@>
+
+<$declareMaterialTexMapArrayBuffer()$>
+
+LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP) uniform sampler2D emissiveMap;
+vec3 fetchLightMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP);
+    vec2 lightmapParams = getTexMapArray()._lightmapParams;
+    return (vec3(lightmapParams.x) + lightmapParams.y * texture(emissiveMap, uv).rgb);
+}
+<@endfunc@>
+
+<@func fetchMaterialTextures(matKey, texcoords, albedo, roughness, normal, metallic, emissive, scattering, occlusion, lightmap)@>
+    vec2 albedoTexCoords = evalTexCoordSet(<$texcoords$>, GRAPHICS_TEXTURE_MATERIAL_ALBEDO);
+    if (getTexMapArray()._materialParams.y != 1.0 && clamp(albedoTexCoords, vec2(0.0), vec2(1.0)) != albedoTexCoords) {
         discard;
     }
 <@if albedo@>
-    vec4 <$albedo$> = mix(vec4(1.0), fetchAlbedoMap(<$texcoord0$>), float((<$matKey$> & (ALBEDO_MAP_BIT | OPACITY_MASK_MAP_BIT | OPACITY_TRANSLUCENT_MAP_BIT)) != 0));
+    vec4 <$albedo$> = mix(vec4(1.0), fetchAlbedoMap(<$texcoords$>), float((<$matKey$> & (ALBEDO_MAP_BIT | OPACITY_MASK_MAP_BIT | OPACITY_TRANSLUCENT_MAP_BIT)) != 0));
 <@endif@>
 <@if roughness@>
-    float <$roughness$> = mix(1.0, fetchRoughnessMap(<$texcoord0$>), float((<$matKey$> & ROUGHNESS_MAP_BIT) != 0));
+    float <$roughness$> = mix(1.0, fetchRoughnessMap(<$texcoords$>), float((<$matKey$> & ROUGHNESS_MAP_BIT) != 0));
 <@endif@>
 <@if normal@>
-    vec3 <$normal$> = mix(vec3(0.0, 1.0, 0.0), fetchNormalMap(<$texcoord0$>), float((<$matKey$> & NORMAL_MAP_BIT) != 0));
+    vec3 <$normal$> = mix(vec3(0.0, 1.0, 0.0), fetchNormalMap(<$texcoords$>), float((<$matKey$> & NORMAL_MAP_BIT) != 0));
 <@endif@>
 <@if metallic@>
-    float <$metallic$> = float((<$matKey$> & METALLIC_MAP_BIT) != 0) * fetchMetallicMap(<$texcoord0$>);
+    float <$metallic$> = float((<$matKey$> & METALLIC_MAP_BIT) != 0) * fetchMetallicMap(<$texcoords$>);
 <@endif@>
 <@if emissive@>
-    vec3 <$emissive$> = float((<$matKey$> & EMISSIVE_MAP_BIT) != 0) * fetchEmissiveMap(<$texcoord0$>);
+    vec3 <$emissive$> = float((<$matKey$> & EMISSIVE_MAP_BIT) != 0) * fetchEmissiveMap(<$texcoords$>);
 <@endif@>
 <@if scattering@>
-    float <$scattering$> = float((<$matKey$> & SCATTERING_MAP_BIT) != 0) * fetchScatteringMap(<$texcoord0$>);
+    float <$scattering$> = float((<$matKey$> & SCATTERING_MAP_BIT) != 0) * fetchScatteringMap(<$texcoords$>);
+<@endif@>
+<@if occlusion@>
+    float <$occlusion$> = mix(1.0, fetchOcclusionMap(<$texcoords$>), float((<$matKey$> & OCCLUSION_MAP_BIT) != 0));
+<@endif@>
+<@if lightmap@>
+    vec3 <$lightmap$> = fetchLightMap(<$texcoords$>);
 <@endif@>
 <@endfunc@>
 
-<@func fetchMaterialTexturesCoord0Triplanar(matKey, positionMS, triplanarScale, albedo, roughness, normal, metallic, emissive, scattering)@>
+<@func fetchMaterialTexturesTriplanar(matKey, positionMS, texCoord1, triplanarScale, albedo, roughness, normal, metallic, emissive, scattering, occlusion, lightmap)@>
     vec3 inPosition = (<$positionMS$> - vec3(0.5)) / <$triplanarScale$>.xyz;
     vec3 normalMS = normalize(cross(dFdy(<$positionMS$>.xyz), dFdx(<$positionMS$>.xyz)));
 
@@ -269,9 +302,16 @@ float fetchScatteringMap(vec2 uv) {
 <@if scattering@>
     float <$scattering$>Triplanar = 0.0;
 <@endif@>
+<@if occlusion@>
+    float <$occlusion$>Triplanar = 0.0;
+<@endif@>
+<@if lightmap@>
+    vec3 <$lightmap$>Triplanar = vec3(0.0);
+<@endif@>
 
     {
-        <$fetchMaterialTexturesCoord0($matKey$, uvXY, $albedo$, $roughness$, $normal$, $metallic$, $emissive$, $scattering$)$>
+        mat2 triplanarUVs = mat2(uvXY, <$texCoord1$>);
+        <$fetchMaterialTextures($matKey$, triplanarUVs, $albedo$, $roughness$, $normal$, $metallic$, $emissive$, $scattering$, $occlusion$, $lightmap$)$>
         float magnitude = blend.z;
         <@if albedo@>
             <$albedo$>Triplanar += magnitude * <$albedo$>;
@@ -291,10 +331,17 @@ float fetchScatteringMap(vec2 uv) {
         <@if scattering@>
             <$scattering$>Triplanar += magnitude * <$scattering$>;
         <@endif@>
+        <@if occlusion@>
+            <$occlusion$>Triplanar += magnitude * <$occlusion$>;
+        <@endif@>
+        <@if lightmap@>
+            <$lightmap$>Triplanar += magnitude * <$lightmap$>;
+        <@endif@>
     }
 
     {
-        <$fetchMaterialTexturesCoord0($matKey$, uvXZ, $albedo$, $roughness$, $normal$, $metallic$, $emissive$, $scattering$)$>
+        mat2 triplanarUVs = mat2(uvXZ, <$texCoord1$>);
+        <$fetchMaterialTextures($matKey$, triplanarUVs, $albedo$, $roughness$, $normal$, $metallic$, $emissive$, $scattering$, $occlusion$, $lightmap$)$>
         float magnitude = blend.y;
         <@if albedo@>
             <$albedo$>Triplanar += magnitude * <$albedo$>;
@@ -314,10 +361,17 @@ float fetchScatteringMap(vec2 uv) {
         <@if scattering@>
             <$scattering$>Triplanar += magnitude * <$scattering$>;
         <@endif@>
+        <@if occlusion@>
+            <$occlusion$>Triplanar += magnitude * <$occlusion$>;
+        <@endif@>
+        <@if lightmap@>
+            <$lightmap$>Triplanar += magnitude * <$lightmap$>;
+        <@endif@>
     }
 
     {
-        <$fetchMaterialTexturesCoord0($matKey$, uvYZ, $albedo$, $roughness$, $normal$, $metallic$, $emissive$, $scattering$)$>
+        mat2 triplanarUVs = mat2(uvYZ, <$texCoord1$>);
+        <$fetchMaterialTextures($matKey$, triplanarUVs, $albedo$, $roughness$, $normal$, $metallic$, $emissive$, $scattering$, $occlusion$, $lightmap$)$>
         float magnitude = blend.x;
         <@if albedo@>
             <$albedo$>Triplanar += magnitude * <$albedo$>;
@@ -336,6 +390,12 @@ float fetchScatteringMap(vec2 uv) {
         <@endif@>
         <@if scattering@>
             <$scattering$>Triplanar += magnitude * <$scattering$>;
+        <@endif@>
+        <@if occlusion@>
+            <$occlusion$>Triplanar += magnitude * <$occlusion$>;
+        <@endif@>
+        <@if lightmap@>
+            <$lightmap$>Triplanar += magnitude * <$lightmap$>;
         <@endif@>
     }
 
@@ -358,28 +418,13 @@ float fetchScatteringMap(vec2 uv) {
 <@if scattering@>
     float <$scattering$> = <$scattering$>Triplanar;
 <@endif@>
-
-<@endfunc@>
-
-<@func fetchMaterialTexturesCoord1(matKey, texcoord1, occlusion, lightmap)@>
 <@if occlusion@>
-    float <$occlusion$> = mix(1.0, fetchOcclusionMap(<$texcoord1$>), float((<$matKey$> & OCCLUSION_MAP_BIT) != 0));
+    float <$occlusion$> = <$occlusion$>Triplanar;
 <@endif@>
 <@if lightmap@>
-    vec3 <$lightmap$> = fetchLightMap(<$texcoord1$>);
+    vec3 <$lightmap$> = <$lightmap$>Triplanar;
 <@endif@>
-<@endfunc@>
 
-
-<@func declareMaterialLightmap()@>
-
-<$declareMaterialTexMapArrayBuffer()$>
-
-LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP) uniform sampler2D emissiveMap;
-vec3 fetchLightMap(vec2 uv) {
-    vec2 lightmapParams = getTexMapArray()._lightmapParams;
-    return (vec3(lightmapParams.x) + lightmapParams.y * texture(emissiveMap, uv).rgb);
-}
 <@endfunc@>
 
 <@func evalMaterialRoughness(fetchedRoughness, materialRoughness, matKey, roughness)@>
@@ -426,56 +471,64 @@ TextureTable(0, matTex);
 
 <@if withAlbedo@>
 #define albedoMap 0
-vec4 fetchAlbedoMap(vec2 uv) {
+vec4 fetchAlbedoMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_ALBEDO);
     return tableTexValue(matTex, albedoMap, uv);
 }
 <@endif@>
 
 <@if withNormal@>
 #define normalMap 1
-vec3 fetchNormalMap(vec2 uv) {
+vec3 fetchNormalMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_NORMAL);
     return tableTexValue(matTex, normalMap, uv).xyz;
 }
 <@endif@>
 
 <@if withShade@>
 #define shadeMap 2
-vec3 fetchShadeMap(vec2 uv) {
+vec3 fetchShadeMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_SHADE);
     return tableTexValue(matTex, shadeMap, uv).rgb;
 }
 <@endif@>
 
 <@if withEmissive@>
 #define emissiveMap 3
-vec3 fetchEmissiveMap(vec2 uv) {
+vec3 fetchEmissiveMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP);
     return tableTexValue(matTex, emissiveMap, uv).rgb;
 }
 <@endif@>
 
 <@if withShadingShift@>
 #define shadingShiftMap 4
-float fetchShadingShiftMap(vec2 uv) {
+float fetchShadingShiftMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_SHADING_SHIFT);
     return tableTexValue(matTex, shadingShiftMap, uv).r;
 }
 <@endif@>
 
 <@if withMatcap@>
 #define matcapMap 5
-vec3 fetchMatcapMap(vec2 uv) {
+vec3 fetchMatcapMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_MATCAP);
     return tableTexValue(matTex, matcapMap, uv).rgb;
 }
 <@endif@>
 
 <@if withRim@>
 #define rimMap 6
-vec3 fetchRimMap(vec2 uv) {
+vec3 fetchRimMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_RIM);
     return tableTexValue(matTex, rimMap, uv).rgb;
 }
 <@endif@>
 
 <@if withUVAnimationMask@>
 #define uvAnimationMaskMap 7
-float fetchUVAnimationMaskMap(vec2 uv) {
+float fetchUVAnimationMaskMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_UV_ANIMATION_MASK);
     return tableTexValue(matTex, uvAnimationMaskMap, uv).r;
 }
 <@endif@>
@@ -484,14 +537,16 @@ float fetchUVAnimationMaskMap(vec2 uv) {
 
 <@if withAlbedo@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_ALBEDO) uniform sampler2D albedoMap;
-vec4 fetchAlbedoMap(vec2 uv) {
+vec4 fetchAlbedoMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_ALBEDO);
     return texture(albedoMap, uv, TAA_TEXTURE_LOD_BIAS);
 }
 <@endif@>
 
 <@if withNormal@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_NORMAL) uniform sampler2D normalMap;
-vec3 fetchNormalMap(vec2 uv) {
+vec3 fetchNormalMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_NORMAL);
     // unpack normal, swizzle to get into hifi tangent space with Y axis pointing out
     vec2 t = 2.0 * (texture(normalMap, uv, TAA_TEXTURE_LOD_BIAS).rg - vec2(0.5, 0.5));
     vec2 t2 = t*t;
@@ -501,21 +556,24 @@ vec3 fetchNormalMap(vec2 uv) {
 
 <@if withShade@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_SHADE) uniform sampler2D shadeMap;
-vec3 fetchShadeMap(vec2 uv) {
+vec3 fetchShadeMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_SHADE);
     return texture(shadeMap, uv, TAA_TEXTURE_LOD_BIAS).rgb;
 }
 <@endif@>
 
 <@if withEmissive@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP) uniform sampler2D emissiveMap;
-vec3 fetchEmissiveMap(vec2 uv) {
+vec3 fetchEmissiveMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_EMISSIVE_LIGHTMAP);
     return texture(emissiveMap, uv, TAA_TEXTURE_LOD_BIAS).rgb;
 }
 <@endif@>
 
 <@if withShadingShift@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_SHADING_SHIFT) uniform sampler2D shadingShiftMap;
-float fetchShadingShiftMap(vec2 uv) {
+float fetchShadingShiftMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_SHADING_SHIFT);
     return texture(shadingShiftMap, uv, TAA_TEXTURE_LOD_BIAS).r;
 }
 <@endif@>
@@ -529,14 +587,16 @@ vec3 fetchMatcapMap(vec2 uv) {
 
 <@if withRim@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_RIM) uniform sampler2D rimMap;
-vec3 fetchRimMap(vec2 uv) {
+vec3 fetchRimMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_RIM);
     return texture(rimMap, uv, TAA_TEXTURE_LOD_BIAS).rgb;
 }
 <@endif@>
 
 <@if withUVAnimationMask@>
 LAYOUT(binding=GRAPHICS_TEXTURE_MATERIAL_UV_ANIMATION_MASK) uniform sampler2D uvAnimationMaskMap;
-float fetchUVAnimationMaskMap(vec2 uv) {
+float fetchUVAnimationMaskMap(mat2 uvs) {
+    vec2 uv = evalTexCoordSet(uvs, GRAPHICS_TEXTURE_MATERIAL_UV_ANIMATION_MASK);
     return texture(uvAnimationMaskMap, uv, TAA_TEXTURE_LOD_BIAS).r;
 }
 <@endif@>
@@ -545,16 +605,17 @@ float fetchUVAnimationMaskMap(vec2 uv) {
 
 <@endfunc@>
 
-<@func fetchMToonMaterialTexturesCoord0(matKey, texcoord0, albedo, normal, shade, emissive, shadingShift, rim, uvScrollSpeed, time)@>
-    if (getTexMapArray()._materialParams.y != 1.0 && clamp(<$texcoord0$>, vec2(0.0), vec2(1.0)) != <$texcoord0$>) {
+<@func fetchMToonMaterialTextures(matKey, texcoords, albedo, normal, shade, emissive, shadingShift, rim, uvScrollSpeed, time)@>
+    vec2 albedoTexCoords = evalTexCoordSet(<$texcoords$>, GRAPHICS_TEXTURE_MATERIAL_ALBEDO);
+    if (getTexMapArray()._materialParams.y != 1.0 && clamp(albedoTexCoords, vec2(0.0), vec2(1.0)) != albedoTexCoords) {
         discard;
     }
 
-    vec2 texCoord = <$texcoord0$>;
+    vec2 texCoord = <$texcoords$>[0];
 
 <@if uvScrollSpeed and time@>
     if ((<$matKey$> & UV_ANIMATION_SCROLL_VAL_BIT) != 0) {
-        <$uvScrollSpeed$> *= mix(1.0, fetchUVAnimationMaskMap(texCoord), float((<$matKey$> & UV_ANIMATION_MASK_MAP_BIT) != 0));
+        <$uvScrollSpeed$> *= mix(1.0, fetchUVAnimationMaskMap(<$texcoords$>), float((<$matKey$> & UV_ANIMATION_MASK_MAP_BIT) != 0));
         <$uvScrollSpeed$> *= time;
         float cosTime = cos(<$uvScrollSpeed$>.z);
         float sinTime = sin(<$uvScrollSpeed$>.z);
@@ -562,27 +623,29 @@ float fetchUVAnimationMaskMap(vec2 uv) {
     }
 <@endif@>
 
+    mat2 texCoordsMToon = mat2(texCoord, <$texcoords$>[1]);
+
 <@if albedo@>
-    vec4 <$albedo$> = mix(vec4(1.0), fetchAlbedoMap(texCoord), float((<$matKey$> & (ALBEDO_MAP_BIT | OPACITY_MASK_MAP_BIT | OPACITY_TRANSLUCENT_MAP_BIT)) != 0));
+    vec4 <$albedo$> = mix(vec4(1.0), fetchAlbedoMap(texCoordsMToon), float((<$matKey$> & (ALBEDO_MAP_BIT | OPACITY_MASK_MAP_BIT | OPACITY_TRANSLUCENT_MAP_BIT)) != 0));
 <@endif@>
 <@if normal@>
-    vec3 <$normal$> = mix(vec3(0.0, 1.0, 0.0), fetchNormalMap(texCoord), float((<$matKey$> & NORMAL_MAP_BIT) != 0));
+    vec3 <$normal$> = mix(vec3(0.0, 1.0, 0.0), fetchNormalMap(texCoordsMToon), float((<$matKey$> & NORMAL_MAP_BIT) != 0));
 <@endif@>
 <@if shade@>
-    vec3 <$shade$> = float((<$matKey$> & SHADE_MAP_BIT) != 0) * fetchShadeMap(texCoord);
+    vec3 <$shade$> = float((<$matKey$> & SHADE_MAP_BIT) != 0) * fetchShadeMap(texCoordsMToon);
 <@endif@>
 <@if emissive@>
-    vec3 <$emissive$> = float((<$matKey$> & EMISSIVE_MAP_BIT) != 0) * fetchEmissiveMap(texCoord);
+    vec3 <$emissive$> = float((<$matKey$> & EMISSIVE_MAP_BIT) != 0) * fetchEmissiveMap(texCoordsMToon);
 <@endif@>
 <@if shadingShift@>
-    float <$shadingShift$> = float((<$matKey$> & SHADING_SHIFT_MAP_BIT) != 0) * fetchShadingShiftMap(texCoord);
+    float <$shadingShift$> = float((<$matKey$> & SHADING_SHIFT_MAP_BIT) != 0) * fetchShadingShiftMap(texCoordsMToon);
 <@endif@>
 <@if rim@>
-    vec3 <$rim$> = mix(vec3(1.0), fetchRimMap(texCoord), float((<$matKey$> & RIM_MAP_BIT) != 0));
+    vec3 <$rim$> = mix(vec3(1.0), fetchRimMap(texCoordsMToon), float((<$matKey$> & RIM_MAP_BIT) != 0));
 <@endif@>
 <@endfunc@>
 
-<@func fetchMToonMaterialTexturesCoord0Triplanar(matKey, positionMS, triplanarScale, albedo, normal, shade, emissive, shadingShift, rim, uvScrollSpeed, time)@>
+<@func fetchMToonMaterialTexturesTriplanar(matKey, positionMS, texCoord1, triplanarScale, albedo, normal, shade, emissive, shadingShift, rim, uvScrollSpeed, time)@>
     vec3 inPosition = (<$positionMS$> - vec3(0.5)) / <$triplanarScale$>.xyz;
     vec3 normalMS = normalize(cross(dFdy(<$positionMS$>.xyz), dFdx(<$positionMS$>.xyz)));
 
@@ -619,7 +682,8 @@ float fetchUVAnimationMaskMap(vec2 uv) {
 <@endif@>
 
     {
-        <$fetchMToonMaterialTexturesCoord0($matKey$, uvXY, $albedo$, $normal$, $shade$, $emissive$, $shadingShift$, $rim$, $uvScrollSpeed$, $time$)$>
+        mat2 triplanarUVs = mat2(uvXY, <$texCoord1$>);
+        <$fetchMToonMaterialTextures($matKey$, triplanarUVs, $albedo$, $normal$, $shade$, $emissive$, $shadingShift$, $rim$, $uvScrollSpeed$, $time$)$>
         float magnitude = blend.z;
         <@if albedo@>
             <$albedo$>Triplanar += magnitude * <$albedo$>;
@@ -642,7 +706,8 @@ float fetchUVAnimationMaskMap(vec2 uv) {
     }
 
     {
-        <$fetchMToonMaterialTexturesCoord0($matKey$, uvXZ, $albedo$, $normal$, $shade$, $emissive$, $shadingShift$, $rim$, $uvScrollSpeed$, $time$)$>
+        mat2 triplanarUVs = mat2(uvXZ, <$texCoord1$>);
+        <$fetchMToonMaterialTextures($matKey$, triplanarUVs, $albedo$, $normal$, $shade$, $emissive$, $shadingShift$, $rim$, $uvScrollSpeed$, $time$)$>
         float magnitude = blend.y;
         <@if albedo@>
             <$albedo$>Triplanar += magnitude * <$albedo$>;
@@ -665,7 +730,8 @@ float fetchUVAnimationMaskMap(vec2 uv) {
     }
 
     {
-        <$fetchMToonMaterialTexturesCoord0($matKey$, uvYZ, $albedo$, $normal$, $shade$, $emissive$, $shadingShift$, $rim$, $uvScrollSpeed$, $time$)$>
+        mat2 triplanarUVs = mat2(uvYZ, <$texCoord1$>);
+        <$fetchMToonMaterialTextures($matKey$, triplanarUVs, $albedo$, $normal$, $shade$, $emissive$, $shadingShift$, $rim$, $uvScrollSpeed$, $time$)$>
         float magnitude = blend.x;
         <@if albedo@>
             <$albedo$>Triplanar += magnitude * <$albedo$>;
@@ -723,13 +789,13 @@ float fetchUVAnimationMaskMap(vec2 uv) {
 }
 <@endfunc@>
 
-<@func evalMaterialMatcap(texcoord0, materialMatcap, matKey, matcap)@>
+<@func evalMaterialMatcap(texcoord, materialMatcap, matKey, matcap)@>
 {
     if ((<$matKey$> & (MATCAP_VAL_BIT | MATCAP_MAP_BIT)) == 0) {
         <$matcap$> = vec3(0.0);
     } else {
         <$matcap$> = mix(vec3(1.0), <$materialMatcap$>, float((<$matKey$> & MATCAP_VAL_BIT) != 0));
-        <$matcap$> *= mix(vec3(1.0), fetchMatcapMap(<$texcoord0$>), float((<$matKey$> & MATCAP_MAP_BIT) != 0));
+        <$matcap$> *= mix(vec3(1.0), fetchMatcapMap(<$texcoord$>), float((<$matKey$> & MATCAP_MAP_BIT) != 0));
     }
 }
 <@endfunc@>

--- a/libraries/model-serializers/src/GLTFSerializer.h
+++ b/libraries/model-serializers/src/GLTFSerializer.h
@@ -57,7 +57,7 @@ private:
     QNetworkReply* request(hifi::URL& url, bool isTest);
 
     void setHFMMaterial(HFMMaterial& hfmMat, const cgltf_material& material);
-    HFMTexture getHFMTexture(const cgltf_texture *texture);
+    HFMTexture getHFMTexture(const cgltf_texture *texture, cgltf_int texCoordSet);
 };
 
 #endif // hifi_GLTFSerializer_h

--- a/libraries/procedural/src/procedural/ProceduralCommon.slh
+++ b/libraries/procedural/src/procedural/ProceduralCommon.slh
@@ -3,6 +3,7 @@
 //
 //  Created by Bradley Austin Davis on 2015/09/05
 //  Copyright 2013-2015 High Fidelity, Inc.
+//  Copyright 2024 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -69,6 +70,7 @@ struct ProceduralVertexData {
     vec3 nonSkinnedTangent;     // input only
     vec4 color;
     vec2 texCoord0;
+    vec2 texCoord1;
 };
 
 struct ProceduralFragment {

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
@@ -157,6 +157,11 @@ static void setMaterialMap(const QJsonValue& value, const std::shared_ptr<Networ
                 auto samplerObject = samplerItr->toObject();
                 material->setSampler(channel, gpu::Sampler::parseSampler(samplerObject));
             }
+
+            auto texCoordItr = valueMap.constFind("texCoord");
+            if (texCoordItr != valueMap.constEnd() && texCoordItr->isDouble()) {
+                material->setTexCoordSet(channel, texCoordItr->toInt());
+            }
         }
     } else if (value.isString()) {
         setMaterialMapString(value.toString(), material, property, baseUrl, setter);
@@ -216,6 +221,7 @@ static void setMaterialMap(const QJsonValue& value, const std::shared_ptr<Networ
  * @typedef {object} Entities.Texture
  * @property {string} url - The URL of the texture.
  * @property {Entities.Sampler} sampler - Set sampler used for this texture.
+ * @property {number} texCoord - The texCoord set to use for this texture.
  */
 
 /*@jsdoc
@@ -843,6 +849,7 @@ graphics::TextureMapPointer NetworkMaterial::fetchTextureMap(const QUrl& baseUrl
     }
     _textures[channel] = Texture { hfmTexture.name, texture };
     setSampler(channel, hfmTexture.sampler);
+    setTexCoordSet(channel, hfmTexture.texcoordSet);
 
     auto map = std::make_shared<graphics::TextureMap>();
     if (texture) {
@@ -949,6 +956,7 @@ NetworkMaterial::NetworkMaterial(const HFMMaterial& material, const QUrl& textur
 
         setTextureMap(MapChannel::ALBEDO_MAP, map);
         setSampler(MapChannel::ALBEDO_MAP, material.albedoTexture.sampler);
+        setTexCoordSet(MapChannel::ALBEDO_MAP, material.albedoTexture.texcoordSet);
     }
 
 
@@ -957,26 +965,31 @@ NetworkMaterial::NetworkMaterial(const HFMMaterial& material, const QUrl& textur
         auto map = fetchTextureMap(textureBaseUrl, material.normalTexture, type, MapChannel::NORMAL_MAP);
         setTextureMap(MapChannel::NORMAL_MAP, map);
         setSampler(MapChannel::NORMAL_MAP, material.normalTexture.sampler);
+        setTexCoordSet(MapChannel::NORMAL_MAP, material.normalTexture.texcoordSet);
     }
 
     if (!material.roughnessTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.roughnessTexture, image::TextureUsage::ROUGHNESS_TEXTURE, MapChannel::ROUGHNESS_MAP);
         setTextureMap(MapChannel::ROUGHNESS_MAP, map);
         setSampler(MapChannel::ROUGHNESS_MAP, material.roughnessTexture.sampler);
+        setTexCoordSet(MapChannel::ROUGHNESS_MAP, material.roughnessTexture.texcoordSet);
     } else if (!material.glossTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.glossTexture, image::TextureUsage::GLOSS_TEXTURE, MapChannel::ROUGHNESS_MAP);
         setTextureMap(MapChannel::ROUGHNESS_MAP, map);
         setSampler(MapChannel::ROUGHNESS_MAP, material.glossTexture.sampler);
+        setTexCoordSet(MapChannel::ROUGHNESS_MAP, material.glossTexture.texcoordSet);
     }
 
     if (!material.metallicTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.metallicTexture, image::TextureUsage::METALLIC_TEXTURE, MapChannel::METALLIC_MAP);
         setTextureMap(MapChannel::METALLIC_MAP, map);
         setSampler(MapChannel::METALLIC_MAP, material.metallicTexture.sampler);
+        setTexCoordSet(MapChannel::METALLIC_MAP, material.metallicTexture.texcoordSet);
     } else if (!material.specularTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.specularTexture, image::TextureUsage::SPECULAR_TEXTURE, MapChannel::METALLIC_MAP);
         setTextureMap(MapChannel::METALLIC_MAP, map);
         setSampler(MapChannel::METALLIC_MAP, material.specularTexture.sampler);
+        setTexCoordSet(MapChannel::METALLIC_MAP, material.specularTexture.texcoordSet);
     }
 
     if (!material.occlusionTexture.filename.isEmpty()) {
@@ -986,18 +999,21 @@ NetworkMaterial::NetworkMaterial(const HFMMaterial& material, const QUrl& textur
         }
         setTextureMap(MapChannel::OCCLUSION_MAP, map);
         setSampler(MapChannel::OCCLUSION_MAP, material.occlusionTexture.sampler);
+        setTexCoordSet(MapChannel::OCCLUSION_MAP, material.occlusionTexture.texcoordSet);
     }
 
     if (!material.emissiveTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.emissiveTexture, image::TextureUsage::EMISSIVE_TEXTURE, MapChannel::EMISSIVE_MAP);
         setTextureMap(MapChannel::EMISSIVE_MAP, map);
         setSampler(MapChannel::EMISSIVE_MAP, material.emissiveTexture.sampler);
+        setTexCoordSet(MapChannel::EMISSIVE_MAP, material.emissiveTexture.texcoordSet);
     }
 
     if (!material.scatteringTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.scatteringTexture, image::TextureUsage::SCATTERING_TEXTURE, MapChannel::SCATTERING_MAP);
         setTextureMap(MapChannel::SCATTERING_MAP, map);
         setSampler(MapChannel::SCATTERING_MAP, material.scatteringTexture.sampler);
+        setTexCoordSet(MapChannel::SCATTERING_MAP, material.scatteringTexture.texcoordSet);
     }
 
     if (!material.lightmapTexture.filename.isEmpty()) {
@@ -1010,6 +1026,7 @@ NetworkMaterial::NetworkMaterial(const HFMMaterial& material, const QUrl& textur
         }
         setTextureMap(MapChannel::LIGHT_MAP, map);
         setSampler(MapChannel::LIGHT_MAP, material.lightmapTexture.sampler);
+        setTexCoordSet(MapChannel::LIGHT_MAP, material.lightmapTexture.texcoordSet);
     }
 }
 
@@ -1123,30 +1140,35 @@ NetworkMToonMaterial::NetworkMToonMaterial(const HFMMaterial& material, const QU
         auto map = fetchTextureMap(textureBaseUrl, material.shadeTexture, image::TextureUsage::ALBEDO_TEXTURE, (MapChannel)MToonMapChannel::SHADE_MAP);
         setTextureMap((MapChannel)MToonMapChannel::SHADE_MAP, map);
         setSampler((MapChannel)MToonMapChannel::SHADE_MAP, material.shadeTexture.sampler);
+        setTexCoordSet((MapChannel)MToonMapChannel::SHADE_MAP, material.shadeTexture.texcoordSet);
     }
 
     if (!material.shadingShiftTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.shadingShiftTexture, image::TextureUsage::ROUGHNESS_TEXTURE, (MapChannel)MToonMapChannel::SHADING_SHIFT_MAP);
         setTextureMap((MapChannel)MToonMapChannel::SHADING_SHIFT_MAP, map);
         setSampler((MapChannel)MToonMapChannel::SHADING_SHIFT_MAP, material.shadingShiftTexture.sampler);
+        setTexCoordSet((MapChannel)MToonMapChannel::SHADING_SHIFT_MAP, material.shadingShiftTexture.texcoordSet);
     }
 
     if (!material.matcapTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.matcapTexture, image::TextureUsage::EMISSIVE_TEXTURE, (MapChannel)MToonMapChannel::MATCAP_MAP);
         setTextureMap((MapChannel)MToonMapChannel::MATCAP_MAP, map);
         setSampler((MapChannel)MToonMapChannel::MATCAP_MAP, material.matcapTexture.sampler);
+        setTexCoordSet((MapChannel)MToonMapChannel::MATCAP_MAP, material.matcapTexture.texcoordSet);
     }
 
     if (!material.rimTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.rimTexture, image::TextureUsage::ALBEDO_TEXTURE, (MapChannel)MToonMapChannel::RIM_MAP);
         setTextureMap((MapChannel)MToonMapChannel::RIM_MAP, map);
         setSampler((MapChannel)MToonMapChannel::RIM_MAP, material.rimTexture.sampler);
+        setTexCoordSet((MapChannel)MToonMapChannel::RIM_MAP, material.rimTexture.texcoordSet);
     }
 
     if (!material.uvAnimationTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.uvAnimationTexture, image::TextureUsage::ROUGHNESS_TEXTURE, (MapChannel)MToonMapChannel::UV_ANIMATION_MASK_MAP);
         setTextureMap((MapChannel)MToonMapChannel::UV_ANIMATION_MASK_MAP, map);
         setSampler((MapChannel)MToonMapChannel::UV_ANIMATION_MASK_MAP, material.uvAnimationTexture.sampler);
+        setTexCoordSet((MapChannel)MToonMapChannel::UV_ANIMATION_MASK_MAP, material.uvAnimationTexture.texcoordSet);
     }
 }
 

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -839,6 +839,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             schemaKey.setAlbedoMap(true);
                             schemaKey.setOpacityMaskMap(material->getKey().isOpacityMaskMap());
                             schemaKey.setTranslucentMap(material->getKey().isTranslucentMap());
+                            schema.setTexCoordSet(gr::Texture::MaterialAlbedo, material->getTexCoordSet(graphics::MaterialKey::ALBEDO_MAP));
                         }
                         break;
                     case graphics::MaterialKey::METALLIC_MAP_BIT:
@@ -860,6 +861,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setMetallicMap(true);
+                            schema.setTexCoordSet(gr::Texture::MaterialMetallic, material->getTexCoordSet(graphics::MaterialKey::METALLIC_MAP));
                         }
                         break;
                     case graphics::MaterialKey::ROUGHNESS_MAP_BIT:
@@ -881,6 +883,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setRoughnessMap(true);
+                            schema.setTexCoordSet(gr::Texture::MaterialRoughness, material->getTexCoordSet(graphics::MaterialKey::ROUGHNESS_MAP));
                         }
                         break;
                     case graphics::MaterialKey::NORMAL_MAP_BIT:
@@ -902,6 +905,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setNormalMap(true);
+                            schema.setTexCoordSet(gr::Texture::MaterialNormal, material->getTexCoordSet(graphics::MaterialKey::NORMAL_MAP));
                         }
                         break;
                     case graphics::MaterialKey::OCCLUSION_MAP_BIT:
@@ -923,6 +927,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setOcclusionMap(true);
+                            schema.setTexCoordSet(gr::Texture::MaterialOcclusion, material->getTexCoordSet(graphics::MaterialKey::OCCLUSION_MAP));
                         }
                         break;
                     case graphics::MaterialKey::SCATTERING_MAP_BIT:
@@ -944,6 +949,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setScatteringMap(true);
+                            schema.setTexCoordSet(gr::Texture::MaterialScattering, material->getTexCoordSet(graphics::MaterialKey::SCATTERING_MAP));
                         }
                         break;
                     case graphics::MaterialKey::EMISSIVE_MAP_BIT:
@@ -966,6 +972,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setEmissiveMap(true);
+                            schema.setTexCoordSet(gr::Texture::MaterialEmissiveLightmap, material->getTexCoordSet(graphics::MaterialKey::EMISSIVE_MAP));
                         } else if (materialKey.isLightMap()) {
                             // We'll set this later when we check the lightmap
                             wasSet = true;
@@ -990,6 +997,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setLightMap(true);
+                            schema.setTexCoordSet(gr::Texture::MaterialEmissiveLightmap, material->getTexCoordSet(graphics::MaterialKey::LIGHT_MAP));
                         }
                         break;
                     case graphics::Material::TEXCOORDTRANSFORM0:
@@ -1077,6 +1085,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                             schemaKey.setAlbedoMap(true);
                             schemaKey.setOpacityMaskMap(material->getKey().isOpacityMaskMap());
                             schemaKey.setTranslucentMap(material->getKey().isTranslucentMap());
+                            toonSchema.setTexCoordSet(gr::Texture::MaterialAlbedo, material->getTexCoordSet(graphics::MaterialKey::ALBEDO_MAP));
                         }
                         break;
                     case graphics::MaterialKey::NORMAL_MAP_BIT:
@@ -1098,6 +1107,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setNormalMap(true);
+                            toonSchema.setTexCoordSet(gr::Texture::MaterialNormal, material->getTexCoordSet(graphics::MaterialKey::NORMAL_MAP));
                         }
                         break;
                     case graphics::MaterialKey::EMISSIVE_MAP_BIT:
@@ -1120,6 +1130,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey.setEmissiveMap(true);
+                            toonSchema.setTexCoordSet(gr::Texture::MaterialEmissiveLightmap, material->getTexCoordSet(graphics::MaterialKey::EMISSIVE_MAP));
                         } else if (materialKey.isLightMap()) {
                             // We'll set this later when we check the lightmap
                             wasSet = true;
@@ -1198,6 +1209,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey._flags.set(NetworkMToonMaterial::MToonFlagBit::SHADE_MAP_BIT, true);
+                            toonSchema.setTexCoordSet(gr::Texture::MaterialShade, material->getTexCoordSet((graphics::Material::MapChannel) NetworkMToonMaterial::SHADE_MAP));
                         }
                         break;
                     case NetworkMToonMaterial::MToonFlagBit::SHADING_SHIFT_MAP_BIT:
@@ -1219,6 +1231,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey._flags.set(NetworkMToonMaterial::MToonFlagBit::SHADING_SHIFT_MAP_BIT, true);
+                            toonSchema.setTexCoordSet(gr::Texture::MaterialShadingShift, material->getTexCoordSet((graphics::Material::MapChannel) NetworkMToonMaterial::SHADING_SHIFT_MAP));
                         }
                         break;
                     case NetworkMToonMaterial::MToonFlagBit::MATCAP_MAP_BIT:
@@ -1240,6 +1253,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey._flags.set(NetworkMToonMaterial::MToonFlagBit::MATCAP_MAP_BIT, true);
+                            toonSchema.setTexCoordSet(gr::Texture::MaterialMatcap, material->getTexCoordSet((graphics::Material::MapChannel) NetworkMToonMaterial::MATCAP_MAP));
                         }
                         break;
                     case NetworkMToonMaterial::MToonFlagBit::RIM_MAP_BIT:
@@ -1261,6 +1275,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey._flags.set(NetworkMToonMaterial::MToonFlagBit::RIM_MAP_BIT, true);
+                            toonSchema.setTexCoordSet(gr::Texture::MaterialRim, material->getTexCoordSet((graphics::Material::MapChannel) NetworkMToonMaterial::RIM_MAP));
                         }
                         break;
                     case NetworkMToonMaterial::MToonFlagBit::UV_ANIMATION_MASK_MAP_BIT:
@@ -1282,6 +1297,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                                 forceDefault = true;
                             }
                             schemaKey._flags.set(NetworkMToonMaterial::MToonFlagBit::UV_ANIMATION_MASK_MAP_BIT, true);
+                            toonSchema.setTexCoordSet(gr::Texture::MaterialUVAnimationMask, material->getTexCoordSet((graphics::Material::MapChannel) NetworkMToonMaterial::UV_ANIMATION_MASK_MAP));
                         }
                         break;
                     case NetworkMToonMaterial::MToonFlagBit::MATCAP_VAL_BIT:

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -108,8 +108,7 @@
 
 layout(location=RENDER_UTILS_ATTR_POSITION_WS) in vec4 _positionWS;
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
-#define _texCoord0 _texCoord01.xy
-#define _texCoord1 _texCoord01.zw
+#define _texCoords mat2(_texCoord01.xy, _texCoord01.zw)
 <@if not HIFI_USE_SHADOW@>
     layout(location=RENDER_UTILS_ATTR_POSITION_ES) in vec4 _positionES;
     layout(location=RENDER_UTILS_ATTR_NORMAL_WS) in vec3 _normalWS;
@@ -144,16 +143,16 @@ void main(void) {
 <@if HIFI_USE_SHADOW or HIFI_USE_UNLIT@>
     <@if not HIFI_USE_TRIPLANAR@>
         <@if not HIFI_USE_MTOON@>
-            <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
+            <$fetchMaterialTextures(matKey, _texCoords, albedoTex)$>
         <@else@>
-            <$fetchMToonMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
+            <$fetchMToonMaterialTextures(matKey, _texCoords, albedoTex)$>
         <@endif@>
     <@else@>
         const vec3 triplanarScale = triplanarParams.scale.xyz;
         <@if not HIFI_USE_MTOON@>
-            <$fetchMaterialTexturesCoord0Triplanar(matKey, _positionMS, triplanarScale, albedoTex)$>
+            <$fetchMaterialTexturesTriplanar(matKey, _positionMS, _texCoord01.zw, triplanarScale, albedoTex)$>
         <@else@>
-            <$fetchMToonMaterialTexturesCoord0Triplanar(matKey, _positionMS, triplanarScale, albedoTex)$>
+            <$fetchMToonMaterialTexturesTriplanar(matKey, _positionMS, _texCoord01.zw, triplanarScale, albedoTex)$>
         <@endif@>
     <@endif@>
 
@@ -211,9 +210,9 @@ void main(void) {
         vec3 uvScrollSpeed = getMaterialUVScrollSpeed(mat);
         float time = getMaterialTime(mat);
     <@if HIFI_USE_NORMALMAP@>
-        <$fetchMToonMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, normalTex, shadeTex, emissiveTex, shadingShiftTex, rimTex, uvScrollSpeed, time)$>
+        <$fetchMToonMaterialTextures(matKey, _texCoords, albedoTex, normalTex, shadeTex, emissiveTex, shadingShiftTex, rimTex, uvScrollSpeed, time)$>
     <@else@>
-        <$fetchMToonMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, _SCRIBE_NULL, shadeTex, emissiveTex, shadingShiftTex, rimTex, uvScrollSpeed, time)$>
+        <$fetchMToonMaterialTextures(matKey, _texCoords, albedoTex, _SCRIBE_NULL, shadeTex, emissiveTex, shadingShiftTex, rimTex, uvScrollSpeed, time)$>
     <@endif@>
 
         float cutoff = getMaterialOpacityCutoff(mat);
@@ -289,43 +288,39 @@ void main(void) {
     <@if not HIFI_USE_TRIPLANAR@>
         <@if not HIFI_USE_LIGHTMAP@>
             <@if HIFI_USE_NORMALMAP and HIFI_USE_TRANSLUCENT@>
-                <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, _SCRIBE_NULL)$>
+                <$fetchMaterialTextures(matKey, _texCoords, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, _SCRIBE_NULL, occlusionTex)$>
             <@elif HIFI_USE_NORMALMAP@>
-                <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, scatteringTex)$>
+                <$fetchMaterialTextures(matKey, _texCoords, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, scatteringTex, occlusionTex)$>
             <@elif HIFI_USE_TRANSLUCENT@>
-                <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, _SCRIBE_NULL)$>
+                <$fetchMaterialTextures(matKey, _texCoords, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, _SCRIBE_NULL, occlusionTex)$>
             <@else@>
-                <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, scatteringTex)$>
+                <$fetchMaterialTextures(matKey, _texCoords, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, scatteringTex, occlusionTex)$>
             <@endif@>
-                <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
         <@else@>
             <@if HIFI_USE_NORMALMAP@>
-                <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex)$>
+                <$fetchMaterialTextures(matKey, _texCoords, albedoTex, roughnessTex, normalTex, metallicTex, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, lightmap)$>
             <@else@>
-                <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex)$>
+                <$fetchMaterialTextures(matKey, _texCoords, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, lightmap)$>
             <@endif@>
-                <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmap)$>
         <@endif@>
     <@else@>
         const vec3 triplanarScale = triplanarParams.scale.xyz;
         <@if not HIFI_USE_LIGHTMAP@>
             <@if HIFI_USE_NORMALMAP and HIFI_USE_TRANSLUCENT@>
-                <$fetchMaterialTexturesCoord0Triplanar(matKey, _positionMS, triplanarScale, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, _SCRIBE_NULL)$>
+                <$fetchMaterialTexturesTriplanar(matKey, _positionMS, _texCoord01.zw, triplanarScale, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, _SCRIBE_NULL, occlusionTex)$>
             <@elif HIFI_USE_NORMALMAP@>
-                <$fetchMaterialTexturesCoord0Triplanar(matKey, _positionMS, triplanarScale, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, scatteringTex)$>
+                <$fetchMaterialTexturesTriplanar(matKey, _positionMS, _texCoord01.zw, triplanarScale, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, scatteringTex, occlusionTex)$>
             <@elif HIFI_USE_TRANSLUCENT@>
-                <$fetchMaterialTexturesCoord0Triplanar(matKey, _positionMS, triplanarScale, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, _SCRIBE_NULL)$>
+                <$fetchMaterialTexturesTriplanar(matKey, _positionMS, _texCoord01.zw, triplanarScale, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, _SCRIBE_NULL, occlusionTex)$>
             <@else@>
-                <$fetchMaterialTexturesCoord0Triplanar(matKey, _positionMS, triplanarScale, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, scatteringTex)$>
+                <$fetchMaterialTexturesTriplanar(matKey, _positionMS, _texCoord01.zw, triplanarScale, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, scatteringTex, occlusionTex)$>
             <@endif@>
-                <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
         <@else@>
             <@if HIFI_USE_NORMALMAP@>
-                <$fetchMaterialTexturesCoord0Triplanar(matKey, _positionMS, triplanarScale, albedoTex, roughnessTex, normalTex, metallicTex)$>
+                <$fetchMaterialTexturesTriplanar(matKey, _positionMS, _texCoord01.zw, triplanarScale, albedoTex, roughnessTex, normalTex, metallicTex, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, lightmap)$>
             <@else@>
-                <$fetchMaterialTexturesCoord0Triplanar(matKey, _positionMS, triplanarScale, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex)$>
+                <$fetchMaterialTexturesTriplanar(matKey, _positionMS, _texCoord01.zw, triplanarScale, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, lightmap)$>
             <@endif@>
-                <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmap)$>
         <@endif@>
     <@endif@>
     

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -102,7 +102,7 @@ void main(void) {
         if ((matKey & OPACITY_MASK_MAP_BIT) != 0) {
             TexMapArray texMapArray = getTexMapArray();
             <$evalTexMapArrayTexcoord0(texMapArray, inTexCoord0, _positionWS, _texCoord01.xy)$>
-            _texCoord01.zw = vec2(0.0);
+            <$evalTexMapArrayTexcoord1(texMapArray, inTexCoord1, _positionWS, _texCoord01.zw)$>
         } else {
             _texCoord01 = vec4(0.0);
         }

--- a/libraries/render-utils/src/simple_procedural.slv
+++ b/libraries/render-utils/src/simple_procedural.slv
@@ -52,6 +52,7 @@ void main(void) {
     vec3 tangentMS = inTangent.xyz;
     vec4 color = color_sRGBAToLinear(inColor);
     vec2 texCoord0 = inTexCoord0.st;
+    vec2 texCoord1 = inTexCoord1.st;
 
 <@if HIFI_USE_DEFORMED or HIFI_USE_DEFORMEDDQ@>
         evalMeshDeformer(inPosition, positionMS, inNormal.xyz, normalMS, inTangent.xyz, tangentMS,
@@ -68,7 +69,8 @@ void main(void) {
         tangentMS,
         inTangent.xyz,
         color,
-        texCoord0
+        texCoord0,
+        texCoord1
     );
 
     getProceduralVertex(proceduralData);
@@ -77,12 +79,13 @@ void main(void) {
     normalMS = proceduralData.normal;
     color = proceduralData.color;
     texCoord0 = proceduralData.texCoord0;
+    texCoord1 = proceduralData.texCoord1;
 #endif
 
     _positionMS = positionMS;
     _normalMS = normalMS;
     _color = color;
-    _texCoord01 = vec4(texCoord0, 0.0, 0.0);
+    _texCoord01 = vec4(texCoord0, texCoord1);
 
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();


### PR DESCRIPTION
closes #311 

building on #1393, you can now also supply "texCoord" in a material JSON per-texture, and the desired texCoords are also read from GLTF files.

note: we still only support 2 texCoords (0 and 1), but the code is written such that it will be simple to eventually expand to 4

this may break existing models that use texCoord 1 for occlusion and lightmaps if they aren't also correctly specifying texCoord 1.  needs some testing to be sure.