### PR TITLE
Fix blur taps alignment issue

### DIFF
--- a/libraries/render/src/render/BlurTask.cpp
+++ b/libraries/render/src/render/BlurTask.cpp
@@ -91,8 +91,12 @@ void BlurParams::setFilterGaussianTaps(int numHalfTaps, float sigma) {
         weight = (float)exp(-offset*offset * inverseTwoSigmaSquared);
         params.filterTaps[i + 1].x = offset;
         params.filterTaps[i + 1].y = weight;
+        params.filterTaps[i + 1].z = 0.0f;
+        params.filterTaps[i + 1].w = 0.0f;
         params.filterTaps[i + 1 + numHalfTaps].x = -offset;
         params.filterTaps[i + 1 + numHalfTaps].y = weight;
+        params.filterTaps[i + 1 + numHalfTaps].z = 0.0f;
+        params.filterTaps[i + 1 + numHalfTaps].w = 0.0f;
         totalWeight += 2 * weight;
     }
 

--- a/libraries/render/src/render/BlurTask.h
+++ b/libraries/render/src/render/BlurTask.h
@@ -60,7 +60,7 @@ public:
         glm::vec4 linearDepthInfo{ 0.0f };
 
         // Taps (offset, weight)
-        glm::vec2 filterTaps[BLUR_MAX_NUM_TAPS];
+        glm::vec4 filterTaps[BLUR_MAX_NUM_TAPS];
 
         Params() {}
     };

--- a/libraries/render/src/render/BlurTask.slh
+++ b/libraries/render/src/render/BlurTask.slh
@@ -18,7 +18,7 @@ struct BlurParameters {
     vec4 depthInfo;
     vec4 stereoInfo;
     vec4 linearDepthInfo;
-    vec2 taps[BLUR_MAX_NUM_TAPS];
+    vec4 taps[BLUR_MAX_NUM_TAPS];
 };
 
 LAYOUT(binding=0) uniform blurParamsBuffer {
@@ -46,7 +46,7 @@ float getOutputAlpha() {
 }
 
 vec2 getFilterTap(int index) {
-    return parameters.taps[index];
+    return parameters.taps[index].xy;
 }
 
 float getFilterTapOffset(vec2 tap) {


### PR DESCRIPTION
Blur tap alignment was wrong, significantly reducing quality of effects relying on BlurGaussian and BlurGaussianDepthAware, for example bloom.
Fixes https://github.com/overte-org/overte/issues/1561