### PR TITLE
Replace Google WebRTC with PulseAudio's webrtc-audio-processing.

### DIFF
--- a/cmake/macros/TargetWebRTC.cmake
+++ b/cmake/macros/TargetWebRTC.cmake
@@ -1,23 +1,11 @@
 #
 #  Copyright 2019 High Fidelity, Inc.
+#  Copyright 2025 Overte e.V.
 #
 #  Distributed under the Apache License, Version 2.0.
 #  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 #
 macro(TARGET_WEBRTC)
-    if (ANDROID)
-        # I don't yet have working libwebrtc for android
-        # include(SelectLibraryConfigurations)
-        # set(INSTALL_DIR ${HIFI_ANDROID_PRECOMPILED}/webrtc/webrtc)
-        # set(WEBRTC_INCLUDE_DIRS "${INSTALL_DIR}/include/webrtc")
-        # set(WEBRTC_LIBRARY_DEBUG ${INSTALL_DIR}/debug/lib/libwebrtc.a)
-        # set(WEBRTC_LIBRARY_RELEASE ${INSTALL_DIR}/lib/libwebrtc.a)
-        # select_library_configurations(WEBRTC)
-    elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-        # WebRTC is basically impossible to build on aarch64 Linux.
-        # I am looking at https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing for an alternative.
-    else()
-        find_package(WebRTC REQUIRED)
-        target_link_libraries(${TARGET_NAME} WebRTC::WebRTC)
-    endif()
+    find_package(webrtc-audio-processing REQUIRED)
+    target_link_libraries(${TARGET_NAME} webrtc-audio-processing::webrtc-audio-processing)
 endmacro()

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,11 +9,9 @@ class Overte(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "qt_source": ["system", "aqt", "source"],
-        "with_webrtc": [True, False],
     }
     default_options = {
         "qt_source": "system",
-        "with_webrtc": True,
         "sdl*:alsa": "False",
         "sdl*:pulse": "False",
         "sdl*:wayland": "False",
@@ -76,6 +74,7 @@ class Overte(ConanFile):
         self.requires("steamworks/158a@overte/prebuild")
         self.requires("v-hacd/4.1.0")
         self.requires("vulkan-memory-allocator/3.0.1")
+        self.requires("webrtc-audio-processing/2.1@overte/stable")
         self.requires("zlib/1.2.13")
         self.requires("glm/0.9.9.5", force=True)
         self.requires("jsoncpp/1.9.6", force=True)
@@ -97,14 +96,10 @@ class Overte(ConanFile):
             self.requires("ovr-skd/1.35.0@overte/prebuild")
             self.requires("ovr-platform-skd/1.10.0@overte/prebuild")
 
-        if self.options.with_webrtc:
-            self.requires("webrtc-prebuild/2021.01.05@overte/stable", force=True)
-
         self.requires(openssl, force=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["DISABLE_WEBRTC"] = "OFF" if self.options.with_webrtc else "ON"
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -5,7 +5,7 @@
 //  Created by Stephen Birarda on 1/22/13.
 //  Copyright 2013 High Fidelity, Inc.
 //  Copyright 2021 Vircadia contributors.
-//  Copyright 2023 Overte e.V.
+//  Copyright 2023-2025 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -1194,18 +1194,12 @@ void AudioClient::configureWebrtc() {
     config.high_pass_filter.enabled = false;
     config.echo_canceller.enabled = true;
     config.echo_canceller.mobile_mode = false;
-#if defined(WEBRTC_LEGACY)
-    config.echo_canceller.use_legacy_aec = false;
-#endif
     config.noise_suppression.enabled = false;
     config.noise_suppression.level = webrtc::AudioProcessing::Config::NoiseSuppression::kModerate;
-    config.voice_detection.enabled = false;
     config.gain_controller1.enabled = false;
     config.gain_controller2.enabled = false;
     config.gain_controller2.fixed_digital.gain_db = 0.0f;
     config.gain_controller2.adaptive_digital.enabled = false;
-    config.residual_echo_detector.enabled = true;
-    config.level_estimation.enabled = false;
 
     _apm->ApplyConfig(config);
 }

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -5,6 +5,7 @@
 //  Created by Stephen Birarda on 1/22/13.
 //  Copyright 2013 High Fidelity, Inc.
 //  Copyright 2021 Vircadia contributors.
+//  Copyright 2025 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -60,8 +61,7 @@
 
 #if defined(WEBRTC_AUDIO)
 #  define WEBRTC_APM_DEBUG_DUMP 0
-#  include <modules/audio_processing/include/audio_processing.h>
-#  include "modules/audio_processing/audio_processing_impl.h"
+#  include <api/audio/audio_processing.h>
 #endif
 
 #ifdef _WIN32
@@ -463,7 +463,7 @@ private:
     static const int WEBRTC_CHANNELS_MAX = 2;
     static const int WEBRTC_FRAMES_MAX = webrtc::AudioProcessing::kChunkSizeMs * WEBRTC_SAMPLE_RATE_MAX / 1000;
 
-    webrtc::AudioProcessing* _apm { nullptr };
+    webrtc::scoped_refptr<webrtc::AudioProcessing> _apm { nullptr };
 
     int16_t _fifoFarEnd[WEBRTC_CHANNELS_MAX * WEBRTC_FRAMES_MAX] {};
     int _numFifoFarEnd = 0; // numFrames saved in fifo

--- a/libraries/shared/src/shared/WebRTC.h
+++ b/libraries/shared/src/shared/WebRTC.h
@@ -23,34 +23,24 @@
 
 #if defined(Q_OS_MAC)
 #  define WEBRTC_AUDIO 1
-#  define WEBRTC_POSIX 1
-#  define WEBRTC_LEGACY 1
 #elif defined(Q_OS_WIN)
-// Our WebRTC binary package seem to be broken on newer Windows SDKs.
-// #  define WEBRTC_AUDIO 1
+#  define WEBRTC_AUDIO 1
+// We use PulseAudio's webrtc-audio-processing, which doesn't include Data Channels.
+// Data Channels were only used for Vircadia's web client.
+// We should replace Google WebRTC with libdatachannel if we ever resurrect it.
 // #  define WEBRTC_DATA_CHANNELS 1
-// #  define WEBRTC_WIN 1
-// #  define NOMINMAX 1
-// #ifndef WIN32_LEAN_AND_MEAN
-// #  define WIN32_LEAN_AND_MEAN 1
-// #endif
+#  define WEBRTC_WIN 1
+#  define NOMINMAX 1  // Windows.h
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN 1
+#  endif
 #elif defined(Q_OS_ANDROID)
-// I don't yet have a working libwebrtc for android
-// #  define WEBRTC_AUDIO 1
-// #  define WEBRTC_POSIX 1
-// #  define WEBRTC_LEGACY 1
-#elif defined(Q_OS_LINUX) && defined(Q_PROCESSOR_X86_64)
+#  define WEBRTC_AUDIO 1
+#elif defined(Q_OS_LINUX)
 #  ifndef DISABLE_WEBRTC
 #    define WEBRTC_AUDIO 1
-#    define WEBRTC_POSIX 1
-#    define WEBRTC_DATA_CHANNELS 1
+// #  define WEBRTC_DATA_CHANNELS 1
 #  endif
-#elif defined(Q_OS_LINUX) && defined(Q_PROCESSOR_ARM)
-// WebRTC is basically impossible to build on aarch64 Linux.
-// I am looking at https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing for an alternative.
-// #  define WEBRTC_AUDIO 1
-// #  define WEBRTC_POSIX 1
-// #  define WEBRTC_LEGACY 1
 #endif
 
 #endif // hifi_WebRTC_h

--- a/tools/conan-profiles/vs-19-debug
+++ b/tools/conan-profiles/vs-19-debug
@@ -6,5 +6,7 @@ compiler.version=192
 compiler.runtime=dynamic
 compiler.runtime_type=Debug
 build_type=Debug
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [options]
 Overte/*:qt_source=aqt

--- a/tools/conan-profiles/vs-19-debug-ninja
+++ b/tools/conan-profiles/vs-19-debug-ninja
@@ -6,6 +6,8 @@ compiler.version=192
 compiler.runtime=dynamic
 compiler.runtime_type=Debug
 build_type=Debug
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 [options]

--- a/tools/conan-profiles/vs-19-release
+++ b/tools/conan-profiles/vs-19-release
@@ -6,5 +6,7 @@ compiler.version=192
 compiler.runtime=dynamic
 compiler.runtime_type=Release
 build_type=Release
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [options]
 Overte/*:qt_source=aqt

--- a/tools/conan-profiles/vs-19-release-ninja
+++ b/tools/conan-profiles/vs-19-release-ninja
@@ -6,6 +6,8 @@ compiler.version=192
 compiler.runtime=dynamic
 compiler.runtime_type=Release
 build_type=Release
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 [options]

--- a/tools/conan-profiles/vs-19-relwithdebinfo
+++ b/tools/conan-profiles/vs-19-relwithdebinfo
@@ -6,5 +6,7 @@ arch_build=x86_64
 compiler=Visual Studio
 compiler.version=16
 build_type=RelWithDebInfo
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [options]
 Overte/*:qt_source=aqt

--- a/tools/conan-profiles/vs-22-debug
+++ b/tools/conan-profiles/vs-22-debug
@@ -6,5 +6,7 @@ compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=Debug
 build_type=Debug
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [options]
 Overte/*:qt_source=aqt

--- a/tools/conan-profiles/vs-22-debug-ninja
+++ b/tools/conan-profiles/vs-22-debug-ninja
@@ -6,6 +6,8 @@ compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=Debug
 build_type=Debug
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 [options]

--- a/tools/conan-profiles/vs-22-release
+++ b/tools/conan-profiles/vs-22-release
@@ -6,5 +6,7 @@ compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=Release
 build_type=Release
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [options]
 Overte/*:qt_source=aqt

--- a/tools/conan-profiles/vs-22-release-ninja
+++ b/tools/conan-profiles/vs-22-release-ninja
@@ -6,6 +6,8 @@ compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=Release
 build_type=Release
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
 [options]

--- a/tools/conan-profiles/vs-22-relwithdebinfo
+++ b/tools/conan-profiles/vs-22-relwithdebinfo
@@ -6,5 +6,7 @@ compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=RelWithDebInfo
 build_type=RelWithDebInfo
+# Build fails on Windows with C++17
+webrtc-audio-processing*:compiler.cppstd=20
 [options]
 Overte/*:qt_source=aqt


### PR DESCRIPTION
This breaks Data Channels, which are unused as far as I know.