### PR TITLE
Don't disable OpenGL 4.5 on all Intel graphics.

### DIFF
--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -236,14 +236,6 @@ uint16_t gl::getAvailableVersion() {
         }
         gl::initModuleGl();
 
-        std::string glvendor{ (const char*)glGetString(GL_VENDOR) };
-        std::transform(glvendor.begin(), glvendor.end(), glvendor.begin(), ::tolower); 
-
-        // Intel has *notoriously* buggy DSA implementations, especially around cubemaps
-        if (std::string::npos != glvendor.find("intel")) {
-            gl::setDisableGl45(true);
-        }
-
         wglMakeCurrent(0, 0);
         hGLRC.reset();
         if (!wglChoosePixelFormatARB || !wglCreateContextAttribsARB) {


### PR DESCRIPTION
Fixes: https://github.com/overte-org/overte/issues/1593

Funny enough, the GL_VENDOR is actually `Intel` and not `intel`, which our Windows builds didn't care about for some reason. So seemingly the only reason this didn't break anything on Linux is that the case was wrong.

As the OpenGL 4.1 backend is currently broken and so far it sounds like nobody wants to fix it, I don't think this needs QA outside of my testing.