### PR TITLE
Stop testing your voice when closing the audio window

### DIFF
--- a/interface/resources/qml/hifi/audio/LoopbackAudio.qml
+++ b/interface/resources/qml/hifi/audio/LoopbackAudio.qml
@@ -4,6 +4,7 @@
 //
 //  Created by Seth Alves on 2019-2-18
 //  Copyright 2019 High Fidelity, Inc.
+//  Copyright 2025 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -66,5 +67,10 @@ RowLayout {
         color: "white";
         font.italic: true
         text: audioLoopedBack ? qsTr("Speak in your input") : "";
+    }
+
+    Component.onDestruction: {
+        loopbackTimer.stop();
+        stopAudioLoopback();
     }
 }


### PR DESCRIPTION
Fixes #316 

This will just stop the audio loop back when the component is destroyed. 
The component gets destroyed when closing the audio settings window. 
Therefore, the audio loop back is stopped when closing the window. 

Science!