### PR TITLE
[IPv6] New features

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -2031,8 +2031,8 @@ void DomainServer::processNodeJSONStatsPacket(QSharedPointer<ReceivedMessage> pa
 QJsonObject DomainServer::jsonForSocket(const SockAddr& socket) {
     QJsonObject socketJSON;
 
-    // TODO(IPv6): IPv6 needs to be added here too
-    socketJSON["ip"] = !socket.getAddressIPv6().isNull() ? socket.getAddressIPv6().toString() : socket.getAddressIPv4().toString();
+    // TODO(IPv6): IPv6 needs to be added here too (done 24/03/2025)
+    socketJSON["ip"] = "v4 " + socket.getAddressIPv4().toString() + " v6 " + socket.getAddressIPv6().toString();
     socketJSON["port"] = socket.getPort();
 
     return socketJSON;

--- a/libraries/networking/src/udt/BasePacket.h
+++ b/libraries/networking/src/udt/BasePacket.h
@@ -54,7 +54,7 @@ public:
     
     // Returns the size of the packet, including the header AND the UDP/IP header
     // TODO(IPv6): Is UDP header size different for IPv6?
-    qint64 getWireSize() const { return getDataSize() + UDP_IPV4_HEADER_SIZE; }
+    qint64 getWireSize() const { return getDataSize() + UDP_MIN_HEADER_SIZE; }
     
     // Returns the size of the payload only
     qint64 getPayloadSize() const { return _payloadSize; }

--- a/libraries/networking/src/udt/Constants.h
+++ b/libraries/networking/src/udt/Constants.h
@@ -19,10 +19,10 @@
 namespace udt {
 
     // TODO(IPv6): Is UDP header size different for IPv6?
-    static const int UDP_IPV4_HEADER_SIZE = 28;
+    static const int UDP_MIN_HEADER_SIZE = 40;
     static const int MAX_PACKET_SIZE_WITH_UDP_HEADER = 1492;
     // TODO(IPv6): Is UDP header size different for IPv6?
-    static const int MAX_PACKET_SIZE = MAX_PACKET_SIZE_WITH_UDP_HEADER - UDP_IPV4_HEADER_SIZE;
+    static const int MAX_PACKET_SIZE = MAX_PACKET_SIZE_WITH_UDP_HEADER - UDP_MIN_HEADER_SIZE;
     static const int MAX_PACKETS_IN_FLIGHT = 25600;
     static const int CONNECTION_RECEIVE_BUFFER_SIZE_PACKETS = 8192;
     static const int CONNECTION_SEND_BUFFER_SIZE_PACKETS = 8192;


### PR DESCRIPTION
Addded start of IPv6 on interface. Changed the packet header size to 40 witch is default for v6 packet size.