### PR TITLE
Support launching Sandbox server on other platforms

### DIFF
--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -1125,9 +1125,7 @@ void watchParentProcess(int parentPID) {
     auto timer = new QTimer(qApp);
     timer->setInterval(MSECS_PER_SECOND);
     QObject::connect(timer, &QTimer::timeout, qApp, [parentPID]() {
-        auto ppid = getppid();
-        if (parentPID != ppid) {
-            // If the PPID changed, then that means our parent process died.
+        if (!processIsRunning(parentPID)) {
             quitWithParentProcess();
         }
     });


### PR DESCRIPTION
`--runServer` now works on Linux! If the `domain-server` and `assignment-client` binaries are available, they can run while Interface is running, and will quit when Interface quits.

The behavior on Windows remains the same, launching the `server-console.exe` binary.

Note that the `--listenPort` flag isn't hooked up on any platform, and `--serverContentPath` isn't used, as it was handled by `server-console` by just copying files into the user's domain server directory. Maybe a future project to add flags for base paths to `domain-server` and `assignment-client`?