### PR TITLE
restore default sampler

### DIFF
--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -162,7 +162,7 @@ public:
         glm::vec4 _borderColor{ 1.0f };
         uint32 _maxAnisotropy = 16;
 
-        uint8 _filter = FILTER_MIN_MAG_POINT;
+        uint8 _filter = FILTER_MIN_MAG_MIP_LINEAR;
         uint8 _comparisonFunc = ALWAYS;
 
         uint8 _wrapModeU = WRAP_REPEAT;


### PR DESCRIPTION
closes #1443 

this should restore the default sampler which was previously set up in `TextureCache::createTexture`