### PR TITLE
Fix build error on newer compilers, add missing header

### DIFF
--- a/libraries/recording/src/recording/Forward.h
+++ b/libraries/recording/src/recording/Forward.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <list>
 #include <limits>
+#include <cstdint>
 
 namespace recording {
 


### PR DESCRIPTION
This fixes builds on Fedora 42 and other new distros
