### PR TITLE
Move to Visual Studio 2022.

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             build_type: full
             qt_source: aqt
           #- os: macOS-10.15
@@ -92,7 +92,7 @@ jobs:
           echo "CONAN_PROFILE=default" >> $GITHUB_ENV
         fi
         # Windows build variables
-        if [ "${{ matrix.os }}" = "windows-2019" ]; then
+        if [ "${{ matrix.os }}" = "windows-2022" ]; then
           echo "CONAN_CPPSTD=17" >> $GITHUB_ENV
           echo "PYTHON_EXEC=python" >> $GITHUB_ENV
           echo "ZIP_COMMAND=7z" >> $GITHUB_ENV
@@ -103,8 +103,8 @@ jobs:
           echo "symbols_archive=${BUILD_NUMBER}-${{ matrix.build_type }}-win-symbols.zip" >> $GITHUB_ENV
           # echo "HF_PFX_PASSPHRASE=${{secrets.pfx_key}}" >> $GITHUB_ENV
           # echo "HF_PFX_FILE=${{runner.workspace}}\build\codesign.pfx" >> $GITHUB_ENV
-          if [[ "${{ matrix.os }}" = "windows-2019" ]]; then
-            echo "CONAN_PROFILE='./tools/conan-profiles/vs-19-release'" >> $GITHUB_ENV
+          if [[ "${{ matrix.os }}" = "windows-2022" ]]; then
+            echo "CONAN_PROFILE='./tools/conan-profiles/vs-22-release'" >> $GITHUB_ENV
           else
             echo "Not sure which Conan profile to use. Exiting." && exit 1
           fi

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -51,8 +51,8 @@ jobs:
     strategy:
         matrix:
           include:
-            - os: Windows 2019
-              runner: windows-2019
+            - os: Windows 2022
+              runner: windows-2022
               arch: x86_64
               build_type: full
               qt_source: aqt
@@ -140,8 +140,8 @@ jobs:
           else
             echo "CMAKE_EXTRA=-A x64 -DJSDOC_ENABLED:BOOL=TRUE -DCLIENT_ONLY=1" >> $GITHUB_ENV
           fi
-          if [[ "${{ matrix.runner }}" = "windows-2019" ]]; then
-            echo "CONAN_PROFILE='./tools/conan-profiles/vs-19-release'" >> $GITHUB_ENV
+          if [[ "${{ matrix.runner }}" = "windows-2022" ]]; then
+            echo "CONAN_PROFILE='./tools/conan-profiles/vs-22-release'" >> $GITHUB_ENV
           else
             echo "Not sure which Conan profile to use. Exiting." && exit 1
           fi

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             build_type: full
             qt_source: aqt
       fail-fast: false
@@ -72,8 +72,8 @@ jobs:
         echo "SYMBOLS_ARCHIVE=$RELEASE_NUMBER-${{ github.sha }}-win-symbols.zip" >> $GITHUB_ENV
         # echo "HF_PFX_PASSPHRASE=${{secrets.pfx_key}}" >> $GITHUB_ENV
         # echo "HF_PFX_FILE=${{runner.workspace}}\build\codesign.pfx" >> $GITHUB_ENV
-        if [[ "${{ matrix.os }}" = "windows-2019" ]]; then
-          echo "CONAN_PROFILE='./tools/conan-profiles/vs-19-release'" >> $GITHUB_ENV
+        if [[ "${{ matrix.os }}" = "windows-2022" ]]; then
+          echo "CONAN_PROFILE='./tools/conan-profiles/vs-22-release'" >> $GITHUB_ENV
         else
           echo "Not sure which Conan profile to use. Exiting." && exit 1
         fi

--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -7,24 +7,24 @@ SPDX-License-Identifier: Apache-2.0
 
 # Build Windows
 
-*Last Updated on 2025-03-17*
+*Last Updated on 2025-06-09*
 
 This is a stand-alone guide for creating your first Overte build for Windows 64-bit.
 
-Note: We are now using Visual Studio 2019 and Qt 5.15.x.
+Note: We are now using Visual Studio 2022 and Qt 5.15.x.
 If you are upgrading from previous versions, do a clean uninstall of those versions before going through this guide.
 
 **Note: The prerequisites will require about 10 GB of space on your drive. You will also need a system with at least 8GB of main memory.**
 
 ## Step 1. Visual Studio & Python 3.x
 
-If you don't have Community or Professional edition of Visual Studio 2019, download [Visual Studio Community 2019](https://visualstudio.microsoft.com/vs/). If you have Visual Studio 2017, you need to download Visual Studio 2019.
+If you don't have Community or Professional edition of Visual Studio 2022, download [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/). While Visual Studio 2019 should still work, we don't support it anymore and might remove workarounds specific to it in the future.
 
 When selecting components, check "Desktop development with C++".
 
 If you do not already have a Python 3.x development environment installed and want to install it with Visual Studio, check "Python Development". If you already have Visual Studio installed and need to add Python, open the "Add or remove programs" control panel and find the "Microsoft Visual Studio Installer". Select it and click "Modify". In the installer, select "Modify" again, then check "Python Development" and allow the installer to apply the changes.
 
-### Visual Studio 2019
+### Visual Studio 2022
 
 On the right on the Summary toolbar, select the following components.
 
@@ -78,13 +78,13 @@ To create this variable:
 
 ## Step 7. Running CMake to Generate Build Files
 
-These instructions only apply to Visual Studio 2019.
+These instructions only apply to Visual Studio 2022.
 
 ### Automatic
 
 There is a batch file to automatically run the commands below for ease of use.
 
-`winprepareVS19.bat`
+`winprepareVS22.bat`
 
 ### Manual
 
@@ -92,8 +92,8 @@ Run the Command Prompt from Start and run the following commands:
 
 ```bash
 cd "%OVERTE_DIR%"
-conan install . -b missing -pr=tools/conan-profiles/vs-19-release -of build
-conan install . -b missing -pr=tools/conan-profiles/vs-19-debug -of build
+conan install . -b missing -pr=tools/conan-profiles/vs-22-release -of build
+conan install . -b missing -pr=tools/conan-profiles/vs-22-debug -of build
 cmake --preset conan-default
 ```
 


### PR DESCRIPTION
GitHub is sunsetting their windows-2019 runners, which is probably a good time for switching to Visual Studio 2022 across the board.

As far as I know, this does break our Oculus runtime support; I believe we deactivated it on Visual Studio 2022 because it didn't build on there and Oculus runtime is replaced by OpenXR (and potentially OpenVR even) anyway.