### PR TITLE
Fix falling though the ground after serverless

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -951,6 +951,7 @@ void Application::setIsServerlessMode(bool serverlessDomain) {
     auto tree = getEntities()->getTree();
     if (tree) {
         tree->setIsServerlessMode(serverlessDomain);
+        _waitForServerlessToBeSet = false;
     }
 }
 
@@ -1915,7 +1916,7 @@ void Application::update(float deltaTime) {
 
         // we haven't yet enabled physics.  we wait until we think we have all the collision information
         // for nearby entities before starting bullet up.
-        if (isServerlessMode()) {
+        if (isServerlessMode() && !_waitForServerlessToBeSet) {
             tryToEnablePhysics();
         } else if (_failedToConnectToEntityServer) {
             if (_octreeProcessor->safeLandingIsActive()) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -923,6 +923,10 @@ private:
     PhysicsEnginePointer _physicsEngine;
 
     bool _physicsEnabled { false };
+    // This is needed so that physics do not get re-enabled before safe landing starts when moving from
+    // serverless to domain server.
+    // It's set to true by Application::clearDomainOctreeData and is cleared by Application::setIsServerlessMode
+    bool _waitForServerlessToBeSet { true };
 
     bool _showTrackedObjects { false };
     bool _prevShowTrackedObjects { false };

--- a/interface/src/Application_Entities.cpp
+++ b/interface/src/Application_Entities.cpp
@@ -224,6 +224,7 @@ void Application::clearDomainOctreeDetails(bool clearAll) {
 
     qCDebug(interfaceapp) << "Clearing domain octree details...";
 
+    _waitForServerlessToBeSet = true;
     resetPhysicsReadyInformation();
     setIsInterstitialMode(true);
 


### PR DESCRIPTION
Fixes the issue where users would fall through the ground when switching from tutorial to Overte_hub and other worlds.
Fixes https://github.com/overte-org/overte/issues/1370