### PR TITLE
Fix "The compiler.cppstd is not defined for this configuration".

### DIFF
--- a/tools/conan-profiles/vs-19-debug
+++ b/tools/conan-profiles/vs-19-debug
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=192
 compiler.runtime=dynamic
 compiler.runtime_type=Debug

--- a/tools/conan-profiles/vs-19-debug-ninja
+++ b/tools/conan-profiles/vs-19-debug-ninja
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=192
 compiler.runtime=dynamic
 compiler.runtime_type=Debug

--- a/tools/conan-profiles/vs-19-release
+++ b/tools/conan-profiles/vs-19-release
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=192
 compiler.runtime=dynamic
 compiler.runtime_type=Release

--- a/tools/conan-profiles/vs-19-release-ninja
+++ b/tools/conan-profiles/vs-19-release-ninja
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=192
 compiler.runtime=dynamic
 compiler.runtime_type=Release

--- a/tools/conan-profiles/vs-19-relwithdebinfo
+++ b/tools/conan-profiles/vs-19-relwithdebinfo
@@ -4,6 +4,7 @@ os_build=Windows
 arch=x86_64
 arch_build=x86_64
 compiler=Visual Studio
+compiler.cppstd=17
 compiler.version=16
 build_type=RelWithDebInfo
 # Build fails on Windows with C++17

--- a/tools/conan-profiles/vs-22-debug
+++ b/tools/conan-profiles/vs-22-debug
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=Debug

--- a/tools/conan-profiles/vs-22-debug-ninja
+++ b/tools/conan-profiles/vs-22-debug-ninja
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=Debug

--- a/tools/conan-profiles/vs-22-release
+++ b/tools/conan-profiles/vs-22-release
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=Release

--- a/tools/conan-profiles/vs-22-release-ninja
+++ b/tools/conan-profiles/vs-22-release-ninja
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=Release

--- a/tools/conan-profiles/vs-22-relwithdebinfo
+++ b/tools/conan-profiles/vs-22-relwithdebinfo
@@ -2,6 +2,7 @@
 os=Windows
 arch=x86_64
 compiler=msvc
+compiler.cppstd=17
 compiler.version=194
 compiler.runtime=dynamic
 compiler.runtime_type=RelWithDebInfo


### PR DESCRIPTION
True edge case in Conan. It seems that the cache logic works without setting compiler.cppstd, while building requires it in some cases. On my system, everything requiring it was already cached, so I didn't run into any errors while building even without it being set.

According to one of the developers, compiler.cppstd is basically a requirement in Conan ( https://github.com/conan-io/conan/issues/18141 ).