### PR TITLE
ArrayBufferView access from C++ script API

### DIFF
--- a/libraries/script-engine/src/ScriptManagerScriptingInterface.cpp
+++ b/libraries/script-engine/src/ScriptManagerScriptingInterface.cpp
@@ -149,14 +149,16 @@ void ScriptManagerScriptingInterface::test__ArrayBufferView(const ScriptValue& v
     auto offset = view->byteOffset();
     auto length = view->byteLength();
 
-    stream << "ArrayBufferView(" << offset << ", " << length << ") [";
+    stream << "ArrayBufferView(" << offset << ", " << length << ") [ ";
 
     if (data) {
         for (size_t i = 0; i < length; i++) {
-            stream << data[i];
+            stream << (uint8_t)data[offset + i];
 
             if (i < length - 1) { stream << ", "; }
         }
+    } else {
+        stream << "(no buffer)";
     }
 
     stream << " ]";

--- a/libraries/script-engine/src/ScriptManagerScriptingInterface.cpp
+++ b/libraries/script-engine/src/ScriptManagerScriptingInterface.cpp
@@ -133,3 +133,33 @@ QString ScriptManagerScriptingInterface::btoa(const QByteArray &binary) {
 QByteArray ScriptManagerScriptingInterface::atob(const QString &base64) {
     return QByteArray::fromBase64(base64.toUtf8());
 }
+
+void ScriptManagerScriptingInterface::test__ArrayBufferView(const ScriptValue& value) {
+    if (!value.isArrayBufferView()) {
+        qInfo() << "value is not an ArrayBufferView";
+        return;
+    }
+
+    auto view = value.toArrayBufferView();
+
+    QString str;
+    QTextStream stream(&str);
+
+    const char* data = reinterpret_cast<const char*>(view->buffer());
+    auto offset = view->byteOffset();
+    auto length = view->byteLength();
+
+    stream << "ArrayBufferView(" << offset << ", " << length << ") [";
+
+    if (data) {
+        for (size_t i = 0; i < length; i++) {
+            stream << data[i];
+
+            if (i < length - 1) { stream << ", "; }
+        }
+    }
+
+    stream << " ]";
+
+    qInfo() << str;
+}

--- a/libraries/script-engine/src/ScriptManagerScriptingInterface.h
+++ b/libraries/script-engine/src/ScriptManagerScriptingInterface.h
@@ -620,6 +620,8 @@ public:
      */
      Q_INVOKABLE QString btoa(const QByteArray &binary);
 
+     Q_INVOKABLE void test__ArrayBufferView(const ScriptValue& value);
+
  signals:
 
     /*@jsdoc

--- a/libraries/script-engine/src/ScriptValue.cpp
+++ b/libraries/script-engine/src/ScriptValue.cpp
@@ -40,6 +40,7 @@ public:
     virtual bool isUndefined() const override;
     virtual bool isValid() const override;
     virtual bool isVariant() const override;
+    virtual bool isArrayBufferView() const override;
     virtual ScriptValueIteratorPointer newIterator() const override;
     virtual ScriptValue property(const QString& name,
                                  const ScriptValue::ResolveFlags& mode = ScriptValue::ResolvePrototype) const override;
@@ -67,6 +68,7 @@ public:
     virtual quint32 toUInt32() const override;
     virtual QVariant toVariant() const override;
     virtual QObject* toQObject() const override;
+    virtual std::shared_ptr<ScriptBufferView> toArrayBufferView() const override;
 };
 
 static ScriptValueProxyNull SCRIPT_VALUE_NULL;
@@ -164,6 +166,10 @@ bool ScriptValueProxyNull::isVariant() const {
     return false;
 }
 
+bool ScriptValueProxyNull::isArrayBufferView() const {
+    return false;
+}
+
 ScriptValueIteratorPointer ScriptValueProxyNull::newIterator() const {
     Q_ASSERT(false);
     qCWarning(scriptengine_script, "ScriptValue::newIterator called on empty value");
@@ -252,5 +258,9 @@ QVariant ScriptValueProxyNull::toVariant() const {
 }
 
 QObject* ScriptValueProxyNull::toQObject() const {
+    return nullptr;
+}
+
+std::shared_ptr<ScriptBufferView> ScriptValueProxyNull::toArrayBufferView() const {
     return nullptr;
 }

--- a/libraries/script-engine/src/ScriptValue.h
+++ b/libraries/script-engine/src/ScriptValue.h
@@ -38,7 +38,6 @@ using ScriptValueIteratorPointer = std::shared_ptr<ScriptValueIterator>;
 
 class ScriptBufferView {
 public:
-    virtual bool hasBuffer() const = 0;
     virtual void* buffer() const = 0;
     virtual size_t byteOffset() const = 0;
     virtual size_t byteLength() const = 0;

--- a/libraries/script-engine/src/ScriptValue.h
+++ b/libraries/script-engine/src/ScriptValue.h
@@ -36,6 +36,14 @@ using ScriptEnginePointer = std::shared_ptr<ScriptEngine>;
 using ScriptValueList = QList<ScriptValue>;
 using ScriptValueIteratorPointer = std::shared_ptr<ScriptValueIterator>;
 
+class ScriptBufferView {
+public:
+    virtual bool hasBuffer() const = 0;
+    virtual void* buffer() const = 0;
+    virtual size_t byteOffset() const = 0;
+    virtual size_t byteLength() const = 0;
+};
+
 /// [ScriptInterface] Provides an engine-independent interface for QScriptValue
 class ScriptValue {
 public:
@@ -87,6 +95,7 @@ public:
     inline bool isUndefined() const;
     inline bool isValid() const;
     inline bool isVariant() const;
+    inline bool isArrayBufferView() const;
     inline ScriptValueIteratorPointer newIterator() const;
     inline ScriptValue property(const QString& name, const ResolveFlags& mode = ResolvePrototype) const;
     inline ScriptValue property(quint32 arrayIndex, const ResolveFlags& mode = ResolvePrototype) const;
@@ -118,6 +127,7 @@ public:
     inline quint32 toUInt32() const;
     inline QVariant toVariant() const;
     inline QObject* toQObject() const;
+    inline std::shared_ptr<ScriptBufferView> toArrayBufferView() const;
 
 protected:
     ScriptValueProxy* _proxy;
@@ -150,6 +160,7 @@ public:
     virtual bool isUndefined() const = 0;
     virtual bool isValid() const = 0;
     virtual bool isVariant() const = 0;
+    virtual bool isArrayBufferView() const = 0;
     virtual ScriptValueIteratorPointer newIterator() const = 0;
     virtual ScriptValue property(const QString& name,
                                  const ScriptValue::ResolveFlags& mode = ScriptValue::ResolvePrototype) const = 0;
@@ -177,6 +188,7 @@ public:
     virtual quint32 toUInt32() const = 0;
     virtual QVariant toVariant() const = 0;
     virtual QObject* toQObject() const = 0;
+    virtual std::shared_ptr<ScriptBufferView> toArrayBufferView() const = 0;
 
 protected:
     virtual ~ScriptValueProxy() {}  // prevent explicit deletion of base class
@@ -305,6 +317,11 @@ bool ScriptValue::isVariant() const {
     return _proxy->isVariant();
 }
 
+bool ScriptValue::isArrayBufferView() const {
+    Q_ASSERT(_proxy != nullptr);
+    return _proxy->isArrayBufferView();
+}
+
 ScriptValueIteratorPointer ScriptValue::newIterator() const {
     Q_ASSERT(_proxy != nullptr);
     return _proxy->newIterator();
@@ -404,6 +421,11 @@ QVariant ScriptValue::toVariant() const {
 QObject* ScriptValue::toQObject() const {
     Q_ASSERT(_proxy != nullptr);
     return _proxy->toQObject();
+}
+
+std::shared_ptr<ScriptBufferView> ScriptValue::toArrayBufferView() const {
+    Q_ASSERT(_proxy != nullptr);
+    return _proxy->toArrayBufferView();
 }
 
 #endif // hifi_ScriptValue_h

--- a/libraries/script-engine/src/v8/ScriptValueV8Wrapper.cpp
+++ b/libraries/script-engine/src/v8/ScriptValueV8Wrapper.cpp
@@ -650,7 +650,9 @@ std::shared_ptr<ScriptBufferView> ScriptValueV8Wrapper::toArrayBufferView() cons
     auto value = _value.constGet();
     if (value->IsArrayBufferView()) {
         v8::Isolate* isolate = _engine->getIsolate();
-        return std::make_shared<ScriptBufferViewV8Wrapper>(isolate, v8::Persistent<v8::Value, v8::CopyablePersistentTraits<v8::Value>>(isolate, value));
+        auto view = v8::ArrayBufferView::Cast(*value);
+        auto persistent = std::make_shared<v8::UniquePersistent<v8::ArrayBuffer>>(isolate, view->Buffer());
+        return std::make_shared<ScriptBufferViewV8Wrapper>(isolate, persistent, view->ByteOffset(), view->ByteLength());
     } else {
         return nullptr;
     }

--- a/libraries/script-engine/src/v8/ScriptValueV8Wrapper.cpp
+++ b/libraries/script-engine/src/v8/ScriptValueV8Wrapper.cpp
@@ -646,6 +646,16 @@ QObject* ScriptValueV8Wrapper::toQObject() const {
     }
 }
 
+std::shared_ptr<ScriptBufferView> ScriptValueV8Wrapper::toArrayBufferView() const {
+    auto value = _value.constGet();
+    if (value->IsArrayBufferView()) {
+        v8::Isolate* isolate = _engine->getIsolate();
+        return std::make_shared<ScriptBufferViewV8Wrapper>(isolate, v8::Persistent<v8::Value, v8::CopyablePersistentTraits<v8::Value>>(isolate, value));
+    } else {
+        return nullptr;
+    }
+}
+
 bool ScriptValueV8Wrapper::equals(const ScriptValue& other) const {
     auto isolate = _engine->getIsolate();
     v8::Locker locker(isolate);
@@ -781,4 +791,13 @@ bool ScriptValueV8Wrapper::isVariant() const {
     Q_ASSERT(false);
     return false;
     //return _value.isVariant();
+}
+
+bool ScriptValueV8Wrapper::isArrayBufferView() const {
+    auto isolate = _engine->getIsolate();
+    v8::Locker locker(isolate);
+    v8::Isolate::Scope isolateScope(isolate);
+    v8::HandleScope handleScope(isolate);
+    v8::Context::Scope contextScope(_engine->getContext());
+    return _value.constGet()->IsArrayBufferView();
 }

--- a/libraries/script-engine/src/v8/ScriptValueV8Wrapper.h
+++ b/libraries/script-engine/src/v8/ScriptValueV8Wrapper.h
@@ -30,43 +30,26 @@
 
 class ScriptBufferViewV8Wrapper final : public ScriptBufferView {
 public:
-    bool hasBuffer() const override {
-        auto view = v8::ArrayBufferView::Cast(*_view.Get(_isolate));
-        return view->HasBuffer();
-    }
-
     void* buffer() const override {
-        auto view = v8::ArrayBufferView::Cast(*_view.Get(_isolate));
-
-        // FIXME: calling IsExternal makes some buffers live longer??
-        view->Buffer()->IsExternal();
-
-        if (view->HasBuffer()) {
-            return view->Buffer()->Data();
-        } else {
-            return nullptr;
-        }
+        return _buffer->Get(_isolate)->Data();
     }
 
     size_t byteOffset() const override {
-        auto view = v8::ArrayBufferView::Cast(*_view.Get(_isolate));
-        return view->ByteOffset();
+        return _offset;
     }
 
     size_t byteLength() const override {
-        auto view = v8::ArrayBufferView::Cast(*_view.Get(_isolate));
-        return view->ByteLength();
+        return _length;
     }
 
-    ScriptBufferViewV8Wrapper(v8::Isolate *isolate, v8::Persistent<v8::Value, v8::CopyablePersistentTraits<v8::Value>> view) : _isolate(isolate), _view(view) {}
-
-    ~ScriptBufferViewV8Wrapper() {
-        _view.Reset();
-    }
+    ScriptBufferViewV8Wrapper(v8::Isolate *isolate, std::shared_ptr<v8::UniquePersistent<v8::ArrayBuffer>> buffer, size_t offset, size_t length) : _isolate(isolate), _buffer(buffer), _offset(offset), _length(length) {}
 
 private:
     v8::Isolate *_isolate;
-    v8::Persistent<v8::Value, v8::CopyablePersistentTraits<v8::Value>> _view;
+    std::shared_ptr<v8::UniquePersistent<v8::ArrayBuffer>> _buffer;
+
+    size_t _offset;
+    size_t _length;
 };
 
 /// [V8] Implements ScriptValue for V8 and translates calls for V8ScriptValue

--- a/libraries/script-engine/src/v8/ScriptValueV8Wrapper.h
+++ b/libraries/script-engine/src/v8/ScriptValueV8Wrapper.h
@@ -37,6 +37,10 @@ public:
 
     void* buffer() const override {
         auto view = v8::ArrayBufferView::Cast(*_view.Get(_isolate));
+
+        // FIXME: calling IsExternal makes some buffers live longer??
+        view->Buffer()->IsExternal();
+
         if (view->HasBuffer()) {
             return view->Buffer()->Data();
         } else {

--- a/libraries/script-engine/src/v8/ScriptValueV8Wrapper.h
+++ b/libraries/script-engine/src/v8/ScriptValueV8Wrapper.h
@@ -58,7 +58,6 @@ public:
 
     ~ScriptBufferViewV8Wrapper() {
         _view.Reset();
-        _isolate->Dispose();
     }
 
 private:


### PR DESCRIPTION
(`Script.test__ArrayBufferView` will be removed after QA testing)

```js
Script.test__ArrayBufferView(new Uint8ClampedArray([1, 2, 3, 4]));

const buffer = new ArrayBuffer(16);
const view = new DataView(buffer);

view.setUint32(0, 0xbeefbabe);
view.setUint32(4, 0xcafecace);

Script.test__ArrayBufferView(new Uint8ClampedArray(buffer, 4, 4));

// expected results:
// ArrayBufferView(0, 4) [1, 2, 3, 4]
// ArrayBufferView(4, 4) [202, 254, 202, 206]
```

Closes #1353