### PR TITLE
Change default PolyLine texture to whitePixel.png

### DIFF
--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -27,7 +27,7 @@ using namespace render::entities;
 
 std::map<std::pair<render::Args::RenderMethod, bool>, gpu::PipelinePointer> PolyLineEntityRenderer::_pipelines;
 
-static const QUrl DEFAULT_POLYLINE_TEXTURE = PathUtils::resourcesUrl("images/paintStroke.png");
+static const QUrl DEFAULT_POLYLINE_TEXTURE = PathUtils::resourcesUrl("images/whitePixel.png");
 
 PolyLineEntityRenderer::PolyLineEntityRenderer(const EntityItemPointer& entity) : Parent(entity) {
     _texture = DependencyManager::get<TextureCache>()->getTexture(DEFAULT_POLYLINE_TEXTURE);


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/bb87c647-cbe2-4162-9caf-fe67360fea07)

After
![image](https://github.com/user-attachments/assets/97478f96-ab0f-46f6-a218-243d7a41dad3)

Testing script (spawns a PolyLine in front of you that disappears after 3 seconds)
```js
let lineEntity = Entities.addEntity({
	type: "PolyLine",
	parentID: MyAvatar.sessionUUID,
	position: MyAvatar.position,
	linePoints: [[-1, 0.5, -1], [1, 0.5, -1]],
	normals: [[0, 0, 1], [0, 0, 1]],
	strokeWidths: [0.3, 0.3],
	color: [255, 255, 255],
	faceCamera: true,
});

Script.scriptEnding.connect(() => Entities.deleteEntity(lineEntity));
Script.setTimeout(() => Script.stop(), 3000);
```

Closes #1501