### PR TITLE
Use GitHub hosted Runners.

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -284,7 +284,7 @@ jobs:
       run: |
         # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
         for counter in {1..2}; do
-          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build --format=json > build.json
+          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${{matrix.qt_source}} -b missing -pr:b=default -of build --format=json > build.json
         done
 
     - name: Configure CMake

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -69,7 +69,6 @@ jobs:
           - os: ubuntu-20.04
             image: docker.io/overte/overte-server-build:0.1.6-ubuntu-20.04-amd64
             arch: amd64
-            conan_qt: True
             qt_source: source
             runner: ubuntu-latest
 
@@ -82,7 +81,7 @@ jobs:
           - os: ubuntu-22.04
             image: docker.io/overte/overte-server-build:0.1.6-ubuntu-22.04-aarch64
             arch: aarch64
-            conan_qt: False
+            qt_source: system
             runner: ubuntu-24.04-arm
 
           - os: ubuntu-24.04

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -34,113 +34,108 @@ jobs:
             image: docker.io/overte/overte-server-build:0.1.6-debian-11-amd64
             arch: amd64
             qt_source: system
-            # https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners/wiki/Meta-Labels
-            # self_hosted makes the Hetzner auto-scaler put up the job.
-            # type-cx52 is a Hetzner VPS server type. In this case cs52 is a server with 16-cores and 32GB of RAM.
-            # image-x86-app-docker-ce is a Hetzner image.
-            # https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners/wiki/Specifying-The-Runner-Image
-            runner: [self_hosted, type-cpx41, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
           - os: debian-11
             image: docker.io/overte/overte-server-build:0.1.6-debian-11-aarch64
             arch: aarch64
             qt_source: system
-            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+            runner: ubuntu-24.04-arm
 
           - os: debian-12
             image: docker.io/overte/overte-server-build:0.1.6-debian-12-amd64
             arch: amd64
             qt_source: system
-            runner: [self_hosted, type-cpx41, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
           - os: debian-12
             image: docker.io/overte/overte-server-build:0.1.6-debian-12-aarch64
             arch: aarch64
             qt_source: system
-            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+            runner: ubuntu-24.04-arm
 
           - os: debian-13
             image: docker.io/overte/overte-server-build:0.1.6-debian-13-amd64
             arch: amd64
             qt_source: system
-            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
           - os: debian-13
             image: docker.io/overte/overte-server-build:0.1.6-debian-13-aarch64
             arch: aarch64
             qt_source: system
-            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+            runner: ubuntu-24.04-arm
 
           - os: ubuntu-20.04
             image: docker.io/overte/overte-server-build:0.1.6-ubuntu-20.04-amd64
             arch: amd64
             conan_qt: True
             qt_source: source
-            runner: [self_hosted, type-cpx41, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
           - os: ubuntu-22.04
             image: docker.io/overte/overte-server-build:0.1.6-ubuntu-22.04-amd64
             arch: amd64
             qt_source: system
-            runner: [self_hosted, type-cpx41, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
           - os: ubuntu-22.04
             image: docker.io/overte/overte-server-build:0.1.6-ubuntu-22.04-aarch64
             arch: aarch64
             conan_qt: False
-            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+            runner: ubuntu-24.04-arm
 
           - os: ubuntu-24.04
             image: docker.io/overte/overte-server-build:0.1.6-ubuntu-24.04-amd64
             arch: amd64
             qt_source: system
-            runner: [self_hosted, type-cpx41, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
           - os: ubuntu-24.04
             image: docker.io/overte/overte-server-build:0.1.6-ubuntu-24.04-aarch64
             arch: aarch64
             qt_source: system
-            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+            runner: ubuntu-24.04-arm
 
           - os: fedora-40
             image: docker.io/overte/overte-server-build:0.1.6-fedora-40-amd64
             arch: amd64
             qt_source: system
-            runner: [self_hosted, type-cpx41, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
           - os: fedora-40
             image: docker.io/overte/overte-server-build:0.1.6-fedora-40-aarch64
             arch: aarch64
             qt_source: system
-            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+            runner: ubuntu-24.04-arm
 
           - os: fedora-41
             image: docker.io/overte/overte-server-build:0.1.6-fedora-41-amd64
             arch: amd64
             qt_source: system
-            runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
           - os: fedora-41
             image: docker.io/overte/overte-server-build:0.1.6-fedora-41-aarch64
             arch: aarch64
             qt_source: system
-            runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+            runner: ubuntu-24.04-arm
 
           #~ - os: fedora-42
             #~ image: docker.io/overte/overte-server-build:0.1.6-fedora-42-amd64
             #~ arch: amd64
-            #~ runner: [self_hosted, type-cx52, image-x86-app-docker-ce]
+            #~ runner: ubuntu-latest
 
           #~ - os: fedora-42
             #~ image: docker.io/overte/overte-server-build:0.1.6-fedora-42-aarch64
             #~ arch: aarch64
-            #~ runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+            #~ runner: ubuntu-24.04-arm
 
           - os: rockylinux-9
             image: docker.io/overte/overte-server-build:0.1.6-rockylinux-9-amd64
             arch: amd64
             qt_source: source
-            runner: [self_hosted, type-cpx41, image-x86-app-docker-ce]
+            runner: ubuntu-latest
 
       fail-fast: false
 

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -71,7 +71,6 @@ jobs:
         echo "{github_sha_short}={`echo $GIT_COMMIT | cut -c1-7`}" >> $GITHUB_OUTPUT
         echo "JOB_NAME=build (${{matrix.os}}, ${{matrix.build_type}})" >> $GITHUB_ENV
         echo "APP_TARGET_NAME=$APP_NAME" >> $GITHUB_ENV
-        echo "qt_source=${{matrix.qt_source}}" >> $GITHUB_ENV
         # Linux build variables
         if [[ "${{ matrix.os }}" = "ubuntu-"* ]]; then
           echo "CONAN_CPPSTD=gnu17" >> $GITHUB_ENV
@@ -196,7 +195,7 @@ jobs:
     - name: Install Conan dependencies
       shell: bash
       run: |
-        conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build
+        conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${{matrix.qt_source}} -b missing -pr:b=default -of build
 
     - name: Cleanup Conan dependencies
       run: conan cache clean "*" -sbd

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -88,7 +88,6 @@ jobs:
         echo "GIT_COMMIT_SHORT=`echo $GIT_COMMIT | cut -c1-7`" >> $GITHUB_ENV
         echo "JOB_NAME=${{matrix.os}}, ${{matrix.build_type}}" >> $GITHUB_ENV
         echo "APP_TARGET_NAME=$APP_NAME" >> $GITHUB_ENV
-        echo "qt_source=${{matrix.qt_source}}" >> $GITHUB_ENV
 
         # Linux build variables
         if [[ "${{ matrix.os }}" = "Ubuntu"* ]]; then
@@ -228,7 +227,7 @@ jobs:
       run: |
         # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
         for counter in {1..2}; do
-          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build
+          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${{matrix.qt_source}} -b missing -pr:b=default -of build
         done
 
     - name: Cleanup Conan dependencies

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -98,10 +98,6 @@ jobs:
           echo "CMAKE_BUILD_EXTRA=$CMAKE_BUILD_EXTRA -- -j$(nproc)" >> $GITHUB_ENV
           # Don't optimize builds to save build time.
           echo "OVERTE_OPTIMIZE=false" >> $GITHUB_ENV
-          # Starting with Ubuntu 22.04 we can use system Qt
-          if [[ "${{ matrix.image }}" = *"ubuntu-22.04"* ]]; then
-            echo "OVERTE_USE_SYSTEM_QT=true" >> $GITHUB_ENV
-          fi
 
           if [[ "${{ matrix.arch }}" = "aarch64" ]]; then
             if [ "${{ matrix.build_type }}" = "full" ]; then
@@ -165,14 +161,6 @@ jobs:
           echo "INSTALLER=Overte-Interface-$RELEASE_NUMBER-${GIT_COMMIT_SHORT}.$INSTALLER_EXT" >> $GITHUB_ENV
         fi
 
-    - name: Clear Working Directories
-      if: contains(matrix.runner, 'linux_aarch64') || contains(matrix.runner, 'linux_amd64')
-      shell: bash
-      run: |
-        rm -rf ./*
-        rm -rf ~/overte-files
-        rm -rf ~/.cache
-
     - uses: actions/checkout@v4
       with:
         submodules: false
@@ -196,16 +184,6 @@ jobs:
 
           echo "Installing apt packages"
           sudo apt install -y ${{ matrix.apt-dependencies }} || exit 1
-
-          echo "Adding Toolchain test PPA"
-          apt install -y software-properties-common
-          add-apt-repository ppa:ubuntu-toolchain-r/test
-
-          echo "Installing gcc-13"
-          apt install -y gcc-13 g++-13 || exit 1
-
-          # Set GCC 13 as default
-          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13 --slave /usr/bin/gcov gcov /usr/bin/gcov-13
 
         else # macOS
           echo "Downloading MacOSX10.12 SDK.."
@@ -367,11 +345,3 @@ jobs:
         name: ${{ env.ARTIFACT_PATTERN }}
         path: ./build/${{ env.ARTIFACT_PATTERN }}
         if-no-files-found: error
-
-    - name: Clear Working Directories
-      if: contains(matrix.runner, 'linux_aarch64') || contains(matrix.runner, 'linux_amd64')
-      shell: bash
-      run: |
-        rm -rf ./*
-        rm -rf ~/overte-files
-        rm -rf ~/.cache

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -57,29 +57,24 @@ jobs:
             #  build_type: full
             #  qt_source: aqt
             - os: Ubuntu 22.04
-              # https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners/wiki/Meta-Labels
-              # self_hosted makes the Hetzner auto-scaler put up the job.
-              # type-cx52 is a Hetzner VPS server type. In this case cs52 is a server with 16-cores and 32GB of RAM.
-              # image-x86-app-docker-ce is a Hetzner image.
-              # https://github.com/testflows/TestFlows-GitHub-Hetzner-Runners/wiki/Specifying-The-Runner-Image
-              runner: [self_hosted, type-cpx41, image-x86-app-docker-ce]
+              image: docker.io/overte/overte-full-build:0.1.6-ubuntu-22.04-amd64
+              runner: ubuntu-latest
               arch: amd64
               build_type: full
               qt_source: system
               apt-dependencies: libxcb-glx0-dev # add missing dependencies to docker image when convenient
-              image: docker.io/overte/overte-full-build:0.1.6-ubuntu-22.04-amd64
             # Android builds are currently failing
             #- os: ubuntu-18.04
             #  build_type: android
             #  apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 python3-github python3-distro
             # Do not change the names of self-hosted runners without knowing what you are doing, as they correspond to labels that have to be set on the runner.
             - os: Ubuntu 22.04
-              runner: [self_hosted, type-cax41, image-arm-app-docker-ce]
+              image: docker.io/overte/overte-full-build:0.1.6-ubuntu-22.04-aarch64
+              runner: ubuntu-24.04-arm
               arch: aarch64
               build_type: full
               qt_source: system
               apt-dependencies: libxcb-glx0-dev # add missing dependencies to docker image when convenient
-              image: docker.io/overte/overte-full-build:0.1.6-ubuntu-22.04-aarch64
         fail-fast: false
     runs-on: ${{matrix.runner}}
     container: ${{matrix.image}}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -115,7 +115,7 @@ jobs:
       run: |
         # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
         for counter in {1..2}; do
-          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build --format=json > build.json
+          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${{matrix.qt_source}} -b missing -pr:b=default -of build --format=json > build.json
         done
 
     - name: Upload Conan dependencies


### PR DESCRIPTION
Apparently, on Conan, our disk space usage went down quite a lot, to the point where we can use the free Runners hosted by GitHub again. (Thought this might be because of how we provide custom images, instead of using GitHub's Runner images.)
It's not exactly a huge monetary saving (10-20€ per month), but it saves me maintenance work and is more reliable that hosting our own GitHub Actions runners.

The Windows CI failing is expected; It is fixed in https://github.com/overte-org/overte/pull/1476