### PR TITLE
Conan: Updates to GitHub Actions

### DIFF
--- a/.github/actions/conan-install/action.yml
+++ b/.github/actions/conan-install/action.yml
@@ -1,0 +1,27 @@
+name: "Install Conan dependencies"
+description: "Runs `conan install` for building Overte."
+inputs:
+   qt_source:
+     required: false
+     description: "Where to get Qt from. See our conanfile.py for the available options."
+   cppstd:
+     required: false
+     description: "Which C++ standard to use."
+   build_type:
+     required: false
+     description: "Which CMake build type to use. E.g. Release, RelWithDebInfo, Debug"
+     default: Release
+   conan_profile:
+     required: false
+     description: "Which Conan profile to use. E.g. './tools/conan-profiles/vs-22-release'. Uses Conan's default if not defined, which may or may not work."
+     default: default
+runs:
+  using: "composite"
+  steps:
+  - name: Install Conan dependencies
+    shell: bash
+    run: |
+      # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
+      for counter in {1..2}; do
+        conan install . -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o '&:qt_source='${{ inputs.qt_source }} -b missing -pr=${{ inputs.conan_profile }} -of build --format=json > build.json
+      done

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -1,0 +1,33 @@
+name: "Prepare Conan Build Environment"
+description: "Configures Conan for building Overte. It also sets up a backup source repository, which requires env CONAN_BUILD_DEPENDENCIES_BACKUP_UPLOAD_TOKEN to be set for uploading backups."
+runs:
+  using: "composite"
+  steps:
+  - name: "Prepare Conan Build Environment"
+    shell: bash
+    run: |
+      conan profile detect -e
+      conan remote add overte https://artifactory.overte.org/artifactory/api/conan/overte -f
+      # Use our mirror of Conan Center to avoid rate limiting.
+      conan remote update conancenter --url https://artifactory.overte.org/artifactory/api/conan/conan-center
+      echo "Starting with a clean Conan global.conf…" && rm ~/.conan2/global.conf
+      echo "tools.system.package_manager:mode = install" >> ~/.conan2/global.conf
+      # Try downloading source files from conandata.yml first. Fall back to our backup if the upstream source is down.
+      echo "core.sources:download_urls=['origin', 'https://artifactory.overte.org/artifactory/build-dependencies-backup/']" >> ~/.conan2/global.conf
+      echo "core.sources:upload_url=https://artifactory.overte.org/artifactory/build-dependencies-backup/" >> ~/.conan2/global.conf
+      # Credentials for uploading backsups of dependency sources.
+      # source-credentials.json is a jinja template, so os.getenv() happens at runtime.
+      cat > ~/.conan2/source-credentials.json <<EOF
+      {% set TOKEN = os.getenv('CONAN_BUILD_DEPENDENCIES_BACKUP_UPLOAD_TOKEN') %}
+      {
+        "credentials": [
+          {
+          "url": "https://artifactory.overte.org/artifactory/build-dependencies-backup/",
+          "token": "{{TOKEN}}"
+          }
+        ]
+      }
+      EOF
+      echo "Printing Conan global.conf…" && cat ~/.conan2/global.conf
+      echo "Printing Conan remotes.json…" && cat ~/.conan2/remotes.json
+      echo "Printing Conan source-credentials.json…" && cat ~/.conan2/source-credentials.json

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -170,7 +170,6 @@ jobs:
         echo "REFNAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
         echo "JOB_NAME=${{matrix.os}}, ${{matrix.arch}}" >> $GITHUB_ENV
-        echo "CONAN_QT=${{matrix.conan_qt}}" >> $GITHUB_ENV
         echo "CONAN_CPPSTD=gnu17" >> $GITHUB_ENV
 
         echo "CMAKE_BUILD_EXTRA=-- -j$(nproc)" >> $GITHUB_ENV
@@ -282,12 +281,11 @@ jobs:
       uses: ./.github/actions/setup-conan
 
     - name: Install Conan dependencies
-      shell: bash
-      run: |
-        # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
-        for counter in {1..2}; do
-          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build --format=json > build.json
-        done
+      uses: ./.github/actions/conan-install
+      with:
+        qt_source: ${{matrix.qt_source}}
+        build_type: ${{env.BUILD_TYPE}}
+        cppstd: ${{env.CONAN_CPPSTD}}
 
     - name: Upload dependency source backups
       shell: bash

--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -279,11 +279,7 @@ jobs:
         fetch-depth: 1
 
     - name: Prepare Conan Build Environment
-      shell: bash
-      run: |
-        conan profile detect -e
-        conan remote add overte https://artifactory.overte.org/artifactory/api/conan/overte -f
-        echo "tools.system.package_manager:mode = install" >> ~/.conan2/global.conf
+      uses: ./.github/actions/setup-conan
 
     - name: Install Conan dependencies
       shell: bash
@@ -292,6 +288,13 @@ jobs:
         for counter in {1..2}; do
           conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build --format=json > build.json
         done
+
+    - name: Upload dependency source backups
+      shell: bash
+      env:
+        # Token for uploading dependency source backups.
+        CONAN_BUILD_DEPENDENCIES_BACKUP_UPLOAD_TOKEN: ${{ secrets.CONAN_BUILD_DEPENDENCIES_BACKUP_UPLOAD_TOKEN }}
+      run: conan cache backup-upload || echo "Credentials cannot be accessed on remote Pull Request builds. Continuing…"
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -138,7 +138,7 @@ jobs:
       with:
         key: conan-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('conanfile.py') }}
         path: ~/.conan2/
-  
+
 
     - name: Install dependencies
       shell: bash
@@ -186,17 +186,19 @@ jobs:
       run: $PYTHON_EXEC -m pip install boto3 PyGithub conan
 
     - name: Prepare Conan Build Environment
-      shell: bash
-      run: |
-        conan profile detect -e
-        conan remote add overte https://artifactory.overte.org/artifactory/api/conan/overte -f
-        conan remote update conancenter --url https://artifactory.overte.org/artifactory/api/conan/conan-center
-        echo "tools.system.package_manager:mode = install" >> ~/.conan2/global.conf
+      uses: ./.github/actions/setup-conan
 
     - name: Install Conan dependencies
       shell: bash
       run: |
         conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build
+
+    - name: Upload dependency source backups
+      shell: bash
+      env:
+        # Token for uploading dependency source backups.
+        CONAN_BUILD_DEPENDENCIES_BACKUP_UPLOAD_TOKEN: ${{ secrets.CONAN_BUILD_DEPENDENCIES_BACKUP_UPLOAD_TOKEN }}
+      run: conan cache backup-upload
 
     - name: Cleanup Conan dependencies
       run: conan cache clean "*" -sbd

--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -71,7 +71,6 @@ jobs:
         echo "{github_sha_short}={`echo $GIT_COMMIT | cut -c1-7`}" >> $GITHUB_OUTPUT
         echo "JOB_NAME=build (${{matrix.os}}, ${{matrix.build_type}})" >> $GITHUB_ENV
         echo "APP_TARGET_NAME=$APP_NAME" >> $GITHUB_ENV
-        echo "qt_source=${{matrix.qt_source}}" >> $GITHUB_ENV
         # Linux build variables
         if [[ "${{ matrix.os }}" = "ubuntu-"* ]]; then
           echo "CONAN_CPPSTD=gnu17" >> $GITHUB_ENV
@@ -79,6 +78,7 @@ jobs:
           echo "INSTALLER_EXT=tgz" >> $GITHUB_ENV
           echo "CMAKE_BUILD_EXTRA=$CMAKE_BUILD_EXTRA -- -j$(nproc)" >> $GITHUB_ENV
           echo "CMAKE_EXTRA=-DOVERTE_CPU_ARCHITECTURE=-msse3 -DBUILD_TOOLS:BOOLEAN=FALSE -DHIFI_PYTHON_EXEC:FILEPATH=$(which python3)" >> $GITHUB_ENV
+          echo "CONAN_PROFILE=default" >> $GITHUB_ENV
         fi
         # Mac build variables
         if [ "${{ matrix.os }}" = "macOS-10.15" ]; then
@@ -89,6 +89,7 @@ jobs:
           echo "CMAKE_EXTRA=-DOVERTE_CPU_ARCHITECTURE= -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED=OFF -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib -G Xcode" >> $GITHUB_ENV
           echo "symbols_archive=${BUILD_NUMBER}-${{ matrix.build_type }}-mac-symbols.zip" >> $GITHUB_ENV
           echo "APP_TARGET_NAME=Overte" >> $GITHUB_ENV
+          echo "CONAN_PROFILE=default" >> $GITHUB_ENV
         fi
         # Windows build variables
         if [ "${{ matrix.os }}" = "windows-2019" ]; then
@@ -102,6 +103,11 @@ jobs:
           echo "symbols_archive=${BUILD_NUMBER}-${{ matrix.build_type }}-win-symbols.zip" >> $GITHUB_ENV
           # echo "HF_PFX_PASSPHRASE=${{secrets.pfx_key}}" >> $GITHUB_ENV
           # echo "HF_PFX_FILE=${{runner.workspace}}\build\codesign.pfx" >> $GITHUB_ENV
+          if [[ "${{ matrix.os }}" = "windows-2019" ]]; then
+            echo "CONAN_PROFILE='./tools/conan-profiles/vs-19-release'" >> $GITHUB_ENV
+          else
+            echo "Not sure which Conan profile to use. Exiting." && exit 1
+          fi
         fi
     # Configuration is broken into two steps because you can't set an env var and also reference it in the same step
     - name: Configure build environment 2
@@ -189,9 +195,12 @@ jobs:
       uses: ./.github/actions/setup-conan
 
     - name: Install Conan dependencies
-      shell: bash
-      run: |
-        conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build
+      uses: ./.github/actions/conan-install
+      with:
+        qt_source: ${{matrix.qt_source}}
+        build_type: ${{env.BUILD_TYPE}}
+        cppstd: ${{env.CONAN_CPPSTD}}
+        conan_profile: ${{env.CONAN_PROFILE}}
 
     - name: Upload dependency source backups
       shell: bash

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -93,7 +93,6 @@ jobs:
         echo "GIT_COMMIT_SHORT=`echo $GIT_COMMIT | cut -c1-7`" >> $GITHUB_ENV
         echo "JOB_NAME=${{matrix.os}}, ${{matrix.build_type}}" >> $GITHUB_ENV
         echo "APP_TARGET_NAME=$APP_NAME" >> $GITHUB_ENV
-        echo "qt_source=${{matrix.qt_source}}" >> $GITHUB_ENV
 
         # Linux build variables
         if [[ "${{ matrix.os }}" = "Ubuntu"* ]]; then
@@ -125,6 +124,7 @@ jobs:
             fi
           fi
         fi
+        echo "CONAN_PROFILE=default" >> $GITHUB_ENV
 
         # Mac build variables
         if [ "${{ matrix.os }}" = "macOS-10.15" ]; then
@@ -136,6 +136,7 @@ jobs:
             echo "CMAKE_EXTRA=-DOVERTE_CPU_ARCHITECTURE= -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -DCLIENT_ONLY=1 -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED=OFF -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib -G Xcode" >> $GITHUB_ENV
           fi
           echo "APP_TARGET_NAME=Overte" >> $GITHUB_ENV
+          echo "CONAN_PROFILE=default" >> $GITHUB_ENV
         fi
         # Windows build variables
         if [[ "${{ matrix.os }}" = "Windows"* ]]; then
@@ -146,6 +147,11 @@ jobs:
             echo "CMAKE_EXTRA=-A x64 -DJSDOC_ENABLED:BOOL=TRUE" >> $GITHUB_ENV
           else
             echo "CMAKE_EXTRA=-A x64 -DJSDOC_ENABLED:BOOL=TRUE -DCLIENT_ONLY=1" >> $GITHUB_ENV
+          fi
+          if [[ "${{ matrix.runner }}" = "windows-2019" ]]; then
+            echo "CONAN_PROFILE='./tools/conan-profiles/vs-19-release'" >> $GITHUB_ENV
+          else
+            echo "Not sure which Conan profile to use. Exiting." && exit 1
           fi
         fi
         # Android + Quest build variables
@@ -246,12 +252,12 @@ jobs:
       uses: ./.github/actions/setup-conan
 
     - name: Install Conan dependencies
-      shell: bash
-      run: |
-        # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
-        for counter in {1..2}; do
-          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build
-        done
+      uses: ./.github/actions/conan-install
+      with:
+        qt_source: ${{matrix.qt_source}}
+        build_type: ${{env.BUILD_TYPE}}
+        cppstd: ${{env.CONAN_CPPSTD}}
+        conan_profile: ${{env.CONAN_PROFILE}}
 
     - name: Upload dependency source backups
       shell: bash

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -189,7 +189,7 @@ jobs:
       with:
         key: conan-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('conanfile.py') }}
         path: ~/.conan2/
-  
+
     - name: Install dependencies
       shell: bash
       if: startsWith(matrix.os, 'Ubuntu') || contains(matrix.os, 'Debian') || startsWith(matrix.os, 'macOS')
@@ -243,12 +243,7 @@ jobs:
       run: $PYTHON_EXEC -m pip install boto3 PyGithub conan
 
     - name: Prepare Conan Build Environment
-      shell: bash
-      run: |
-        conan profile detect -e
-        conan remote add overte https://artifactory.overte.org/artifactory/api/conan/overte -f
-        conan remote update conancenter --url https://artifactory.overte.org/artifactory/api/conan/conan-center
-        echo "tools.system.package_manager:mode = install" >> ~/.conan2/global.conf
+      uses: ./.github/actions/setup-conan
 
     - name: Install Conan dependencies
       shell: bash
@@ -257,6 +252,13 @@ jobs:
         for counter in {1..2}; do
           conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build
         done
+
+    - name: Upload dependency source backups
+      shell: bash
+      env:
+        # Token for uploading dependency source backups.
+        CONAN_BUILD_DEPENDENCIES_BACKUP_UPLOAD_TOKEN: ${{ secrets.CONAN_BUILD_DEPENDENCIES_BACKUP_UPLOAD_TOKEN }}
+      run: conan cache backup-upload || echo "Credentials cannot be accessed on remote Pull Request builds. Continuing…"
 
     - name: Cleanup Conan dependencies
       run: conan cache clean "*" -sbd

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -103,12 +103,7 @@ jobs:
       run: $PYTHON_EXEC -m pip install boto3 PyGithub conan
 
     - name: Prepare Conan Build Environment
-      shell: bash
-      run: |
-        conan profile detect -e
-        conan remote add overte https://artifactory.overte.org/artifactory/api/conan/overte -f
-        conan remote update conancenter --url https://artifactory.overte.org/artifactory/api/conan/conan-center  # Use our mirror of Conan Center to avoid rate limiting.
-        echo "tools.system.package_manager:mode = install" >> ~/.conan2/global.conf
+      uses: ./.github/actions/setup-conan
 
     - name: Install Conan dependencies
       shell: bash

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -61,7 +61,6 @@ jobs:
 
         echo "JOB_NAME=${{matrix.os}}, ${{matrix.build_type}}" >> $GITHUB_ENV
         echo "APP_TARGET_NAME=$APP_NAME" >> $GITHUB_ENV
-        echo "CONAN_QT=${{matrix.conan_qt}}" >> $GITHUB_ENV
         echo "CONAN_CPPSTD=17" >> $GITHUB_ENV
 
         echo "PYTHON_EXEC=python" >> $GITHUB_ENV
@@ -73,6 +72,11 @@ jobs:
         echo "SYMBOLS_ARCHIVE=$RELEASE_NUMBER-${{ github.sha }}-win-symbols.zip" >> $GITHUB_ENV
         # echo "HF_PFX_PASSPHRASE=${{secrets.pfx_key}}" >> $GITHUB_ENV
         # echo "HF_PFX_FILE=${{runner.workspace}}\build\codesign.pfx" >> $GITHUB_ENV
+        if [[ "${{ matrix.os }}" = "windows-2019" ]]; then
+          echo "CONAN_PROFILE='./tools/conan-profiles/vs-19-release'" >> $GITHUB_ENV
+        else
+          echo "Not sure which Conan profile to use. Exiting." && exit 1
+        fi
 
     # Configuration is broken into two steps because you can't set an env var and also reference it in the same step
     - name: Configure build environment 2
@@ -106,12 +110,12 @@ jobs:
       uses: ./.github/actions/setup-conan
 
     - name: Install Conan dependencies
-      shell: bash
-      run: |
-        # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
-        for counter in {1..2}; do
-          conan install . -s compiler.cppstd=$CONAN_CPPSTD -s build_type=$BUILD_TYPE -o '&:qt_source='${qt_source} -b missing -pr:b=default -of build --format=json > build.json
-        done
+      uses: ./.github/actions/conan-install
+      with:
+        qt_source: ${{matrix.qt_source}}
+        build_type: ${{env.BUILD_TYPE}}
+        cppstd: ${{env.CONAN_CPPSTD}}
+        conan_profile: ${{env.CONAN_PROFILE}}
 
     - name: Upload Conan dependencies
       # Conan isn't glibc aware, so we need to be really careful what we upload to the binary cache on Linux.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -1,5 +1,10 @@
 set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
-set(CMAKE_CXX_STANDARD 14)
+if (WIN32)
+  # Building with webrtc-audio-processing on Windows fails on cppstd 14.
+  set(CMAKE_CXX_STANDARD 17)
+else ()
+  set(CMAKE_CXX_STANDARD 14)
+endif ()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (NOT "${CMAKE_SIZEOF_VOID_P}" EQUAL "8")


### PR DESCRIPTION
This PR enables automatically using and creating a backup of dependency sources. Meaning that if an upstream source (like `https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz`) goes down, Conan will get a backup of `nasm-2.15.05.tar.xz` from [artifactory.overte.org](https://artifactory.overte.org/).

I also started using GitHub Actions "Composite Actions" to deduplicate code, as our Actions have become quite the spaghetti over the years. Both me and Edgar were changing code in one workflow file, while leaving it unchanged in other workflow files accidentally.

This also starts using our Conan profiles on Windows, to fix the CI pipeline not being able to build webrtc-audio-processing introduced in https://github.com/overte-org/overte/pull/1454.