### PR TITLE
OpenXR Body Tracking, Palm Pose

### DIFF
--- a/interface/resources/controllers/openxr.json
+++ b/interface/resources/controllers/openxr.json
@@ -69,6 +69,32 @@
         { "from": "OpenXR.RightHandPinky1", "to": "Standard.RightHandPinky1"},
         { "from": "OpenXR.RightHandPinky2", "to": "Standard.RightHandPinky2"},
         { "from": "OpenXR.RightHandPinky3", "to": "Standard.RightHandPinky3"},
-        { "from": "OpenXR.RightHandPinky4", "to": "Standard.RightHandPinky4"}
+        { "from": "OpenXR.RightHandPinky4", "to": "Standard.RightHandPinky4"},
+
+        { "from": "OpenXR.LeftEye", "to": "Standard.LeftEye"},
+        { "from": "OpenXR.EyeBlink_L", "to": "Standard.EyeBlink_L"},
+        { "from": "OpenXR.RightEye", "to": "Standard.RightEye"},
+        { "from": "OpenXR.EyeBlink_R", "to": "Standard.EyeBlink_R"},
+
+        { "from": "OpenXR.Hips", "to": "Standard.Hips"},
+        { "from": "OpenXR.LeftFoot", "to": "Standard.LeftFoot"},
+        { "from": "OpenXR.RightFoot", "to": "Standard.RightFoot"},
+
+        { "from": "OpenXR.TrackedObject00", "to": "Standard.TrackedObject00"},
+        { "from": "OpenXR.TrackedObject01", "to": "Standard.TrackedObject01"},
+        { "from": "OpenXR.TrackedObject02", "to": "Standard.TrackedObject02"},
+        { "from": "OpenXR.TrackedObject03", "to": "Standard.TrackedObject03"},
+        { "from": "OpenXR.TrackedObject04", "to": "Standard.TrackedObject04"},
+        { "from": "OpenXR.TrackedObject05", "to": "Standard.TrackedObject05"},
+        { "from": "OpenXR.TrackedObject06", "to": "Standard.TrackedObject06"},
+        { "from": "OpenXR.TrackedObject07", "to": "Standard.TrackedObject07"},
+        { "from": "OpenXR.TrackedObject08", "to": "Standard.TrackedObject08"},
+        { "from": "OpenXR.TrackedObject09", "to": "Standard.TrackedObject09"},
+        { "from": "OpenXR.TrackedObject10", "to": "Standard.TrackedObject10"},
+        { "from": "OpenXR.TrackedObject11", "to": "Standard.TrackedObject11"},
+        { "from": "OpenXR.TrackedObject12", "to": "Standard.TrackedObject12"},
+        { "from": "OpenXR.TrackedObject13", "to": "Standard.TrackedObject13"},
+        { "from": "OpenXR.TrackedObject14", "to": "Standard.TrackedObject14"},
+        { "from": "OpenXR.TrackedObject15", "to": "Standard.TrackedObject15"}
     ]
 }

--- a/interface/resources/controllers/openxr.json
+++ b/interface/resources/controllers/openxr.json
@@ -3,13 +3,13 @@
     "channels": [
         { "from": "OpenXR.Head", "to" : "Standard.Head", "when" : [ "Application.InHMD"] },
 
-        { "from": "OpenXR.LT", "to": "Standard.LT", "filters": [{"type": "deadZone", "min": 0.05}] },
-        { "from": "OpenXR.RT", "to": "Standard.RT", "filters": [{"type": "deadZone", "min": 0.05}] },
+        { "from": "OpenXR.LT", "to": "Standard.LT" },
+        { "from": "OpenXR.RT", "to": "Standard.RT" },
         { "from": "OpenXR.LTClick", "to": "Standard.LTClick" },
         { "from": "OpenXR.RTClick", "to": "Standard.RTClick" },
 
-        { "from": "OpenXR.LeftGrip", "to": "Standard.LeftGrip", "filters": [{ "type": "deadZone", "min": 0.05 }] },
-        { "from": "OpenXR.RightGrip", "to": "Standard.RightGrip", "filters": [{ "type": "deadZone", "min": 0.05 }] },
+        { "from": "OpenXR.LeftGrip", "to": "Standard.LeftGrip" },
+        { "from": "OpenXR.RightGrip", "to": "Standard.RightGrip" },
 
         { "from": "OpenXR.LX", "to": "Standard.LX", "filters": [{ "type": "deadZone", "min": 0.05 }] },
         { "from": "OpenXR.LY", "to": "Standard.LY", "filters": [{ "type": "deadZone", "min": 0.05 }] },
@@ -19,8 +19,6 @@
 
         { "from": "OpenXR.LS", "to": "Standard.LS" },
         { "from": "OpenXR.RS", "to": "Standard.RS" },
-        { "from": "OpenXR.LSTouch", "to": "Standard.LSTouch" },
-        { "from": "OpenXR.RSTouch", "to": "Standard.RSTouch" },
 
         { "from": "OpenXR.LeftPrimaryThumb", "to": "Standard.LeftPrimaryThumb" },
         { "from": "OpenXR.RightPrimaryThumb", "to": "Standard.RightPrimaryThumb" },
@@ -71,30 +69,9 @@
         { "from": "OpenXR.RightHandPinky3", "to": "Standard.RightHandPinky3"},
         { "from": "OpenXR.RightHandPinky4", "to": "Standard.RightHandPinky4"},
 
-        { "from": "OpenXR.LeftEye", "to": "Standard.LeftEye"},
-        { "from": "OpenXR.EyeBlink_L", "to": "Standard.EyeBlink_L"},
-        { "from": "OpenXR.RightEye", "to": "Standard.RightEye"},
-        { "from": "OpenXR.EyeBlink_R", "to": "Standard.EyeBlink_R"},
-
-        { "from": "OpenXR.Hips", "to": "Standard.Hips"},
-        { "from": "OpenXR.LeftFoot", "to": "Standard.LeftFoot"},
-        { "from": "OpenXR.RightFoot", "to": "Standard.RightFoot"},
-
-        { "from": "OpenXR.TrackedObject00", "to": "Standard.TrackedObject00"},
-        { "from": "OpenXR.TrackedObject01", "to": "Standard.TrackedObject01"},
-        { "from": "OpenXR.TrackedObject02", "to": "Standard.TrackedObject02"},
-        { "from": "OpenXR.TrackedObject03", "to": "Standard.TrackedObject03"},
-        { "from": "OpenXR.TrackedObject04", "to": "Standard.TrackedObject04"},
-        { "from": "OpenXR.TrackedObject05", "to": "Standard.TrackedObject05"},
-        { "from": "OpenXR.TrackedObject06", "to": "Standard.TrackedObject06"},
-        { "from": "OpenXR.TrackedObject07", "to": "Standard.TrackedObject07"},
-        { "from": "OpenXR.TrackedObject08", "to": "Standard.TrackedObject08"},
-        { "from": "OpenXR.TrackedObject09", "to": "Standard.TrackedObject09"},
-        { "from": "OpenXR.TrackedObject10", "to": "Standard.TrackedObject10"},
-        { "from": "OpenXR.TrackedObject11", "to": "Standard.TrackedObject11"},
-        { "from": "OpenXR.TrackedObject12", "to": "Standard.TrackedObject12"},
-        { "from": "OpenXR.TrackedObject13", "to": "Standard.TrackedObject13"},
-        { "from": "OpenXR.TrackedObject14", "to": "Standard.TrackedObject14"},
-        { "from": "OpenXR.TrackedObject15", "to": "Standard.TrackedObject15"}
+        { "from": "OpenXR.Hips", "to": "Standard.Hips" },
+        { "from": "OpenXR.Spine2", "to": "Standard.Spine2" },
+        { "from": "OpenXR.LeftFoot", "to": "Standard.LeftFoot" },
+        { "from": "OpenXR.RightFoot", "to": "Standard.RightFoot" }
     ]
 }

--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -247,6 +247,8 @@ Item {
                         if (loader.item.hasOwnProperty("pluginName")) {
                             if (openVRDevices.indexOf(box.textAt(box.currentIndex)) !== -1) {
                                 loader.item.pluginName = "OpenVR";
+                            } else if (box.currentIndex.startsWith("OpenXR")) {
+                                loader.item.pluginName = "OpenXR";
                             } else {
                                 loader.item.pluginName = box.textAt(box.currentIndex);
                             }
@@ -301,6 +303,8 @@ Item {
                 var source = "";
                 if (openVRDevices.indexOf(selectedDevice) !== -1) {
                     source = InputConfiguration.configurationLayout("OpenVR");
+                } else if (selectedDevice.startsWith("OpenXR")) {
+                    source = InputConfiguration.configurationLayout("OpenXR");
                 } else {
                     source = InputConfiguration.configurationLayout(selectedDevice);
                 }

--- a/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
@@ -60,6 +60,7 @@ Flickable {
 
     Component.onCompleted: {
         page = config.createObject(flick.contentItem);
+        page.displayConfiguration();
     }
     Component {
         id: config
@@ -88,6 +89,30 @@ Flickable {
                 }
             }
 
+            Row {
+                id: otherConfig
+                anchors.left: parent.left
+                anchors.leftMargin: leftMargin + 10
+                spacing: 10
+
+                HifiControls.CheckBox {
+                    id: hapticsBox
+                    width: 15
+                    height: 15
+                    boxRadius: 7
+
+                    onClicked: {
+                        sendConfigurationSettings();
+                    }
+                }
+
+                RalewayBold {
+                    size: 12
+                    text: "Enable Controller Haptics"
+                    color: hifi.colors.lightGrayText
+                }
+            }
+
             RalewayBold {
                 id: bodyTracking
 
@@ -96,8 +121,10 @@ Flickable {
 
                 color: hifi.colors.white
 
+                anchors.top: otherConfig.bottom
                 anchors.left: parent.left
                 anchors.leftMargin: leftMargin
+                anchors.topMargin: 10
             }
 
             RalewayRegular {
@@ -110,6 +137,8 @@ Flickable {
                     left: bodyTracking.right
                     leftMargin: 10
                     verticalCenter: bodyTracking.verticalCenter
+                    topMargin: 10
+                    top: bodyTracking.bottom
                 }
 
                 Rectangle {
@@ -280,10 +309,6 @@ Flickable {
                 }
             }
 
-            Component.onCompleted: {
-                lastConfiguration = composeConfigurationSettings();
-            }
-
             Component.onDestruction: {
                 var settings = InputConfiguration.configurationSettings("OpenXR");
                 var data = {};
@@ -361,7 +386,19 @@ Flickable {
 
             function displayConfiguration() {
                 isConfiguring = true;
+
+                var settings = InputConfiguration.configurationSettings("OpenXR");
+                hapticsBox.checked = settings["enable_haptics"];
+
                 isConfiguring = false;
+            }
+
+            function sendConfigurationSettings() {
+                var settings = InputConfiguration.configurationSettings("OpenXR");
+
+                settings["enable_haptics"] = hapticsBox.checked;
+
+                InputConfiguration.setConfigurationSettings(settings, "OpenXR");
             }
         }
     }

--- a/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
@@ -23,7 +23,6 @@ Flickable {
     anchors.fill: parent
     contentHeight: 550
     flickableDirection: Flickable.VerticalFlick
-    property string pluginName: ""
     property var page: null;
 
     ScrollBar.vertical: ScrollBar {
@@ -59,13 +58,6 @@ Flickable {
         }
     }
 
-    onPluginNameChanged: {
-        if (page !== null) {
-            page.pluginName = flick.pluginName;
-            page.displayConfiguration();
-        }
-    }
-
     function bringToView(item) {
         var yTop = item.mapToItem(contentItem, 0, 0).y;
         var yBottom = yTop + item.height;
@@ -89,7 +81,6 @@ Flickable {
 
             property int leftMargin: 75
             property int countDown: 0
-            property string pluginName: ""
             property var displayInformation: null
 
             property var lastConfiguration:  null
@@ -288,7 +279,7 @@ Flickable {
                 repeat: false
                 interval: 20
                 onTriggered: {
-                    InputConfiguration.calibratePlugin(openXrConfiguration.pluginName);
+                    InputConfiguration.calibratePlugin("OpenXR");
                     stack.currentItem.success();
                 }
             }
@@ -306,7 +297,7 @@ Flickable {
             }
 
             Component.onDestruction: {
-                var settings = InputConfiguration.configurationSettings(openXrConfiguration.pluginName);
+                var settings = InputConfiguration.configurationSettings("OpenXR");
                 var data = {};
                 UserActivityLogger.logAction("mocap_ui_close_dialog", data);
             }
@@ -418,7 +409,7 @@ Flickable {
             function displayConfiguration() {
                 isConfiguring = true;
 
-                var settings = InputConfiguration.configurationSettings(openXrConfiguration.pluginName);
+                var settings = InputConfiguration.configurationSettings("OpenXR");
 
                 // default offset for user wearing puck on the center of their forehead.
                 headYOffset.realValue = 4; // (cm), puck is above the head joint.
@@ -461,7 +452,7 @@ Flickable {
                     return;
                 }
                 var settings = composeConfigurationSettings();
-                InputConfiguration.setConfigurationSettings(settings, openXrConfiguration.pluginName);
+                InputConfiguration.setConfigurationSettings(settings, "OpenXR");
             }
         }
     }

--- a/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
@@ -58,18 +58,6 @@ Flickable {
         }
     }
 
-    function bringToView(item) {
-        var yTop = item.mapToItem(contentItem, 0, 0).y;
-        var yBottom = yTop + item.height;
-
-        var surfaceTop = contentY;
-        var surfaceBottom = contentY + height;
-
-        if(yTop < surfaceTop || yBottom > surfaceBottom) {
-            contentY = yTop - height / 2 + item.height
-        }
-    }
-
     Component.onCompleted: {
         page = config.createObject(flick.contentItem);
     }
@@ -363,41 +351,6 @@ Flickable {
                 to: 0
             }
 
-
-            function logAction(action, status) {
-                var data = {
-                    "puck_configuration": status["configuration"],
-                }
-                UserActivityLogger.logAction(action, data);
-            }
-
-
-            function trackersForConfiguration() {
-                var pucksNeeded = 0;
-
-                if (headPuckBox.checked) {
-                    pucksNeeded++;
-                }
-
-                if (feetBox.checked) {
-                    pucksNeeded++;
-                }
-
-                if (hipBox.checked) {
-                    pucksNeeded++;
-                }
-
-                if (chestBox.checked) {
-                    pucksNeeded++;
-                }
-
-                if (shoulderBox.checked) {
-                    pucksNeeded++;
-                }
-
-                return pucksNeeded;
-            }
-
             function cancelCalibration() {
                 calibrationTimer.stop();
             }
@@ -408,51 +361,7 @@ Flickable {
 
             function displayConfiguration() {
                 isConfiguring = true;
-
-                var settings = InputConfiguration.configurationSettings("OpenXR");
-
-                // default offset for user wearing puck on the center of their forehead.
-                headYOffset.realValue = 4; // (cm), puck is above the head joint.
-                headZOffset.realValue = 8; // (cm), puck is in front of the head joint.
-
-                // defaults for user wearing the pucks on the backs of their palms.
-                handYOffset.realValue = 8; // (cm), puck is past the the hand joint.  (set this to zero if puck is on the wrist)
-                handZOffset.realValue = -4; // (cm), puck is on above hand joint.
-
-                var eyeTrackingEnabled = settings["eyeTrackingEnabled"];
-
-                armCircumference.realValue = settings["armCircumference"];
-                shoulderWidth.realValue = settings["shoulderWidth"];
-
-                eyeTracking.checked = eyeTrackingEnabled;
-                outOfRangeDataStrategyComboBox.currentIndex = outOfRangeDataStrategyComboBox.model.indexOf(settings.outOfRangeDataStrategy);
-
-                var data = {
-                    "num_pucks": settings["puckCount"]
-                };
-
-                UserActivityLogger.logAction("mocap_ui_open_dialog", data);
-
                 isConfiguring = false;
-            }
-
-            function composeConfigurationSettings() {
-                var settingsObject = {
-                    "armCircumference": armCircumference.realValue,
-                    "shoulderWidth": shoulderWidth.realValue,
-                    "outOfRangeDataStrategy": outOfRangeDataStrategyComboBox.model[outOfRangeDataStrategyComboBox.currentIndex],
-                }
-
-                return settingsObject;
-            }
-
-            function sendConfigurationSettings() {
-                if (isConfiguring) {
-                    // Ignore control value changes during dialog initialization.
-                    return;
-                }
-                var settings = composeConfigurationSettings();
-                InputConfiguration.setConfigurationSettings(settings, "OpenXR");
             }
         }
     }

--- a/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
@@ -1,0 +1,468 @@
+//
+//  Created by Ada <ada@thingvellir.net> on 2025-06-15
+//  Copyright 2025 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import QtQuick 2.5
+import QtGraphicalEffects 1.0
+import QtQuick.Controls 2.2
+
+import stylesUit 1.0
+import "../../controls"
+import controlsUit 1.0 as HifiControls
+import "."
+
+
+Flickable {
+    id: flick
+    width: parent.width
+    height: parent.height
+    anchors.fill: parent
+    contentHeight: 550
+    flickableDirection: Flickable.VerticalFlick
+    property string pluginName: ""
+    property var page: null;
+
+    ScrollBar.vertical: ScrollBar {
+        policy: ScrollBar.AlwaysOn
+        parent: flick.parent
+        anchors.top: flick.top
+        anchors.right: flick.right
+        anchors.bottom: flick.bottom
+        z: 100  // Display over top of separators.
+
+        background: Item {
+            implicitWidth: verticalScrollWidth
+            Rectangle {
+                color: hifi.colors.baseGrayShadow
+                radius: 4
+                anchors {
+                    fill: parent
+                    bottomMargin: 1
+                }
+            }
+        }
+        contentItem: Item {
+            implicitWidth: verticalScrollShaft
+            Rectangle {
+                radius: verticalScrollShaft/2
+                color: hifi.colors.white30
+                anchors {
+                    fill: parent
+                    topMargin: 1
+                    bottomMargin: 1
+                }
+            }
+        }
+    }
+
+    onPluginNameChanged: {
+        if (page !== null) {
+            page.pluginName = flick.pluginName;
+            page.displayConfiguration();
+        }
+    }
+
+    function bringToView(item) {
+        var yTop = item.mapToItem(contentItem, 0, 0).y;
+        var yBottom = yTop + item.height;
+
+        var surfaceTop = contentY;
+        var surfaceBottom = contentY + height;
+
+        if(yTop < surfaceTop || yBottom > surfaceBottom) {
+            contentY = yTop - height / 2 + item.height
+        }
+    }
+
+    Component.onCompleted: {
+        page = config.createObject(flick.contentItem);
+    }
+    Component {
+        id: config
+        Rectangle {
+            id: openXrConfiguration
+            anchors.fill: parent
+
+            property int leftMargin: 75
+            property int countDown: 0
+            property string pluginName: ""
+            property var displayInformation: null
+
+            property var lastConfiguration:  null
+            property bool isConfiguring: false
+
+            HifiConstants { id: hifi }
+
+            Component { id: screen; CalibratingScreen {} }
+
+            MouseArea {
+                id: mouseArea
+
+                anchors.fill: parent
+                propagateComposedEvents: true
+                onPressed: {
+                    mouse.accepted = false;
+                }
+            }
+
+            RalewayBold {
+                id: bodyTracking
+
+                text: "Body Tracking"
+                size: 12
+
+                color: hifi.colors.white
+
+                anchors.left: parent.left
+                anchors.leftMargin: leftMargin
+            }
+
+            RalewayRegular {
+                id: info
+
+                text: "See Recommended Placement"
+                color: hifi.colors.blueHighlight
+                size: 12
+                anchors {
+                    left: bodyTracking.right
+                    leftMargin: 10
+                    verticalCenter: bodyTracking.verticalCenter
+                }
+
+                Rectangle {
+                    id: selected
+                    color: hifi.colors.blueHighlight
+
+                    width: info.width
+                    height: 1
+
+                    anchors {
+                        top: info.bottom
+                        topMargin: 1
+                        left: info.left
+                        right: info.right
+                    }
+
+                    visible: false
+                }
+
+                MouseArea {
+                    anchors.fill: parent;
+                    hoverEnabled: true
+
+                    onEntered: {
+                        selected.visible = true;
+                    }
+
+                    onExited: {
+                        selected.visible = false;
+                    }
+                    onClicked: {
+                        stack.messageVisible = true;
+                    }
+                }
+            }
+
+            color: hifi.colors.baseGray
+
+            Rectangle {
+                id: calibrationButton
+                property int color: hifi.buttons.blue
+                property int colorScheme: hifi.colorSchemes.light
+                property string glyph: hifi.glyphs.avatar1
+                property bool enabled: true
+                property bool pressed: false
+                property bool hovered: false
+                property int size: 32
+                property string text: "Calibrate"
+                property int padding: 12
+
+                width: glyphButton.width + calibrationText.width + padding
+                height: hifi.dimensions.controlLineHeight
+                anchors.top: bodyTracking.bottom
+                anchors.topMargin: 15
+                anchors.left: parent.left
+                anchors.leftMargin: leftMargin
+
+                radius: hifi.buttons.radius
+
+                gradient: Gradient {
+                    GradientStop {
+                        position: 0.2
+                        color: {
+                            if (!calibrationButton.enabled) {
+                                hifi.buttons.disabledColorStart[calibrationButton.colorScheme]
+                            } else if (calibrationButton.pressed) {
+                                hifi.buttons.pressedColor[calibrationButton.color]
+                            } else if (calibrationButton.hovered) {
+                                hifi.buttons.hoveredColor[calibrationButton.color]
+                            } else {
+                                hifi.buttons.colorStart[calibrationButton.color]
+                            }
+                        }
+                    }
+
+                    GradientStop {
+                        position: 1.0
+                        color: {
+                            if (!calibrationButton.enabled) {
+                                hifi.buttons.disabledColorFinish[calibrationButton.colorScheme]
+                            } else if (calibrationButton.pressed) {
+                                hifi.buttons.pressedColor[calibrationButton.color]
+                            } else if (calibrationButton.hovered) {
+                                hifi.buttons.hoveredColor[calibrationButton.color]
+                            } else {
+                                hifi.buttons.colorFinish[calibrationButton.color]
+                            }
+                        }
+                    }
+                }
+
+                HiFiGlyphs {
+                    id: glyphButton
+                    color: enabled ? hifi.buttons.textColor[calibrationButton.color]
+                        : hifi.buttons.disabledTextColor[calibrationButton.colorScheme]
+                    text: calibrationButton.glyph
+                    size: calibrationButton.size
+
+                    anchors {
+                        top: parent.top
+                        bottom: parent.bottom
+                        bottomMargin: 1
+                    }
+                }
+
+                RalewayBold {
+                    id: calibrationText
+                    font.capitalization: Font.AllUppercase
+                    color: enabled ? hifi.buttons.textColor[calibrationButton.color]
+                        : hifi.buttons.disabledTextColor[calibrationButton.colorScheme]
+                    size: hifi.fontSizes.buttonLabel
+                    text: calibrationButton.text
+
+                    anchors {
+                        left: glyphButton.right
+                        top: parent.top
+                        topMargin: 7
+                    }
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: {
+                        calibrationTimer.interval = timeToCalibrate.realValue * 1000
+                        openXrConfiguration.countDown = timeToCalibrate.realValue;
+                        var calibratingScreen = screen.createObject();
+                        stack.push(calibratingScreen);
+                        calibratingScreen.canceled.connect(cancelCalibration);
+                        calibratingScreen.restart.connect(restartCalibration);
+                        calibratingScreen.start(calibrationTimer.interval, timeToCalibrate.realValue);
+                        calibrationTimer.start();
+                    }
+
+                    onPressed: {
+                        calibrationButton.pressed = true;
+                    }
+
+                    onReleased: {
+                        calibrationButton.pressed = false;
+                    }
+
+                    onEntered: {
+                        calibrationButton.hovered = true;
+                    }
+
+                    onExited: {
+                        calibrationButton.hovered = false;
+                    }
+                }
+            }
+
+            Timer {
+                id: calibrationTimer
+                repeat: false
+                interval: 20
+                onTriggered: {
+                    InputConfiguration.calibratePlugin(openXrConfiguration.pluginName);
+                    stack.currentItem.success();
+                }
+            }
+
+            Timer {
+                id: displayTimer
+                repeat: false
+                interval: 3000
+                onTriggered: {
+                }
+            }
+
+            Component.onCompleted: {
+                lastConfiguration = composeConfigurationSettings();
+            }
+
+            Component.onDestruction: {
+                var settings = InputConfiguration.configurationSettings(openXrConfiguration.pluginName);
+                var data = {};
+                UserActivityLogger.logAction("mocap_ui_close_dialog", data);
+            }
+
+            HifiControls.SpinBox {
+                id: timeToCalibrate
+                width: 70
+                anchors.top: calibrationButton.bottom
+                anchors.topMargin: 20
+                anchors.left: parent.left
+                anchors.leftMargin: leftMargin
+
+                minimumValue: 0
+                maximumValue: 5
+                realValue: 5
+                realStepSize: 1.0
+                colorScheme: hifi.colorSchemes.dark
+
+                onRealValueChanged: {
+                    calibrationTimer.interval = realValue * 1000;
+                    openXrConfiguration.countDown = realValue;
+                    numberAnimation.duration = calibrationTimer.interval;
+                }
+            }
+
+            RalewayBold {
+                id: delayTextInfo
+                size: 10
+                text: "Delay Before Calibration Starts"
+                color: hifi.colors.white
+
+                anchors {
+                    left: timeToCalibrate.right
+                    leftMargin: 20
+                    verticalCenter: timeToCalibrate.verticalCenter
+                }
+            }
+
+            RalewayRegular {
+                size: 12
+                text: "sec"
+                color: hifi.colors.lightGray
+
+                anchors {
+                    left: delayTextInfo.right
+                    leftMargin: 10
+                    verticalCenter: delayTextInfo.verticalCenter
+                }
+            }
+
+            Separator {
+                id: advanceSeperator
+                width: parent.width
+                anchors.top: timeToCalibrate.bottom
+                anchors.topMargin: 10
+            }
+
+
+            NumberAnimation {
+                id: numberAnimation
+                target: openXrConfiguration
+                property: "countDown"
+                to: 0
+            }
+
+
+            function logAction(action, status) {
+                var data = {
+                    "puck_configuration": status["configuration"],
+                }
+                UserActivityLogger.logAction(action, data);
+            }
+
+
+            function trackersForConfiguration() {
+                var pucksNeeded = 0;
+
+                if (headPuckBox.checked) {
+                    pucksNeeded++;
+                }
+
+                if (feetBox.checked) {
+                    pucksNeeded++;
+                }
+
+                if (hipBox.checked) {
+                    pucksNeeded++;
+                }
+
+                if (chestBox.checked) {
+                    pucksNeeded++;
+                }
+
+                if (shoulderBox.checked) {
+                    pucksNeeded++;
+                }
+
+                return pucksNeeded;
+            }
+
+            function cancelCalibration() {
+                calibrationTimer.stop();
+            }
+
+            function restartCalibration() {
+                calibrationTimer.restart();
+            }
+
+            function displayConfiguration() {
+                isConfiguring = true;
+
+                var settings = InputConfiguration.configurationSettings(openXrConfiguration.pluginName);
+
+                // default offset for user wearing puck on the center of their forehead.
+                headYOffset.realValue = 4; // (cm), puck is above the head joint.
+                headZOffset.realValue = 8; // (cm), puck is in front of the head joint.
+
+                // defaults for user wearing the pucks on the backs of their palms.
+                handYOffset.realValue = 8; // (cm), puck is past the the hand joint.  (set this to zero if puck is on the wrist)
+                handZOffset.realValue = -4; // (cm), puck is on above hand joint.
+
+                var eyeTrackingEnabled = settings["eyeTrackingEnabled"];
+
+                armCircumference.realValue = settings["armCircumference"];
+                shoulderWidth.realValue = settings["shoulderWidth"];
+
+                eyeTracking.checked = eyeTrackingEnabled;
+                outOfRangeDataStrategyComboBox.currentIndex = outOfRangeDataStrategyComboBox.model.indexOf(settings.outOfRangeDataStrategy);
+
+                var data = {
+                    "num_pucks": settings["puckCount"]
+                };
+
+                UserActivityLogger.logAction("mocap_ui_open_dialog", data);
+
+                isConfiguring = false;
+            }
+
+            function composeConfigurationSettings() {
+                var settingsObject = {
+                    "armCircumference": armCircumference.realValue,
+                    "shoulderWidth": shoulderWidth.realValue,
+                    "outOfRangeDataStrategy": outOfRangeDataStrategyComboBox.model[outOfRangeDataStrategyComboBox.currentIndex],
+                }
+
+                return settingsObject;
+            }
+
+            function sendConfigurationSettings() {
+                if (isConfiguring) {
+                    // Ignore control value changes during dialog initialization.
+                    return;
+                }
+                var settings = composeConfigurationSettings();
+                InputConfiguration.setConfigurationSettings(settings, openXrConfiguration.pluginName);
+            }
+        }
+    }
+}

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -294,6 +294,10 @@ int main(int argc, const char* argv[]) {
         "xrNoHandTracking",
         "Debug option. Disables OpenXR hand tracking, even if it's supported by the runtime."
     );
+    QCommandLineOption xrNoBodyTrackingOption(
+        "xrNoBodyTracking",
+        "Debug option. Disables OpenXR body tracking (MNDX_xdev_space or HTCX_vive_tracker_interaction), even if it's supported by the runtime."
+    );
 
     // "--qmljsdebugger", which appears in output from "--help-all".
     // Those below don't seem to be optional.

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -292,11 +292,15 @@ int main(int argc, const char* argv[]) {
     );
     QCommandLineOption xrNoHandTrackingOption(
         "xrNoHandTracking",
-        "Debug option. Disables OpenXR hand tracking, even if it's supported by the runtime."
+        "Debug option. Disables OpenXR hand tracking, even if it's supported."
     );
     QCommandLineOption xrNoBodyTrackingOption(
         "xrNoBodyTracking",
-        "Debug option. Disables OpenXR body tracking (MNDX_xdev_space or HTCX_vive_tracker_interaction), even if it's supported by the runtime."
+        "Debug option. Disables OpenXR body tracking, even if it's supported."
+    );
+    QCommandLineOption xrNoPalmPoseOption(
+        "xrNoPalmPose",
+        "Debug option. Disables use of the OpenXR palm pose, even if it's supported. Falls back to the controller's grip pose."
     );
 
     // "--qmljsdebugger", which appears in output from "--help-all".
@@ -349,6 +353,7 @@ int main(int argc, const char* argv[]) {
     parser.addOption(getProtocolVersionDataOption);
     parser.addOption(useExperimentalXROption);
     parser.addOption(xrNoHandTrackingOption);
+    parser.addOption(xrNoPalmPoseOption);
 
 
     QString applicationPath;

--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -105,6 +105,7 @@ bool OpenXrContext::initInstance() {
     bool userPresenceSupported = false;
     bool odysseyControllerSupported = false;
     bool handTrackingSupported = false;
+    bool palmPoseSupported = false;
     bool MNDX_xdevSpaceSupported = false;
     bool HTCX_viveTrackerInteractionSupported = false;
 
@@ -123,6 +124,8 @@ bool OpenXrContext::initInstance() {
             MNDX_xdevSpaceSupported = true;
         } else if (strcmp(XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME, properties[i].extensionName) == 0) {
             HTCX_viveTrackerInteractionSupported = true;
+        } else if (strcmp(XR_EXT_PALM_POSE_EXTENSION_NAME, properties[i].extensionName) == 0) {
+            palmPoseSupported = true;
         }
     }
 
@@ -154,6 +157,11 @@ bool OpenXrContext::initInstance() {
     if (HTCX_viveTrackerInteractionSupported) {
         enabled.push_back(XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
         _HTCX_viveTrackerInteractionSupported = true;
+    }
+
+    if (palmPoseSupported) {
+        enabled.push_back(XR_EXT_PALM_POSE_EXTENSION_NAME);
+        _palmPoseSupported = true;
     }
 
     XrInstanceCreateInfo info = {
@@ -334,6 +342,10 @@ bool OpenXrContext::initSystem() {
     if (qApp->arguments().contains("--xrNoBodyTracking")) {
         _MNDX_xdevSpaceSupported = false;
         _HTCX_viveTrackerInteractionSupported = false;
+    }
+
+    if (qApp->arguments().contains("--xrNoPalmPose")) {
+        _palmPoseSupported = false;
     }
 
     // disable the MNDX tracker extension if they're both available

--- a/plugins/openxr/src/OpenXrContext.h
+++ b/plugins/openxr/src/OpenXrContext.h
@@ -12,6 +12,7 @@
 #include <optional>
 
 #include <openxr/openxr.h>
+#include "vendored_headers/XR_MNDX_xdev_space.h"
 
 #include "gpu/gl/GLBackend.h"
 
@@ -84,10 +85,20 @@ public:
     bool _hmdMounted = true;
 
     bool _handTrackingSupported = false;
-
     PFN_xrCreateHandTrackerEXT xrCreateHandTrackerEXT = nullptr;
     PFN_xrLocateHandJointsEXT xrLocateHandJointsEXT = nullptr;
     PFN_xrDestroyHandTrackerEXT xrDestroyHandTrackerEXT = nullptr;
+
+    bool _MNDX_xdevSpaceSupported = false;
+    PFN_xrCreateXDevListMNDX xrCreateXDevListMNDX = nullptr;
+    PFN_xrGetXDevListGenerationNumberMNDX xrGetXDevListGenerationNumberMNDX = nullptr;
+    PFN_xrEnumerateXDevsMNDX xrEnumerateXDevsMNDX = nullptr;
+    PFN_xrGetXDevPropertiesMNDX xrGetXDevPropertiesMNDX = nullptr;
+    PFN_xrDestroyXDevListMNDX xrDestroyXDevListMNDX = nullptr;
+    PFN_xrCreateXDevSpaceMNDX xrCreateXDevSpaceMNDX = nullptr;
+
+    bool _HTCX_viveTrackerInteractionSupported = false;
+    PFN_xrEnumerateViveTrackerPathsHTCX xrEnumerateViveTrackerPathsHTCX = nullptr;
 
 private:
     XrSessionState _lastSessionState = XR_SESSION_STATE_UNKNOWN;

--- a/plugins/openxr/src/OpenXrContext.h
+++ b/plugins/openxr/src/OpenXrContext.h
@@ -89,6 +89,8 @@ public:
     PFN_xrLocateHandJointsEXT xrLocateHandJointsEXT = nullptr;
     PFN_xrDestroyHandTrackerEXT xrDestroyHandTrackerEXT = nullptr;
 
+    bool _palmPoseSupported = false;
+
     bool _MNDX_xdevSpaceSupported = false;
     PFN_xrCreateXDevListMNDX xrCreateXDevListMNDX = nullptr;
     PFN_xrGetXDevListGenerationNumberMNDX xrGetXDevListGenerationNumberMNDX = nullptr;

--- a/plugins/openxr/src/OpenXrInputPlugin.cpp
+++ b/plugins/openxr/src/OpenXrInputPlugin.cpp
@@ -1057,6 +1057,7 @@ void OpenXrInputPlugin::InputDevice::update(float deltaTime, const controller::I
         emulateStickFromTrackpad();
     }
 
+    // TODO: Fix up and finish the HTCX_vive_tracker_interaction support
     if (_context->_HTCX_viveTrackerInteractionSupported) {
         updateBodyFromViveTrackers(sensorToAvatar);
     } else if (_context->_MNDX_xdevSpaceSupported) {

--- a/plugins/openxr/src/OpenXrInputPlugin.cpp
+++ b/plugins/openxr/src/OpenXrInputPlugin.cpp
@@ -1228,10 +1228,19 @@ void OpenXrInputPlugin::InputDevice::calibratePucks(const controller::InputCalib
         // not connected, don't calibrate
         if (!_poseStateMap[channel].isValid()) { continue; }
 
-        auto position = _poseStateMap[channel].getTranslation();
-        auto rotation = _poseStateMap[channel].getRotation();
+        // get the heading of the headset for the forward direction
+        vec3 headEuler = glm::eulerAngles(_context->_lastHeadPose.getRotation());
+        headEuler.x = 0.0f;
+        quat headAngle = glm::inverse(quat(headEuler));
 
-        _trackerCalibrations[channel] = Pose(vec3(), glm::inverse(rotation) * quat(defaultPoseOffset(data, channel)));
+        auto position = headAngle * _poseStateMap[channel].getTranslation();
+        auto rotation = headAngle * _poseStateMap[channel].getRotation();
+        auto offset = defaultPoseOffset(data, channel);
+
+        _trackerCalibrations[channel] = Pose(
+            vec3(),//position - vec3(offset[3]),
+            glm::inverse(rotation) * quat(offset)
+        );
     }
 
     _wantsCalibrate = false;

--- a/plugins/openxr/src/OpenXrInputPlugin.cpp
+++ b/plugins/openxr/src/OpenXrInputPlugin.cpp
@@ -1229,16 +1229,15 @@ void OpenXrInputPlugin::InputDevice::calibratePucks(const controller::InputCalib
         if (!_poseStateMap[channel].isValid()) { continue; }
 
         // get the heading of the headset for the forward direction
-        vec3 headEuler = glm::eulerAngles(_context->_lastHeadPose.getRotation());
-        headEuler.x = 0.0f;
-        quat headAngle = glm::inverse(quat(headEuler));
+        auto heading = glm::eulerAngles(_context->_lastHeadPose.getRotation()).y;
+        auto headAngle = glm::inverse(quat(vec3(0.0f, heading, 0.0f)));
 
-        auto position = headAngle * _poseStateMap[channel].getTranslation();
+        //auto position = glm::inverse(headAngle) * _poseStateMap[channel].getTranslation();
         auto rotation = headAngle * _poseStateMap[channel].getRotation();
         auto offset = defaultPoseOffset(data, channel);
 
         _trackerCalibrations[channel] = Pose(
-            vec3(),//position - vec3(offset[3]),
+            glm::inverse(rotation) * vec3(0.0f, channel == HIPS ? -0.05f : 0.0f, 0.1f),
             glm::inverse(rotation) * quat(offset)
         );
     }

--- a/plugins/openxr/src/OpenXrInputPlugin.h
+++ b/plugins/openxr/src/OpenXrInputPlugin.h
@@ -14,7 +14,10 @@
 #include "OpenXrContext.h"
 
 #define HAND_COUNT 2
-#define MAX_TRACKER_COUNT 16
+
+// most of the time this should be less than 16, but some devices like
+// SlimeVR report xdev trackers for the joints of a simulated skeleton
+#define MAX_TRACKER_COUNT 64
 
 class OpenXrInputPlugin : public InputPlugin {
     Q_OBJECT
@@ -112,6 +115,7 @@ private:
         bool _actionsInitialized = false;
 
         std::unordered_map<XrXDevIdMNDX, XDevTracker> _xdev;
+        std::unordered_map<controller::StandardPoseChannel, controller::Pose> _trackerCalibrations;
 
         XrHandTrackerEXT _handTracker[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
 

--- a/plugins/openxr/src/OpenXrInputPlugin.h
+++ b/plugins/openxr/src/OpenXrInputPlugin.h
@@ -81,6 +81,7 @@ private:
         std::optional<controller::StandardPoseChannel> pose_channel;
         XrXDevPropertiesMNDX properties;
     };
+    void guessXDevRoles(std::unordered_map<XrXDevIdMNDX, XDevTracker>& trackers);
 
     class InputDevice : public controller::InputDevice {
     public:
@@ -98,6 +99,7 @@ private:
 
         void updateBodyFromViveTrackers(const mat4& sensorToAvatar);
         void updateBodyFromXDevSpaces(const mat4& sensorToAvatar);
+        void calibratePucks(const controller::InputCalibrationData& inputCalibrationData);
 
         mutable std::recursive_mutex _lock;
         template <typename F>
@@ -116,6 +118,7 @@ private:
 
         std::unordered_map<XrXDevIdMNDX, XDevTracker> _xdev;
         std::unordered_map<controller::StandardPoseChannel, controller::Pose> _trackerCalibrations;
+        bool _wantsCalibrate = false;
 
         XrHandTrackerEXT _handTracker[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
 

--- a/plugins/openxr/src/OpenXrInputPlugin.h
+++ b/plugins/openxr/src/OpenXrInputPlugin.h
@@ -14,6 +14,7 @@
 #include "OpenXrContext.h"
 
 #define HAND_COUNT 2
+#define MAX_TRACKER_COUNT 16
 
 class OpenXrInputPlugin : public InputPlugin {
     Q_OBJECT
@@ -71,6 +72,13 @@ private:
         XrSpace _poseSpace = XR_NULL_HANDLE;
     };
 
+    struct XDevTracker {
+        XrSpace space;
+        XrPosef offset_pose;
+        std::optional<controller::StandardPoseChannel> pose_channel;
+        XrXDevPropertiesMNDX properties;
+    };
+
     class InputDevice : public controller::InputDevice {
     public:
         InputDevice(std::shared_ptr<OpenXrContext> c);
@@ -84,6 +92,9 @@ private:
 
         void emulateStickFromTrackpad();
         void getHandTrackingInputs(int index, const mat4& sensorToAvatar);
+
+        void updateBodyFromViveTrackers(const mat4& sensorToAvatar);
+        void updateBodyFromXDevSpaces(const mat4& sensorToAvatar);
 
         mutable std::recursive_mutex _lock;
         template <typename F>
@@ -99,6 +110,8 @@ private:
         std::map<std::string, std::shared_ptr<Action>> _actions;
         std::shared_ptr<OpenXrContext> _context;
         bool _actionsInitialized = false;
+
+        std::unordered_map<XrXDevIdMNDX, XDevTracker> _xdev;
 
         XrHandTrackerEXT _handTracker[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
 

--- a/plugins/openxr/src/OpenXrInputPlugin.h
+++ b/plugins/openxr/src/OpenXrInputPlugin.h
@@ -64,6 +64,7 @@ private:
         XrActionStateVector2f getVector2f();
         XrActionStateBoolean getBool();
         XrSpaceLocation getPose();
+        bool isPoseActive();
         bool applyHaptic(XrDuration duration, float frequency, float amplitude);
 
         XrAction _action = XR_NULL_HANDLE;
@@ -121,6 +122,8 @@ private:
         bool _wantsCalibrate = false;
 
         XrHandTrackerEXT _handTracker[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
+
+        bool _hapticsEnabled = true;
 
         bool initActions();
         bool initBindings(const std::string& profileName, const std::map<std::string, std::string>& actionsToBind);

--- a/plugins/openxr/src/vendored_headers/XR_MNDX_xdev_space.h
+++ b/plugins/openxr/src/vendored_headers/XR_MNDX_xdev_space.h
@@ -1,0 +1,80 @@
+// Copyright 2023-2024, Collabora, Ltd.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * @file
+ * @brief  Preview header for XR_MNDX_xdev_space extension.
+ * @author Jakob Bornecrantz <jakob@collabora.com>
+ * @ingroup external_openxr
+ */
+#ifndef XR_MNDX_XDEV_SPACE_H
+#define XR_MNDX_XDEV_SPACE_H 1
+
+#include "openxr_extension_helpers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Extension number 445 (444 prefix)
+#define XR_MNDX_xdev_space 1
+#define XR_MNDX_xdev_space_SPEC_VERSION 1
+#define XR_MNDX_XDEV_SPACE_EXTENSION_NAME "XR_MNDX_xdev_space"
+
+
+XR_DEFINE_ATOM(XrXDevIdMNDX)
+XR_DEFINE_HANDLE(XrXDevListMNDX)
+
+
+XR_STRUCT_ENUM(XR_TYPE_SYSTEM_XDEV_SPACE_PROPERTIES_MNDX, 1000444001);
+// XrSystemXDevSpacePropertiesMNDX extends XrSystemProperties
+typedef struct XrSystemXDevSpacePropertiesMNDX {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrBool32              supportsXDevSpace;
+} XrSystemXDevSpacePropertiesMNDX;
+
+XR_STRUCT_ENUM(XR_TYPE_CREATE_XDEV_LIST_INFO_MNDX, 1000444002);
+typedef struct XrCreateXDevListInfoMNDX {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+} XrCreateXDevListInfoMNDX;
+
+XR_STRUCT_ENUM(XR_TYPE_GET_XDEV_INFO_MNDX, 1000444003);
+typedef struct XrGetXDevInfoMNDX {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrXDevIdMNDX                id;
+} XrGetXDevInfoMNDX;
+
+XR_STRUCT_ENUM(XR_TYPE_XDEV_PROPERTIES_MNDX, 1000444004);
+typedef struct XrXDevPropertiesMNDX {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    char                  name[256];
+    char                  serial[256];
+    XrBool32              canCreateSpace;
+} XrXDevPropertiesMNDX;
+
+XR_STRUCT_ENUM(XR_TYPE_CREATE_XDEV_SPACE_INFO_MNDX, 1000444005);
+typedef struct XrCreateXDevSpaceInfoMNDX {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrXDevListMNDX              xdevList;
+    XrXDevIdMNDX                id;
+    XrPosef                     offset;
+} XrCreateXDevSpaceInfoMNDX;
+
+
+typedef XrResult (XRAPI_PTR *PFN_xrCreateXDevListMNDX)(XrSession session, const XrCreateXDevListInfoMNDX *info, XrXDevListMNDX *xdevList);
+typedef XrResult (XRAPI_PTR *PFN_xrGetXDevListGenerationNumberMNDX)(XrXDevListMNDX xdevList, uint64_t *outGeneration);
+typedef XrResult (XRAPI_PTR *PFN_xrEnumerateXDevsMNDX)(XrXDevListMNDX xdevList, uint32_t xdevCapacityInput, uint32_t* xdevCountOutput, XrXDevIdMNDX* xdevs);
+typedef XrResult (XRAPI_PTR *PFN_xrGetXDevPropertiesMNDX)(XrXDevListMNDX xdevList, const XrGetXDevInfoMNDX *info, XrXDevPropertiesMNDX *properties);
+typedef XrResult (XRAPI_PTR *PFN_xrDestroyXDevListMNDX)(XrXDevListMNDX xdevList);
+typedef XrResult (XRAPI_PTR *PFN_xrCreateXDevSpaceMNDX)(XrSession session, const XrCreateXDevSpaceInfoMNDX *createInfo, XrSpace *space);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/plugins/openxr/src/vendored_headers/openxr_extension_helpers.h
+++ b/plugins/openxr/src/vendored_headers/openxr_extension_helpers.h
@@ -1,0 +1,18 @@
+/*
+** Copyright (c) 2017-2022, The Khronos Group Inc.
+**
+** SPDX-License-Identifier: Apache-2.0
+*/
+
+#pragma once
+
+#include <openxr/openxr.h>
+
+// These are just convenience macros for defining enums that would
+// normally be declared in the body of the enum, but can't be declared
+// that way easily for experimental extensions.
+
+#define XR_ENUM(type, enm, constant) static const type enm = (type)constant
+#define XR_STRUCT_ENUM(enm, constant) XR_ENUM(XrStructureType, enm, constant)
+#define XR_RESULT_ENUM(enm, constant) XR_ENUM(XrResult, enm, constant)
+#define XR_REFSPACE_ENUM(enm, constant) XR_ENUM(XrReferenceSpaceType, enm, constant)


### PR DESCRIPTION
* Tracking puck support for OpenXR, using both the `MNDX_xdev_space` and `HTCX_vive_tracker_interaction` extensions. (Monado currently only supports the former, and SteamVR only supports the latter.)
* Palm pose support for more consistent hand poses, especially on SteamVR where the grip pose seems to sometimes end up too far off on some controllers.
* Adds a toggle in the OpenXR controller settings to turn off controller haptics. (Should be moved into the plain controller settings so it affects OpenVR and gamepads too, and also so the setting actually gets saved)

## Current state
* Automatic tracker role picking for `MNDX_xdev_space` (roles are handled by the runtime with `HTCX_vive_tracker_interaction`)
* Calibration is close, possibly good already? I can't test with my hip tracker on my back because I only have one working base station.

https://github.com/user-attachments/assets/272230dd-8d42-4977-873e-594973a76a99