### PR TITLE
Fix "QML AnimatedImage: Error Reading Animated Image File" warning.

### DIFF
--- a/scripts/system/assets/images/tools/progress-background.svg
+++ b/scripts/system/assets/images/tools/progress-background.svg
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" width="360" height="120" viewBox="0 0 360.00 120.00" enable-background="new 0 0 360.00 120.00" xml:space="preserve">
+	<path fill="#343434" fill-opacity="1" stroke-linejoin="round" d="M 10,7.62939e-006L 350,7.62939e-006C 355.523,7.62939e-006 360,4.47717 360,10L 360,110C 360,115.523 355.523,120 350,120L 10,120C 4.47716,120 7.66041e-006,115.523 7.66041e-006,110L 7.66041e-006,10C 7.66041e-006,4.47717 4.47716,7.62939e-006 10,7.62939e-006 Z "/>
+</svg>

--- a/scripts/system/libraries/progressDialog.js
+++ b/scripts/system/libraries/progressDialog.js
@@ -8,7 +8,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-var toolIconUrl = Script.getExternalPath(Script.ExternalPaths.HF_Public, "images/tools/");
+// This URL will be used not relative to this script, but relative to the QML that handles the Overlay, so we need an absolute URL.
+var toolIconUrl = Script.resolvePath("../assets/images/tools/");
 
 progressDialog = (function () {
     var that = {},


### PR DESCRIPTION
Fixes:
```
[04/24 10:27:22] [WARNING] [default] qrc:/qml/hifi/overlays/ImageOverlay.qml:9:5: QML AnimatedImage: Error Reading Animated Image File qrc:/qml/hifi/overlays/images/tools/progress-background.svg
```
This must have been broken for quite some years already.
Don't ask me what this does. It appears to be some sort of progress bar used in Create app, but the warning appears without even opening Create.  ¯\_(ツ)_/¯