### PR TITLE
Places App: Make navigation buttons not draggable

### DIFF
--- a/scripts/system/places/places.html
+++ b/scripts/system/places/places.html
@@ -50,9 +50,9 @@
                 <tr valign = 'middle'>
                     <td width = '20%'>
                         <div id='navigationBar'>
-                            <input type='image' class='navBtn' src='icons/home.png' onClick = 'goHome();'>
-                            <input type='image' class='navBtn' src='icons/back.png' onClick = 'goBack();'>
-                            <input type='image' class='navBtn' src='icons/forward.png' onClick = 'goForward();'>
+                            <input type='image' draggable="false" class='navBtn' src='icons/home.png' onClick = 'goHome();'>
+                            <input type='image' draggable="false" class='navBtn' src='icons/back.png' onClick = 'goBack();'>
+                            <input type='image' draggable="false" class='navBtn' src='icons/forward.png' onClick = 'goForward();'>
                         </div>
                     </td>
                     <td width = '80%'>
@@ -68,7 +68,7 @@
                                         </table>
                                     </div>
                                 </td>
-                                <td width='10%' align='left'><input type='image' class='searchBtn' src='icons/teleport.png' onClick = 'teleportUsingAddressBarValue(document.getElementById("search").value);'></td>
+                                <td width='10%' align='left'><input type='image' draggable="false" class='searchBtn' src='icons/teleport.png' onClick = 'teleportUsingAddressBarValue(document.getElementById("search").value);'></td>
                             </tr>
                         </table>
                     </td>


### PR DESCRIPTION
This PR sets the 4 remaining images as not draggable:

![image](https://github.com/user-attachments/assets/127367b8-dd21-4bfa-a48a-df43c7cb616f)

I inspected all the other images of this app, and they were all already non-draggable.

Addressing issue #1502


To test:
Just try to drag each of the 4 icons in world... you should not be able to do it anymore.