### PR TITLE
add pick filter support to Entities.XXXX methods

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1360,14 +1360,13 @@ void EntityScriptingInterface::onDeletingEntity(EntityItem* entity) {
     }
 }
 
-QUuid EntityScriptingInterface::findClosestEntity(const glm::vec3& center, float radius) const {
+QUuid EntityScriptingInterface::findClosestEntity(const glm::vec3& center, float radius, uint filter) const {
     PROFILE_RANGE(script_entities, __FUNCTION__);
 
     EntityItemID result;
     if (_entityTree) {
-        unsigned int searchFilter = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES);
         _entityTree->withReadLock([&] {
-            result = _entityTree->evalClosestEntity(center, radius, PickFilter(searchFilter));
+            result = _entityTree->evalClosestEntity(center, radius, PickFilter(filter));
         });
     }
     return result;
@@ -1382,34 +1381,32 @@ void EntityScriptingInterface::dumpTree() const {
     }
 }
 
-QVector<QUuid> EntityScriptingInterface::findEntities(const glm::vec3& center, float radius) const {
+QVector<QUuid> EntityScriptingInterface::findEntities(const glm::vec3& center, float radius, uint filter) const {
     PROFILE_RANGE(script_entities, __FUNCTION__);
 
     QVector<QUuid> result;
     if (_entityTree) {
-        unsigned int searchFilter = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES);
         _entityTree->withReadLock([&] {
-            _entityTree->evalEntitiesInSphere(center, radius, PickFilter(searchFilter), result);
+            _entityTree->evalEntitiesInSphere(center, radius, PickFilter(filter), result);
         });
     }
     return result;
 }
 
-QVector<QUuid> EntityScriptingInterface::findEntitiesInBox(const glm::vec3& corner, const glm::vec3& dimensions) const {
+QVector<QUuid> EntityScriptingInterface::findEntitiesInBox(const glm::vec3& corner, const glm::vec3& dimensions, uint filter) const {
     PROFILE_RANGE(script_entities, __FUNCTION__);
 
     QVector<QUuid> result;
     if (_entityTree) {
-        unsigned int searchFilter = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES);
         _entityTree->withReadLock([&] {
             AABox box(corner, dimensions);
-            _entityTree->evalEntitiesInBox(box, PickFilter(searchFilter), result);
+            _entityTree->evalEntitiesInBox(box, PickFilter(filter), result);
         });
     }
     return result;
 }
 
-QVector<QUuid> EntityScriptingInterface::findEntitiesInFrustum(QVariantMap frustum) const {
+QVector<QUuid> EntityScriptingInterface::findEntitiesInFrustum(QVariantMap frustum, uint filter) const {
     PROFILE_RANGE(script_entities, __FUNCTION__);
 
     QVector<QUuid> result;
@@ -1439,9 +1436,8 @@ QVector<QUuid> EntityScriptingInterface::findEntitiesInFrustum(QVariantMap frust
         viewFrustum.calculate();
 
         if (_entityTree) {
-            unsigned int searchFilter = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES);
             _entityTree->withReadLock([&] {
-                _entityTree->evalEntitiesInFrustum(viewFrustum, PickFilter(searchFilter), result);
+                _entityTree->evalEntitiesInFrustum(viewFrustum, PickFilter(filter), result);
             });
         }
     }
@@ -1449,62 +1445,53 @@ QVector<QUuid> EntityScriptingInterface::findEntitiesInFrustum(QVariantMap frust
     return result;
 }
 
-QVector<QUuid> EntityScriptingInterface::findEntitiesByType(const QString entityType, const glm::vec3& center, float radius) const {
+QVector<QUuid> EntityScriptingInterface::findEntitiesByType(const QString entityType, const glm::vec3& center, float radius, uint filter) const {
     EntityTypes::EntityType type = EntityTypes::getEntityTypeFromName(entityType);
 
     QVector<QUuid> result;
     if (_entityTree) {
-        unsigned int searchFilter = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES);
         _entityTree->withReadLock([&] {
-            _entityTree->evalEntitiesInSphereWithType(center, radius, type, PickFilter(searchFilter), result);
+            _entityTree->evalEntitiesInSphereWithType(center, radius, type, PickFilter(filter), result);
         });
     }
     return result;
 }
 
-QVector<QUuid> EntityScriptingInterface::findEntitiesByName(const QString entityName, const glm::vec3& center, float radius, bool caseSensitiveSearch) const {
+QVector<QUuid> EntityScriptingInterface::findEntitiesByName(const QString entityName,
+                                                            const glm::vec3& center,
+                                                            float radius,
+                                                            bool caseSensitiveSearch,
+                                                            uint filter) const {
     QVector<QUuid> result;
     if (_entityTree) {
         _entityTree->withReadLock([&] {
-            unsigned int searchFilter = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES);
-            _entityTree->evalEntitiesInSphereWithName(center, radius, entityName, caseSensitiveSearch, PickFilter(searchFilter), result);
+            _entityTree->evalEntitiesInSphereWithName(center, radius, entityName, caseSensitiveSearch, PickFilter(filter), result);
         });
     }
     return result;
 }
 
-QVector<QUuid> EntityScriptingInterface::findEntitiesByTags(const QVector<QString> entityTags, const glm::vec3& center, float radius, bool caseSensitiveSearch) const {
+QVector<QUuid> EntityScriptingInterface::findEntitiesByTags(const QVector<QString> entityTags,
+                                                            const glm::vec3& center,
+                                                            float radius,
+                                                            bool caseSensitiveSearch,
+                                                            uint filter) const {
     QVector<QUuid> result;
     if (_entityTree) {
         _entityTree->withReadLock([&] {
-            unsigned int searchFilter = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES);
-            _entityTree->evalEntitiesInSphereWithTags(center, radius, entityTags, caseSensitiveSearch, PickFilter(searchFilter), result);
+            _entityTree->evalEntitiesInSphereWithTags(center, radius, entityTags, caseSensitiveSearch, PickFilter(filter), result);
         });
     }
     return result;
 }
 
-RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersection(const PickRay& ray, bool precisionPicking,
-        const ScriptValue& entityIdsToInclude, const ScriptValue& entityIdsToDiscard, bool visibleOnly, bool collidableOnly) const {
+RayToEntityIntersectionResult EntityScriptingInterface::findRayIntersection(const PickRay& ray, uint filter,
+        const ScriptValue& entityIdsToInclude, const ScriptValue& entityIdsToDiscard) const {
     PROFILE_RANGE(script_entities, __FUNCTION__);
     QVector<EntityItemID> entitiesToInclude = qVectorEntityItemIDFromScriptValue(entityIdsToInclude);
     QVector<EntityItemID> entitiesToDiscard = qVectorEntityItemIDFromScriptValue(entityIdsToDiscard);
 
-    unsigned int searchFilter = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES);
-
-    if (!precisionPicking) {
-        searchFilter = searchFilter | PickFilter::getBitMask(PickFilter::FlagBit::COARSE);
-    }
-
-    if (visibleOnly) {
-        searchFilter = searchFilter | PickFilter::getBitMask(PickFilter::FlagBit::VISIBLE);
-    }
-
-    if (collidableOnly) {
-        searchFilter = searchFilter | PickFilter::getBitMask(PickFilter::FlagBit::COLLIDABLE);
-    }
-
-    return evalRayIntersectionWorker(ray, Octree::Lock, PickFilter(searchFilter), entitiesToInclude, entitiesToDiscard);
+    return evalRayIntersectionWorker(ray, Octree::Lock, PickFilter(filter), entitiesToInclude, entitiesToDiscard);
 }
 
 RayToEntityIntersectionResult EntityScriptingInterface::evalRayIntersectionVector(const PickRay& ray, PickFilter searchFilter,

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -766,10 +766,13 @@ public slots:
         const QStringList& params = QStringList());
 
     /*@jsdoc
-     * Finds the domain or avatar entity with a position closest to a specified point and within a specified radius.
+     * Finds the entity with a position closest to a specified point and within a specified radius, according to <code>filter</code>.
      * @function Entities.findClosestEntity
      * @param {Vec3} center - The point about which to search.
      * @param {number} radius - The radius within which to search.
+     * @param {FilterFlags} [filter=Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_COARSE] - The filter
+     *     for this search to use. Construct using {@link Picks} FilterFlags property values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>)
+     *     combined with <code>|</code> (bitwise OR) operators.
      * @returns {Uuid} The ID of the entity that is closest to the <code>center</code> and within the <code>radius</code>, if
      *     there is one, otherwise <code>null</code>.
      * @example <caption>Find the closest entity within 10m of your avatar.</caption>
@@ -777,15 +780,18 @@ public slots:
      * print("Closest entity: " + entityID);
      */
     /// this function will not find any models in script engine contexts which don't have access to models
-    Q_INVOKABLE QUuid findClosestEntity(const glm::vec3& center, float radius) const;
+    Q_INVOKABLE QUuid findClosestEntity(const glm::vec3& center, float radius, uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
-     * Finds all domain and avatar entities that intersect a sphere.
+     * Finds all entities that intersect a sphere, according to <code>filter</code>.
      * <p><strong>Note:</strong> Server entity scripts only find entities that have a server entity script
      * running in them or a parent entity. You can apply a dummy script to entities that you want found in a search.</p>
      * @function Entities.findEntities
      * @param {Vec3} center - The point about which to search.
      * @param {number} radius - The radius within which to search.
+     * @param {FilterFlags} [filter=Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_COARSE] - The filter
+     *     for this search to use. Construct using {@link Picks} FilterFlags property values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>)
+     *     combined with <code>|</code> (bitwise OR) operators.
      * @returns {Uuid[]} An array of entity IDs that intersect the search sphere. The array is empty if no entities could be 
      *     found.
      * @example <caption>Report how many entities are within 10m of your avatar.</caption>
@@ -793,29 +799,38 @@ public slots:
      * print("Number of entities within 10m: " + entityIDs.length);
      */
     /// this function will not find any models in script engine contexts which don't have access to models
-    Q_INVOKABLE QVector<QUuid> findEntities(const glm::vec3& center, float radius) const;
+    Q_INVOKABLE QVector<QUuid> findEntities(const glm::vec3& center,
+                                            float radius, uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
-     * Finds all domain and avatar entities whose axis-aligned boxes intersect a search axis-aligned box.
+     * Finds all entities whose axis-aligned boxes intersect a search axis-aligned box, according to <code>filter</code>.
      * <p><strong>Note:</strong> Server entity scripts only find entities that have a server entity script
      * running in them or a parent entity. You can apply a dummy script to entities that you want found in a search.</p>
      * @function Entities.findEntitiesInBox
      * @param {Vec3} corner - The corner of the search AA box with minimum co-ordinate values.
      * @param {Vec3} dimensions - The dimensions of the search AA box.
+     * @param {FilterFlags} [filter=Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_COARSE] - The filter
+     *     for this search to use. Construct using {@link Picks} FilterFlags property values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>)
+     *     combined with <code>|</code> (bitwise OR) operators.
      * @returns {Uuid[]} An array of entity IDs whose AA boxes intersect the search AA box. The array is empty if no entities
      *     could be found.
      */
     /// this function will not find any models in script engine contexts which don't have access to models
-    Q_INVOKABLE QVector<QUuid> findEntitiesInBox(const glm::vec3& corner, const glm::vec3& dimensions) const;
+    Q_INVOKABLE QVector<QUuid> findEntitiesInBox(const glm::vec3& corner,
+                                                 const glm::vec3& dimensions,
+                                                 uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
-     * Finds all domain and avatar entities whose axis-aligned boxes intersect a search frustum.
+     * Finds all entities whose axis-aligned boxes intersect a search frustum, according to <code>filter</code>.
      * <p><strong>Note:</strong> Server entity scripts only find entities that have a server entity script
      * running in them or a parent entity. You can apply a dummy script to entities that you want found in a search.</p>
      * @function Entities.findEntitiesInFrustum
      * @param {ViewFrustum} frustum - The frustum to search in. The <code>position</code>, <code>orientation</code>, 
      *     <code>projection</code>, and <code>centerRadius</code> properties must be specified. The <code>fieldOfView</code> 
      *     and <code>aspectRatio</code> properties are not used; these values are specified by the <code>projection</code>.
+     * @param {FilterFlags} [filter=Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_COARSE] - The filter
+     *     for this search to use. Construct using {@link Picks} FilterFlags property values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>)
+     *     combined with <code>|</code> (bitwise OR) operators.
      * @returns {Uuid[]} An array of entity IDs whose axis-aligned boxes intersect the search frustum. The array is empty if no 
      *     entities could be found.
      * @example <caption>Report the number of entities in view.</caption>
@@ -823,16 +838,19 @@ public slots:
      * print("Number of entities in view: " + entityIDs.length);
      */
     /// this function will not find any models in script engine contexts which don't have access to entities
-    Q_INVOKABLE QVector<QUuid> findEntitiesInFrustum(QVariantMap frustum) const;
+    Q_INVOKABLE QVector<QUuid> findEntitiesInFrustum(QVariantMap frustum, uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
-     * Finds all domain and avatar entities of a particular type that intersect a sphere.
+     * Finds all entities of a particular type that intersect a sphere, according to <code>filter</code>.
      * <p><strong>Note:</strong> Server entity scripts only find entities that have a server entity script
      * running in them or a parent entity. You can apply a dummy script to entities that you want found in a search.</p>
      * @function Entities.findEntitiesByType
      * @param {Entities.EntityType} entityType - The type of entity to search for.
      * @param {Vec3} center - The point about which to search.
      * @param {number} radius - The radius within which to search.
+     * @param {FilterFlags} [filter=Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_COARSE] - The filter
+     *     for this search to use. Construct using {@link Picks} FilterFlags property values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>)
+     *     combined with <code>|</code> (bitwise OR) operators.
      * @returns {Uuid[]} An array of entity IDs of the specified type that intersect the search sphere. The array is empty if
      *     no entities could be found.
      * @example <caption>Report the number of Model entities within 10m of your avatar.</caption>
@@ -840,10 +858,13 @@ public slots:
      * print("Number of Model entities within 10m: " + entityIDs.length);
      */
     /// this function will not find any entities in script engine contexts which don't have access to entities
-    Q_INVOKABLE QVector<QUuid> findEntitiesByType(const QString entityType, const glm::vec3& center, float radius) const;
+    Q_INVOKABLE QVector<QUuid> findEntitiesByType(const QString entityType,
+                                                  const glm::vec3& center,
+                                                  float radius,
+                                                  uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
-     * Finds all domain and avatar entities with a particular name that intersect a sphere.
+     * Finds all entities with a particular name that intersect a sphere, according to <code>filter</code>.
      * <p><strong>Note:</strong> Server entity scripts only find entities that have a server entity script
      * running in them or a parent entity. You can apply a dummy script to entities that you want found in a search.</p>
      * @function Entities.findEntitiesByName
@@ -852,6 +873,9 @@ public slots:
      * @param {number} radius - The radius within which to search.
      * @param {boolean} [caseSensitive=false] - <code>true</code> if the search is case-sensitive, <code>false</code> if it is 
      *     case-insensitive.
+     * @param {FilterFlags} [filter=Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_COARSE] - The filter
+     *     for this search to use. Construct using {@link Picks} FilterFlags property values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>)
+     *     combined with <code>|</code> (bitwise OR) operators.
      * @returns {Uuid[]} An array of entity IDs that have the specified name and intersect the search sphere. The array is 
      *     empty if no entities could be found.
      * @example <caption>Report the number of entities with the name, "Light-Target".</caption>
@@ -859,10 +883,11 @@ public slots:
      * print("Number of entities with the name Light-Target: " + entityIDs.length);
      */
     Q_INVOKABLE QVector<QUuid> findEntitiesByName(const QString entityName, const glm::vec3& center, float radius,
-        bool caseSensitiveSearch = false) const;
+                                                  bool caseSensitiveSearch = false,
+                                                  uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
-     * Finds all domain and avatar entities with particular tags that intersect a sphere.
+     * Finds all entities with particular tags that intersect a sphere, according to <code>filter</code>.
      * <p><strong>Note:</strong> Server entity scripts only find entities that have a server entity script
      * running in them or a parent entity. You can apply a dummy script to entities that you want found in a search.</p>
      * @function Entities.findEntitiesByTags
@@ -871,6 +896,9 @@ public slots:
      * @param {number} radius - The radius within which to search.
      * @param {boolean} [caseSensitive=false] - <code>true</code> if the search is case-sensitive, <code>false</code> if it is
      *     case-insensitive.
+     * @param {FilterFlags} [filter=Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_COARSE] - The filter
+     *     for this search to use. Construct using {@link Picks} FilterFlags property values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>)
+     *     combined with <code>|</code> (bitwise OR) operators.
      * @returns {Uuid[]} An array of entity IDs that have the specified name and intersect the search sphere. The array is
      *     empty if no entities could be found.
      * @example <caption>Report the number of entities with the tag, "Light-Target".</caption>
@@ -878,26 +906,21 @@ public slots:
      * print("Number of entities with the tag Light-Target: " + entityIDs.length);
      */
     Q_INVOKABLE QVector<QUuid> findEntitiesByTags(const QVector<QString> entityTags, const glm::vec3& center, float radius,
-        bool caseSensitiveSearch = false) const;
+                                                  bool caseSensitiveSearch = false,
+                                                  uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
-     * Finds the first avatar or domain entity intersected by a {@link PickRay}. <code>Light</code> and <code>Zone</code> 
+     * Finds the first entity intersected by a {@link PickRay}, according to <code>filter</code>. <code>Light</code> and <code>Zone</code> 
      * entities are not intersected unless they've been configured as pickable using 
      * {@link Entities.setLightsArePickable|setLightsArePickable} and {@link Entities.setZonesArePickable|setZonesArePickable}, 
      * respectively.
      * @function Entities.findRayIntersection
      * @param {PickRay} pickRay - The pick ray to use for finding entities.
-     * @param {boolean} [precisionPicking=false] - <code>true</code> to pick against precise meshes, <code>false</code> to pick 
-     *     against coarse meshes. If <code>true</code> and the intersected entity is a <code>Model</code> entity, the result's 
-     *     <code>extraInfo</code> property includes more information than it otherwise would.
+     * @param {FilterFlags} [filter=Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_COARSE] - The filter
+     *     for this search to use. Construct using {@link Picks} FilterFlags property values (e.g., <code>Picks.PICK_DOMAIN_ENTITIES</code>)
+     *     combined with <code>|</code> (bitwise OR) operators.
      * @param {Uuid[]} [entitiesToInclude=[]] - If not empty, then the search is restricted to these entities.
      * @param {Uuid[]} [entitiesToDiscard=[]] - Entities to ignore during the search.
-     * @param {boolean} [visibleOnly=false] - <code>true</code> if only entities that are 
-     *     <code>{@link Entities.EntityProperties|visible}</code> are searched for, <code>false</code> if their visibility 
-     *     doesn't matter.
-     * @param {boolean} [collideableOnly=false] - <code>true</code> if only entities that are not 
-     *     <code>{@link Entities.EntityProperties|collisionless}</code> are searched, <code>false</code> if their 
-     *     collideability doesn't matter.
      * @returns {Entities.RayToEntityIntersectionResult} The result of the search for the first intersected entity.
      * @example <caption>Find the entity directly in front of your avatar.</caption>
      * var pickRay = {
@@ -905,7 +928,7 @@ public slots:
      *     direction: Quat.getFront(MyAvatar.orientation)
      * };
      *
-     * var intersection = Entities.findRayIntersection(pickRay, true);
+     * var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
      * if (intersection.intersects) {
      *     print("Entity in front of avatar: " + intersection.entityID);
      * } else {
@@ -915,9 +938,10 @@ public slots:
     /// If the scripting context has visible entities, this will determine a ray intersection, the results
     /// may be inaccurate if the engine is unable to access the visible entities, in which case result.accurate
     /// will be false.
-    Q_INVOKABLE RayToEntityIntersectionResult findRayIntersection(const PickRay& ray, bool precisionPicking = false,
-            const ScriptValue& entityIdsToInclude = ScriptValue(), const ScriptValue& entityIdsToDiscard = ScriptValue(),
-            bool visibleOnly = false, bool collidableOnly = false) const;
+    Q_INVOKABLE RayToEntityIntersectionResult findRayIntersection(const PickRay& ray,
+                                                                  uint filter = ENTITY_PICK_FILTER,
+                                                                  const ScriptValue& entityIdsToInclude = ScriptValue(),
+                                                                  const ScriptValue& entityIdsToDiscard = ScriptValue()) const;
 
     /*@jsdoc
      * Reloads an entity's server entity script such that the latest version re-downloaded.
@@ -2747,6 +2771,11 @@ private:
     bool _bidOnSimulationOwnership { false };
 
     ActivityTracking _activityTracking;
+
+    // By default, we do coarse picking against only domain and avatar entities
+    static const uint ENTITY_PICK_FILTER = PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) |
+                                           PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES) |
+                                           PickFilter::getBitMask(PickFilter::FlagBit::COARSE);
 };
 
 #endif // hifi_EntityScriptingInterface_h

--- a/scripts/developer/automaticLookAt.js
+++ b/scripts/developer/automaticLookAt.js
@@ -672,7 +672,7 @@
                     self.nearAvatarList[id].moved = false;
                     var eyePos = MyAvatar.getDefaultEyePosition();
                     var avatarSight = Vec3.subtract(avatar.headPosition, eyePos);
-                    var intersection = Entities.findRayIntersection({origin: eyePos, direction: Vec3.normalize(avatarSight)}, true);
+                    var intersection = Entities.findRayIntersection({ origin: eyePos, direction: Vec3.normalize(avatarSight) }, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
                     self.nearAvatarList[avatar.id].engaged = !intersection.intersects || intersection.distance > Vec3.length(avatarSight);
                 }
             }

--- a/scripts/developer/tests/controllerTableTest.js
+++ b/scripts/developer/tests/controllerTableTest.js
@@ -257,7 +257,7 @@
         direction: { x: 0, y: -1, z: 0 },
         length: 20
     };
-    var intersection = Entities.findRayIntersection(pickRay, true, [], [], true);
+    var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_INCLUDE_VISIBLE);
 
     if (intersection.intersects) {
         var testBaseTransform = Mat4.createFromRotAndTrans(MyAvatar.rotation, intersection.intersection);

--- a/scripts/developer/tests/performance/rayPickPerformance.js
+++ b/scripts/developer/tests/performance/rayPickPerformance.js
@@ -63,7 +63,7 @@ function rayCastTest() {
                             direction: direction
                         };
 
-                        var pickResults = Entities.findRayIntersection(pickRay, true);
+                        var pickResults = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
 
                         var color;
                         var visible;

--- a/scripts/developer/utilities/render/materialInspector.js
+++ b/scripts/developer/utilities/render/materialInspector.js
@@ -52,8 +52,7 @@ function getHoveredMaterialLocation(event) {
     var id;
     var type = "Entity";
     var avatar = AvatarManager.findRayIntersection(pickRay);
-    var entity = Entities.findRayIntersection(pickRay, true);
-    var overlay = Overlays.findRayIntersection(pickRay, true);
+    var entity = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_LOCAL_ENTITIES);
 
     closest = entity;
     id = entity.entityID;
@@ -62,10 +61,6 @@ function getHoveredMaterialLocation(event) {
         closest = avatar;
         id = avatar.avatarID;
         type = "Avatar";
-    } else if (overlay.intersects && overlay.distance < closest.distance) {
-        closest = overlay;
-        id = overlay.overlayID;
-        type = "Overlay";
     }
 
     if (closest.intersects) {

--- a/scripts/developer/utilities/tests/entityPerfTest.js
+++ b/scripts/developer/utilities/tests/entityPerfTest.js
@@ -81,11 +81,11 @@ function makeEntity () {
     }
     entityTests.addTestCase('findRayIntersection, precisionPicking=true')
         .withRay(function(){
-            Entities.findRayIntersection(this.ray, true);
+            Entities.findRayIntersection(this.ray, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
         })
     entityTests.addTestCase('findRayIntersection, precisionPicking=false')
         .withRay(function(){
-            Entities.findRayIntersection(this.ray, false);
+            Entities.findRayIntersection(this.ray);
         });
     entityTests.addTestCase('no-op')
         .run(function(){});

--- a/scripts/simplifiedUI/clickToZoom/clickToZoom.js
+++ b/scripts/simplifiedUI/clickToZoom/clickToZoom.js
@@ -393,12 +393,12 @@
                     var pickRay = Camera.computePickRay(event.x, event.y);
                     var intersection = AvatarManager.findRayIntersection({origin: pickRay.origin, direction: pickRay.direction}, [], [MyAvatar.sessionUUID], false);
                     if (!intersection.intersects) {
-                        intersection = Entities.findRayIntersection({origin: pickRay.origin, direction: pickRay.direction}, true);
+                        intersection = Entities.findRayIntersection({ origin: pickRay.origin, direction: pickRay.direction }, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
                         var entityProps = Entities.getEntityProperties(intersection.entityID);
                         if (entityProps.type === "Shape") {
                             var FIND_SHAPES_DISTANCE = 10.0;
                             var shapes = Entities.findEntitiesByType("Shape", intersection.intersection, FIND_SHAPES_DISTANCE);
-                            intersection = Entities.findRayIntersection({origin: pickRay.origin, direction: pickRay.direction}, true, [], shapes);
+                            intersection = Entities.findRayIntersection({ origin: pickRay.origin, direction: pickRay.direction }, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES, [], shapes);
                             entityProps = Entities.getEntityProperties(intersection.entityID);
                         }
                         if (!entityProps.dimensions) {

--- a/scripts/simplifiedUI/simplifiedEmote/simplifiedEmote.js
+++ b/scripts/simplifiedUI/simplifiedEmote/simplifiedEmote.js
@@ -313,7 +313,7 @@ function mouseMoveEvent(event) {
 
     var pickRay = Camera.computePickRay(event.x, event.y);
     var avatarIntersectionData = AvatarManager.findRayIntersection(pickRay, [], [MyAvatar.sessionUUID], false);
-    var entityIntersectionData = Entities.findRayIntersection(pickRay, true);
+    var entityIntersectionData = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
     var avatarIntersectionDistanceM = avatarIntersectionData.intersects && avatarIntersectionData.distance < MAX_INTERSECTION_DISTANCE_M ? avatarIntersectionData.distance : null;
     var entityIntersectionDistanceM = entityIntersectionData.intersects && entityIntersectionData.distance < MAX_INTERSECTION_DISTANCE_M ? entityIntersectionData.distance : null;
 

--- a/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/pickRayController.js
+++ b/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/pickRayController.js
@@ -146,12 +146,12 @@ function pickRayTypeHandler(pickRay){
             handleUUID(avatarIntersection.avatarID);
             break;
         case 'local':
-            var overlayIntersection = Overlays.findRayIntersection(pickRay, [], []);
+            var overlayIntersection = Entities.findRayIntersection(pickRay, Picks.PICK_LOCAL_ENTITIES);
             _this.intersection = overlayIntersection;
             handleUUID(overlayIntersection.overlayID);
             break;
         case 'entity':
-            var entityIntersection = Entities.findRayIntersection(pickRay, [], []);
+            var entityIntersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
             _this.intersection = entityIntersection;
             handleUUID(entityIntersection.avatarID);
             break;

--- a/scripts/system/+android_interface/androidControls.js
+++ b/scripts/system/+android_interface/androidControls.js
@@ -25,13 +25,6 @@
     this.touchStartTime = 0;
   }
 
-  AndroidControls.prototype.intersectsOverlay = function (intersection) {
-    if (intersection && intersection.intersects && intersection.overlayID) {
-      return true;
-    }
-    return false;
-  };
-
   AndroidControls.prototype.intersectsEntity = function (intersection) {
     if (intersection && intersection.intersects && intersection.entityID) {
       return true;
@@ -40,15 +33,11 @@
   };
 
   AndroidControls.prototype.findRayIntersection = function (pickRay) {
-    // Check 3D overlays and entities. Argument is an object with origin and direction.
-    var overlayRayIntersection = Overlays.findRayIntersection(pickRay);
-    var entityRayIntersection = Entities.findRayIntersection(pickRay, true);
-    var isOverlayInters = this.intersectsOverlay(overlayRayIntersection);
+    // Check all entities. Argument is an object with origin and direction.
+    var entityRayIntersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_LOCAL_ENTITIES);
     var isEntityInters = this.intersectsEntity(entityRayIntersection);
 
-    if (isOverlayInters && (!isEntityInters || overlayRayIntersection.distance < entityRayIntersection.distance)) {
-      return {type: 'overlay', obj: overlayRayIntersection};
-    } else if (isEntityInters) {
+    if (isEntityInters) {
       return {type: 'entity', obj: entityRayIntersection};
     }
     return false;
@@ -73,9 +62,7 @@
 
     var properties = Entities.getEntityProperties(entityId, DISPATCHER_TOUCH_PROPERTIES);
     if (properties.id === entityId) {
-      pointerEvent.pos2D = info.type === "entity"
-        ? projectOntoEntityXYPlane(entityId, info.obj.intersection, properties)
-        : projectOntoOverlayXYPlane(entityId, info.obj.intersection, properties);
+      pointerEvent.pos2D = projectOntoEntityXYPlane(entityId, info.obj.intersection, properties);
     }
 
     return pointerEvent;
@@ -88,7 +75,7 @@
       return;
     }
 
-    var entityId = info.type === "entity" ? info.obj.entityID : info.obj.overlayID;
+    var entityId = info.obj.entityID;
     var pressEvent = this.createEventProperties(entityId, info, 'Press');
     var releaseEvent = this.createEventProperties(entityId, info, 'Release');
 

--- a/scripts/system/+android_interface/radar.js
+++ b/scripts/system/+android_interface/radar.js
@@ -264,12 +264,8 @@ function findLineToHeightIntersectionCoords(px, py, pz, qx, qy, qz, planeY) {
 }
 
 function findRayIntersection(pickRay) {
-    // Check 3D overlays and entities. Argument is an object with origin and
-    // direction.
-    var result = Overlays.findRayIntersection(pickRay);
-    if (!result.intersects) {
-        result = Entities.findRayIntersection(pickRay, true);
-    }
+    // Check all entities. Argument is an object with origin and direction.
+    var result = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_LOCAL_ENTITIES);
     return result;
 }
 
@@ -518,8 +514,8 @@ function Teleporter() {
             var pickRay = Camera.computePickRay(touchEventPos.x,
                     touchEventPos.y);
             printd("newTeleportDetect - pickRay " + JSON.stringify(pickRay));
-            var destination = Entities.findRayIntersection(pickRay, true, [],
-                    [], false, true);
+            var destination = Entities.findRayIntersection(pickRay,
+                Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_INCLUDE_COLLIDABLE, [], []);
             printd("newTeleportDetect - destination "
                     + JSON.stringify(destination));
             return destination;

--- a/scripts/system/controllers/controllerModules/equipEntity.js
+++ b/scripts/system/controllers/controllerModules/equipEntity.js
@@ -789,7 +789,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
             return;
         }
         var pickRay = Camera.computePickRay(event.x, event.y);
-        var intersection = Entities.findRayIntersection(pickRay, true);
+        var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
         if (intersection.intersects) {
             var entityID = intersection.entityID;
             var entityProperties = Entities.getEntityProperties(entityID, DISPATCHER_PROPERTIES);

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -1321,13 +1321,13 @@
         var pickRay = Camera.computePickRay(event.x, event.y);
         var tabletIDs = getMainTabletIDs();
         if (tabletIDs.length > 0) {
-            var overlayResult = Overlays.findRayIntersection(pickRay, true, tabletIDs);
-            if (overlayResult.intersects) {
+            var tabletResult = Entities.findRayIntersection(pickRay, Picks.PICK_LOCAL_ENTITIES, tabletIDs);
+            if (tabletResult.intersects) {
                 return null;
             }
         }
 
-        var entityResult = Entities.findRayIntersection(pickRay, true); // want precision picking
+        var entityResult = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES); // want precision picking
         var iconResult = entityIconOverlayManager.findRayIntersection(pickRay);
         iconResult.accurate = true;
 

--- a/scripts/system/create/editModes/editVoxels.js
+++ b/scripts/system/create/editModes/editVoxels.js
@@ -337,8 +337,7 @@ EditVoxels = function() {
         continuousStartTimer = 0;
 
         var pickRay = generalComputePickRay(event.x, event.y);
-        var intersection = Entities.findRayIntersection(pickRay, true); // accurate picking
-        var overlaysIntersection = Overlays.findRayIntersection(pickRay, true); // accurate picking
+        var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_LOCAL_ENTITIES); // accurate picking
 
         if (wantDebug) {
             print("Pick ray: " + JSON.stringify(pickRay));
@@ -346,17 +345,6 @@ EditVoxels = function() {
         }
 
         if (intersection.intersects) {
-            if (overlaysIntersection.intersects) {
-                var overlaysIntersectionDistance = Vec3.distance(overlaysIntersection.intersection, pickRay.origin);
-                var intersectionDistance = Vec3.distance(intersection.intersection, pickRay.origin);
-                if (wantDebug) {
-                    print("overlaysIntersectionDistance: " + overlaysIntersectionDistance);
-                    print("intersectionDistance: " + intersectionDistance);
-                }
-                if (overlaysIntersectionDistance < intersectionDistance) {
-                    return;
-                }
-            }
             if (attemptVoxelChangeForEntity(intersection.entityID, pickRay.direction, intersection.intersection)) {
                 Script.update.connect(onUpdateHandler);
                 isOnUpdateConnected = true;

--- a/scripts/system/libraries/controllerDispatcherUtils.js
+++ b/scripts/system/libraries/controllerDispatcherUtils.js
@@ -48,7 +48,6 @@
    controllerDispatcherPluginsNeedSort:true,
    projectOntoXYPlane:true,
    projectOntoEntityXYPlane:true,
-   projectOntoOverlayXYPlane:true,
    makeLaserLockInfo:true,
    entityHasActions:true,
    ensureDynamic:true,
@@ -437,15 +436,6 @@ var projectOntoEntityXYPlane = function (entityID, worldPos, popProps) {
                               popProps.dimensions, popProps.registrationPoint);
 };
 
-var projectOntoOverlayXYPlane = function projectOntoOverlayXYPlane(overlayID, worldPos) {
-    var position = Entities.getEntityProperties(overlayID, ["position"]).position;
-    var rotation = Entities.getEntityProperties(overlayID, ["rotation"]).rotation;
-    var dimensions = Entities.getEntityProperties(overlayID, ["dimensions"]).dimensions;
-    dimensions.z = 0.01; // we are projecting onto the XY plane of the overlay, so ignore the z dimension
-
-    return projectOntoXYPlane(worldPos, position, rotation, dimensions, DEFAULT_REGISTRATION_POINT);
-};
-
 var entityHasActions = function (entityID) {
     return Entities.getActionIDs(entityID).length > 0;
 };
@@ -639,7 +629,6 @@ if (typeof module !== 'undefined') {
         entityIsEquippable: entityIsEquippable,
         entityIsGrabbable: entityIsGrabbable,
         NEAR_GRAB_RADIUS: NEAR_GRAB_RADIUS,
-        projectOntoOverlayXYPlane: projectOntoOverlayXYPlane,
         projectOntoEntityXYPlane: projectOntoEntityXYPlane,
         TRIGGER_OFF_VALUE: TRIGGER_OFF_VALUE,
         TRIGGER_ON_VALUE: TRIGGER_ON_VALUE,

--- a/scripts/system/libraries/touchEventUtils.js
+++ b/scripts/system/libraries/touchEventUtils.js
@@ -129,27 +129,6 @@ function sendTouchMoveEventToTouchTarget(hand, touchTarget) {
     }
 }
 
-function composeTouchTargetFromIntersection(intersection) {
-    var isEntity = (intersection.type === Picks.INTERSECTED_ENTITY);
-    var objectID = intersection.objectID;
-    var worldPos = intersection.intersection;
-    var props = null;
-    if (isEntity) {
-        props = Entities.getProperties(intersection.objectID);
-    }
-
-    var position2D =(isEntity ? controllerDispatcher.projectOntoEntityXYPlane(objectID, worldPos, props) :
-        controllerDispatcher.projectOntoOverlayXYPlane(objectID, worldPos));
-    return {
-        entityID: isEntity ? objectID : null,
-        overlayID: isEntity ? null : objectID,
-        distance: intersection.distance,
-        position: worldPos,
-        position2D: position2D,
-        normal: intersection.surfaceNormal
-    };
-}
-
 // will return undefined if overlayID does not exist.
 function calculateTouchTargetFromOverlay(touchTip, overlayID) {
     var overlayPosition = Entities.getEntityProperties(overlayID, ["position"]).position;
@@ -247,5 +226,4 @@ module.exports = {
     sendTouchStartEventToTouchTarget: sendTouchStartEventToTouchTarget,
     sendTouchEndEventToTouchTarget: sendTouchEndEventToTouchTarget,
     sendTouchMoveEventToTouchTarget: sendTouchMoveEventToTouchTarget,
-    composeTouchTargetFromIntersection: composeTouchTargetFromIntersection
 };

--- a/scripts/system/voxels.js
+++ b/scripts/system/voxels.js
@@ -501,7 +501,7 @@ function mousePressEvent(event) {
     }
 
     var pickRay = Camera.computePickRay(event.x, event.y);
-    var intersection = Entities.findRayIntersection(pickRay, true); // accurate picking
+    var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES); // accurate picking
 
     if (intersection.intersects) {
         if (attemptVoxelChange(pickRay.direction, intersection)) {
@@ -511,7 +511,7 @@ function mousePressEvent(event) {
 
     // if the PolyVox entity is empty, we can't pick against its "on" voxels.  try picking against its
     // bounding box, instead.
-    intersection = Entities.findRayIntersection(pickRay, false); // bounding box picking
+    intersection = Entities.findRayIntersection(pickRay); // bounding box picking
     if (intersection.intersects) {
         attemptVoxelChange(pickRay.direction, intersection);
     }

--- a/scripts/tutorials/entity_scripts/pistol.js
+++ b/scripts/tutorials/entity_scripts/pistol.js
@@ -140,7 +140,7 @@
                 direction: this.firingDirection
             };
             this.createGunFireEffect(this.barrelPoint)
-            var intersection = Entities.findRayIntersection(pickRay, true);
+            var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
             if (intersection.intersects) {
                 this.createEntityHitEffect(intersection.intersection);
                 if (Math.random() < this.playRichochetSoundChance) {

--- a/unpublishedScripts/DomainContent/Home/growingPlant/waterCanEntityScript.js
+++ b/unpublishedScripts/DomainContent/Home/growingPlant/waterCanEntityScript.js
@@ -144,7 +144,7 @@
                 origin: spoutProps.position,
                 direction: direction
             };
-            var intersection = Entities.findRayIntersection(pickRay, true, _this.growableEntities);
+            var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES, _this.growableEntities);
 
             if (intersection.intersects) {
                 //We've intersected with a waterable object

--- a/unpublishedScripts/DomainContent/Home/whiteboard/markerEntityScript.js
+++ b/unpublishedScripts/DomainContent/Home/whiteboard/markerEntityScript.js
@@ -70,7 +70,7 @@
                 origin: backedOrigin,
                 direction: Quat.getFront(markerProps.rotation)
             }
-            var intersection = Entities.findRayIntersection(pickRay, true, _this.whiteboards);
+            var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES, _this.whiteboards);
 
             if (intersection.intersects && Vec3.distance(intersection.intersection, markerProps.position) <= _this.DRAW_ON_BOARD_DISTANCE) {
                 _this.currentWhiteboard = intersection.entityID;

--- a/unpublishedScripts/DomainContent/Toybox/pistol/pistol.js
+++ b/unpublishedScripts/DomainContent/Toybox/pistol/pistol.js
@@ -137,7 +137,7 @@
                 direction: this.firingDirection
             };
             this.createGunFireEffect(this.barrelPoint)
-            var intersection = Entities.findRayIntersection(pickRay, true);
+            var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
             if (intersection.intersects) {
                 this.createEntityHitEffect(intersection.intersection);
                 if (Math.random() < this.playRichochetSoundChance) {

--- a/unpublishedScripts/marketplace/gameTable/games/deckOfCards/deckOfCards.js
+++ b/unpublishedScripts/marketplace/gameTable/games/deckOfCards/deckOfCards.js
@@ -248,7 +248,7 @@
 
             var location = Vec3.sum(rightPickRay.origin, Vec3.multiply(rightPickRay.direction, 50));
 
-            var rightIntersection = Entities.findRayIntersection(rightPickRay, true, [], [this.targetEntity]);
+            var rightIntersection = Entities.findRayIntersection(rightPickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES, [], [this.targetEntity]);
 
             if (rightIntersection.intersects) {
                 this.rightLineOn(rightPickRay.origin, rightIntersection.intersection, COLORS_CAN_PLACE);
@@ -281,7 +281,7 @@
 
             var location = Vec3.sum(MyAvatar.position, Vec3.multiply(leftPickRay.direction, 50));
 
-            var leftIntersection = Entities.findRayIntersection(leftPickRay, true, [], [this.targetEntity]);
+            var leftIntersection = Entities.findRayIntersection(leftPickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES, [], [this.targetEntity]);
 
             if (leftIntersection.intersects) {
                 this.leftLineOn(leftPickRay.origin, leftIntersection.intersection, COLORS_CAN_PLACE);

--- a/unpublishedScripts/marketplace/laser/laserPointerApp.js
+++ b/unpublishedScripts/marketplace/laser/laserPointerApp.js
@@ -67,7 +67,7 @@
             pickRay.direction = MyAvatar.jointToWorldDirection(Vec3.UP, MyAvatar.getJointIndex(jointName));
         }
 
-        var ray = Entities.findRayIntersection(pickRay, true, [], rayExclusionList, true);
+        var ray = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES | Picks.PICK_INCLUDE_VISIBLE, [], rayExclusionList);
         var avatarRay = AvatarManager.findRayIntersection(pickRay, true, [], rayExclusionList, true);
 
         var dist = PICK_MAX_DISTANCE;

--- a/unpublishedScripts/marketplace/shortbow/utils.js
+++ b/unpublishedScripts/marketplace/shortbow/utils.js
@@ -48,7 +48,7 @@ utils = {
         var result = Entities.findRayIntersection({
             origin: pos,
             direction: { x: 0.0, y: -1.0, z: 0.0 }
-        }, true);
+        }, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
         if (result.intersects) {
             return result.intersection;
         }

--- a/unpublishedScripts/marketplace/xylophone/xylophoneRezzer.js
+++ b/unpublishedScripts/marketplace/xylophone/xylophoneRezzer.js
@@ -64,7 +64,7 @@ for (var i = 1; i <= SOUND_FILES.length; i++) {
 
 // if rezzed on/above something, wait until after model has loaded so you can read its dimensions then move object on to that surface.
 var pickRay = {origin: center, direction: {x: 0, y: -1, z: 0}};
-var intersection = Entities.findRayIntersection(pickRay, true);
+var intersection = Entities.findRayIntersection(pickRay, Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES);
 if (intersection.intersects && (intersection.distance < 10)) {
     var surfaceY = intersection.intersection.y;
     Script.setTimeout( function() {


### PR DESCRIPTION
adds an optional new parameter to Entities.findClosestEntity, Entities.findEntities, Entities.findEntitiesInBox, Entities.findEntitiesInFrustum, Entities.findEntitiesByType, Entities.findEntitiesByName, Entities.findEntitiesByTags, and Entities.findRayIntersection which lets you precisely control the search filters, including allowing the methods to all work with local entities

for all but Entities.findRayIntersection, this is a non-breaking change.  but findRayIntersection already had some parameters for this, so I've had to modify them.  I've updated all of the built in scripts, but this could break other uses.  do we think that's ok?  I think it's worth it to finally get everything on the new API