### PR TITLE
Cherrypick warning fixes

### DIFF
--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -425,7 +425,7 @@ void Stats::updateStats(bool force) {
     gpu::ContextStats gpuFrameStats;
     gpuContext->getFrameStats(gpuFrameStats);
 
-    STAT_UPDATE(drawcalls, gpuFrameStats._DSNumDrawcalls);
+    STAT_UPDATE(drawcalls, (quint32)gpuFrameStats._DSNumDrawcalls);
     STAT_UPDATE(lodTargetFramerate, DependencyManager::get<LODManager>()->getLODTargetFPS());
     STAT_UPDATE(lodAngle, DependencyManager::get<LODManager>()->getLODAngleDeg());
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
@@ -50,7 +50,10 @@ void GLBackend::do_setProjectionJitterSequence(const Batch& batch, size_t paramO
     auto& projectionJitter = _transform._projectionJitter;
     projectionJitter._offsetSequence.resize(count);
     if (count) {
-        memcpy(projectionJitter._offsetSequence.data(), batch.readData(batch._params[paramOffset + 1]._uint), sizeof(Vec2) * count);
+        const Vec2* data = (Vec2 *)batch.readData(batch._params[paramOffset + 1]._uint);
+        for (uint32 i = 0; i < count; i++) {
+            projectionJitter._offsetSequence[i] = data[i];
+        }
         projectionJitter._offset = projectionJitter._offsetSequence[projectionJitter._currentSampleIndex  % count];
     } else {
         projectionJitter._offset = Vec2(0.0f);

--- a/libraries/gpu/src/gpu/Buffer.h
+++ b/libraries/gpu/src/gpu/Buffer.h
@@ -198,9 +198,13 @@ public:
 
     //Template iterator with random access on the buffer sysmem
     template<typename T>
-    class Iterator : public std::iterator<std::random_access_iterator_tag, T, Index, T*, T&>
-    {
+    class Iterator {
     public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = T;
+        using difference_type = Index;
+        using pointer = const value_type*;
+        using reference = const value_type&;
 
         Iterator(T* ptr = NULL, int stride = sizeof(T)): _ptr(ptr), _stride(stride) { }
         Iterator(const Iterator<T>& iterator) = default;


### PR DESCRIPTION
This PR cherry-picks some warning fixes from protocol-changes.

At least the `libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp` warning spam gets fixed by this.

Smoke-testing yielded no issues, and I couldn't find any new warnings in our warning flood.