### PR TITLE
API function to export all loaded world entities as-is

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -497,6 +497,7 @@ public slots:
     bool exportEntities(const QString& filename, const QVector<QUuid>& entityIDs, const glm::vec3* givenOffset = nullptr);
     bool exportEntities(const QString& filename, float x, float y, float z, float scale);
     bool importEntities(const QString& url, const bool isObservable = true, const qint64 callerId = -1);
+    bool exportWorldEntities(const QString& filename, const QVector<QString>& propertiesToPrune = QVector<QString>());
 
     void setKeyboardFocusHighlight(const glm::vec3& position, const glm::quat& rotation, const glm::vec3& dimensions);
     QUuid getKeyboardFocusEntity() const { return _keyboardFocusedEntity.get(); }  // thread-safe

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -494,10 +494,9 @@ public slots:
 
     // Entities
     QVector<EntityItemID> pasteEntities(const QString& entityHostType, float x, float y, float z);
-    bool exportEntities(const QString& filename, const QVector<QUuid>& entityIDs, const glm::vec3* givenOffset = nullptr);
-    bool exportEntities(const QString& filename, float x, float y, float z, float scale);
+    bool exportEntities(const QString& filename, const QVector<QUuid>& entityIDs, const glm::vec3* givenOffset = nullptr, const QVariantMap& options = QVariantMap());
+    bool exportEntities(const QString& filename, float x, float y, float z, float scale, const QVariantMap& options = QVariantMap());
     bool importEntities(const QString& url, const bool isObservable = true, const qint64 callerId = -1);
-    bool exportWorldEntities(const QString& filename, const QVector<QString>& propertiesToPrune = QVector<QString>());
 
     void setKeyboardFocusHighlight(const glm::vec3& position, const glm::quat& rotation, const glm::vec3& dimensions);
     QUuid getKeyboardFocusEntity() const { return _keyboardFocusedEntity.get(); }  // thread-safe

--- a/interface/src/Application_Entities.cpp
+++ b/interface/src/Application_Entities.cpp
@@ -46,19 +46,12 @@ bool Application::exportEntities(const QString& filename,
                                  const glm::vec3* givenOffset,
                                  const QVariantMap& options) {
     QVector<QString> propertiesToPrune = {
-        "queryAACube", "age", "created", "lastEdited", "lastEditedBy",
-        "faceCamera", "isFacingAvatar",
+        "queryAACube", "age", "created", "lastEdited", "lastEditedBy", "faceCamera",
+        "isFacingAvatar", "clientOnly", "avatarEntity", "localEntity",
     };
 
-    bool domainOnly = options.value("domainOnly", false).toBool();
     bool globalPositions = options.value("globalPositions", false).toBool();
     auto paths = options.value("paths", QVariantMap()).toMap();
-
-    if (domainOnly) {
-        propertiesToPrune.push_back("clientOnly");
-        propertiesToPrune.push_back("avatarEntity");
-        propertiesToPrune.push_back("localEntity");
-    }
 
     QHash<EntityItemID, EntityItemPointer> entities;
 
@@ -71,15 +64,13 @@ bool Application::exportEntities(const QString& filename,
     exportTree->createRootElement();
     glm::vec3 root(TREE_SCALE, TREE_SCALE, TREE_SCALE);
     bool success = true;
-    entityTree->withReadLock([entityIDs, entityTree, givenOffset, myAvatarID, &root, &entities, &success, &exportTree, domainOnly, globalPositions] {
+    entityTree->withReadLock([entityIDs, entityTree, givenOffset, myAvatarID, &root, &entities, &success, &exportTree, globalPositions] {
         for (auto entityID : entityIDs) { // Gather entities and properties.
             auto entityItem = entityTree->findEntityByEntityItemID(entityID);
             if (!entityItem) {
                 qCWarning(interfaceapp) << "Skipping export of" << entityID << "that is not in scene.";
                 continue;
             }
-
-            if (domainOnly && !entityItem->isDomainEntity()) { continue; }
 
             if (!givenOffset && !globalPositions) {
                 EntityItemID parentID = entityItem->getParentID();

--- a/interface/src/Application_Entities.cpp
+++ b/interface/src/Application_Entities.cpp
@@ -43,7 +43,23 @@ QVector<EntityItemID> Application::pasteEntities(const QString& entityHostType, 
 
 bool Application::exportEntities(const QString& filename,
                                  const QVector<QUuid>& entityIDs,
-                                 const glm::vec3* givenOffset) {
+                                 const glm::vec3* givenOffset,
+                                 const QVariantMap& options) {
+    QVector<QString> propertiesToPrune = {
+        "queryAACube", "age", "created", "lastEdited", "lastEditedBy",
+        "faceCamera", "isFacingAvatar",
+    };
+
+    bool domainOnly = options.value("domainOnly", false).toBool();
+    bool globalPositions = options.value("globalPositions", false).toBool();
+    auto paths = options.value("paths", QVariantMap()).toMap();
+
+    if (domainOnly) {
+        propertiesToPrune.push_back("clientOnly");
+        propertiesToPrune.push_back("avatarEntity");
+        propertiesToPrune.push_back("localEntity");
+    }
+
     QHash<EntityItemID, EntityItemPointer> entities;
 
     auto nodeList = DependencyManager::get<NodeList>();
@@ -55,7 +71,7 @@ bool Application::exportEntities(const QString& filename,
     exportTree->createRootElement();
     glm::vec3 root(TREE_SCALE, TREE_SCALE, TREE_SCALE);
     bool success = true;
-    entityTree->withReadLock([entityIDs, entityTree, givenOffset, myAvatarID, &root, &entities, &success, &exportTree] {
+    entityTree->withReadLock([entityIDs, entityTree, givenOffset, myAvatarID, &root, &entities, &success, &exportTree, domainOnly, globalPositions] {
         for (auto entityID : entityIDs) { // Gather entities and properties.
             auto entityItem = entityTree->findEntityByEntityItemID(entityID);
             if (!entityItem) {
@@ -63,7 +79,9 @@ bool Application::exportEntities(const QString& filename,
                 continue;
             }
 
-            if (!givenOffset) {
+            if (domainOnly && !entityItem->isDomainEntity()) { continue; }
+
+            if (!givenOffset && !globalPositions) {
                 EntityItemID parentID = entityItem->getParentID();
                 bool parentIsAvatar = (parentID == AVATAR_SELF_ID || parentID == myAvatarID);
                 if (!parentIsAvatar && (parentID.isInvalidID() ||
@@ -76,6 +94,7 @@ bool Application::exportEntities(const QString& filename,
                     root.z = glm::min(root.z, position.z);
                 }
             }
+
             entities[entityID] = entityItem;
         }
 
@@ -84,9 +103,12 @@ bool Application::exportEntities(const QString& filename,
             return;
         }
 
-        if (givenOffset) {
+        if (globalPositions) {
+            root = {0.0f, 0.0f, 0.0f};
+        } else if (givenOffset) {
             root = *givenOffset;
         }
+
         for (EntityItemPointer& entityDatum : entities) {
             auto properties = entityDatum->getProperties();
             EntityItemID parentID = properties.getParentID();
@@ -103,18 +125,82 @@ bool Application::exportEntities(const QString& filename,
             exportTree->addEntity(entityDatum->getEntityItemID(), properties);
         }
     });
+
     if (success) {
-        success = exportTree->writeToJSONFile(filename.toLocal8Bit().constData());
+        QJsonDocument jsonDocument;
+        bool success = exportTree->toJSONDocument(&jsonDocument);
+
+        if (!success) { return false; }
+
+        auto object = jsonDocument.object();
+
+        if (propertiesToPrune.size() != 0) {
+            auto entityList = object["Entities"].toArray();
+
+            for (int i = 0; i < entityList.size(); i++) {
+                auto entity = entityList[i].toObject();
+
+                for (auto property : propertiesToPrune) {
+                    entity.remove(property);
+                }
+
+                entityList[i] = entity;
+            }
+
+            // these have to be re-assigned rather than modified by reference
+            // because it looks like Qt only gives us copies
+            object["Entities"] = entityList;
+        }
+
+        if (!paths.isEmpty()) {
+            QJsonObject pathsObject;
+
+            foreach (const QString& key, paths.keys()) {
+                auto object = paths.value(key).toMap();
+                auto position = object.value("position").toMap();
+                auto orientation = object.value("orientation").toMap();
+
+                pathsObject[key] = QString("/%1,%2,%3/%4,%5,%6,%7")
+                    .arg(position["x"].toDouble())
+                    .arg(position["y"].toDouble())
+                    .arg(position["z"].toDouble())
+                    .arg(orientation["x"].toDouble())
+                    .arg(orientation["y"].toDouble())
+                    .arg(orientation["z"].toDouble())
+                    .arg(orientation["w"].toDouble());
+            }
+
+            object["Paths"] = pathsObject;
+        }
+
+        // weirdly QJsonDocument::object returns a copy and not a reference
+        jsonDocument.setObject(object);
+
+        // Octree::writeToJSONFile
+        QSaveFile persistFile(filename);
+        if (persistFile.open(QIODevice::WriteOnly)) {
+            if (persistFile.write(jsonDocument.toJson()) != -1) {
+                success = persistFile.commit();
+                if (!success) {
+                    qCritical() << "Failed to commit to JSON save file:" << persistFile.errorString();
+                }
+            } else {
+                qCritical("Failed to write to JSON file.");
+            }
+        } else {
+            qCritical("Failed to open JSON file for writing.");
+        }
 
         // restore the main window's active state
 #ifdef USE_GL
         _window->activateWindow(); //VKTODO
 #endif
     }
+
     return success;
 }
 
-bool Application::exportEntities(const QString& filename, float x, float y, float z, float scale) {
+bool Application::exportEntities(const QString& filename, float x, float y, float z, float scale, const QVariantMap& options) {
     glm::vec3 center(x, y, z);
     glm::vec3 minCorner = center - vec3(scale);
     float cubeSize = scale * 2;
@@ -124,109 +210,7 @@ bool Application::exportEntities(const QString& filename, float x, float y, floa
     entityTree->withReadLock([&] {
         entityTree->evalEntitiesInCube(boundingCube, PickFilter(), entities);
     });
-    return exportEntities(filename, entities, &center);
-}
-
-bool Application::exportWorldEntities(const QString& filename, const QVector<QString>& propertiesToPrune) {
-    auto nodeList = DependencyManager::get<NodeList>();
-
-    // only allow exporting if the user has edit, private userdata, and asset URL permissions
-    bool allowed = nodeList->isAllowedEditor() && nodeList->getThisNodeCanGetAndSetPrivateUserData() && nodeList->getThisNodeCanViewAssetURLs();
-
-    if (!allowed) { return false; }
-
-    qCDebug(interfaceapp) << "Starting world export";
-
-    auto entityTree = getEntities()->getTree();
-    auto exportTree = std::make_shared<EntityTree>();
-    exportTree->setMyAvatar(getMyAvatar());
-    exportTree->createRootElement();
-
-    entityTree->withReadLock([entityTree, &exportTree] {
-        // there's no tree iterator and no "eval all" operator, so use an infinite box
-        const vec3 vec3_inf(FLT_MAX, FLT_MAX, FLT_MAX);
-
-        QVector<QUuid> entityIDs;
-        entityTree->evalEntitiesInCube(
-            AACube(Extents(-vec3_inf, vec3_inf)),
-            PickFilter::Flags(PickFilter::getBitMask(PickFilter::DOMAIN_ENTITIES)),
-            entityIDs
-        );
-
-        for (auto entityID : entityIDs) {
-            auto entityItem = entityTree->findEntityByEntityItemID(entityID);
-
-            exportTree->addEntity(entityID, entityItem->getProperties());
-        }
-    });
-
-    QJsonDocument jsonDocument;
-    bool success = exportTree->toJSONDocument(&jsonDocument);
-
-    if (!success) { return false; }
-
-    auto position = getMyAvatar()->getWorldFeetPosition();
-    auto rotation = getMyAvatar()->getWorldOrientation();
-
-    auto object = jsonDocument.object();
-
-    if (propertiesToPrune.size() != 0) {
-        auto entityList = object["Entities"].toArray();
-
-        for (int i = 0; i < entityList.size(); i++) {
-            auto entity = entityList[i].toObject();
-
-            for (auto property : propertiesToPrune) {
-                entity.remove(property);
-            }
-
-            entityList[i] = entity;
-        }
-
-        // these have to be re-assigned rather than modified by reference
-        // because it looks like Qt only gives us copies
-        object["Entities"] = entityList;
-    }
-
-    // set the "/" path to the avatar's current position
-    object["Paths"] = QJsonObject {
-        {
-            "/",
-            QString("/%1,%2,%3/%4,%5,%6,%7")
-            .arg(position[0])
-            .arg(position[1])
-            .arg(position[2])
-            .arg(rotation[0])
-            .arg(rotation[1])
-            .arg(rotation[2])
-            .arg(rotation[3])
-        }
-    };
-
-    // weirdly QJsonDocument::object returns a copy and not a reference
-    jsonDocument.setObject(object);
-
-    // Octree::writeToJSONFile
-    QSaveFile persistFile(filename);
-    if (persistFile.open(QIODevice::WriteOnly)) {
-        if (persistFile.write(jsonDocument.toJson()) != -1) {
-            success = persistFile.commit();
-            if (!success) {
-                qCritical() << "Failed to commit to JSON save file:" << persistFile.errorString();
-            }
-        } else {
-            qCritical("Failed to write to JSON file.");
-        }
-    } else {
-        qCritical("Failed to open JSON file for writing.");
-    }
-
-    qCDebug(interfaceapp) << "World export done";
-
-    // restore the main window's active state
-    _window->activateWindow();
-
-    return success;
+    return exportEntities(filename, entities, &center, options);
 }
 
 bool Application::importEntities(const QString& urlOrFilename, const bool isObservable, const qint64 callerId) {

--- a/interface/src/Application_Entities.cpp
+++ b/interface/src/Application_Entities.cpp
@@ -21,6 +21,7 @@
 #include <recording/ClipCache.h>
 #include <RenderableEntityItem.h>
 #include <SoundCache.h>
+#include <QSaveFile>
 
 #include "InterfaceLogging.h"
 #include "LODManager.h"
@@ -124,6 +125,107 @@ bool Application::exportEntities(const QString& filename, float x, float y, floa
         entityTree->evalEntitiesInCube(boundingCube, PickFilter(), entities);
     });
     return exportEntities(filename, entities, &center);
+}
+
+bool Application::exportWorldEntities(const QString& filename, const QVector<QString>& propertiesToPrune) {
+    auto nodeList = DependencyManager::get<NodeList>();
+
+    // only allow exporting if the user has edit, private userdata, and asset URL permissions
+    bool allowed = nodeList->isAllowedEditor() && nodeList->getThisNodeCanGetAndSetPrivateUserData() && nodeList->getThisNodeCanViewAssetURLs();
+
+    if (!allowed) { return false; }
+
+    qCDebug(interfaceapp) << "Starting world export";
+
+    auto entityTree = getEntities()->getTree();
+    auto exportTree = std::make_shared<EntityTree>();
+    exportTree->setMyAvatar(getMyAvatar());
+    exportTree->createRootElement();
+
+    entityTree->withReadLock([entityTree, &exportTree] {
+        // there's no tree iterator and no "eval all" operator, so use an infinite box
+        const vec3 vec3_inf(FLT_MAX, FLT_MAX, FLT_MAX);
+
+        QVector<QUuid> entityIDs;
+        entityTree->evalEntitiesInCube(AACube(Extents(-vec3_inf, vec3_inf)), PickFilter(), entityIDs);
+
+        for (auto entityID : entityIDs) {
+            auto entityItem = entityTree->findEntityByEntityItemID(entityID);
+
+            // only export domain entities
+            if (!entityItem->isDomainEntity()) { continue; }
+
+            exportTree->addEntity(entityID, entityItem->getProperties());
+        }
+    });
+
+    QJsonDocument jsonDocument;
+    bool success = exportTree->toJSONDocument(&jsonDocument);
+
+    if (!success) { return false; }
+
+    auto position = getMyAvatar()->getWorldFeetPosition();
+    auto rotation = getMyAvatar()->getWorldOrientation();
+
+    auto object = jsonDocument.object();
+
+    if (propertiesToPrune.size() != 0) {
+        auto entityList = object["Entities"].toArray();
+
+        for (int i = 0; i < entityList.size(); i++) {
+            auto entity = entityList[i].toObject();
+
+            for (auto property : propertiesToPrune) {
+                entity.remove(property);
+            }
+
+            entityList[i] = entity;
+        }
+
+        // these have to be re-assigned rather than modified by reference
+        // because it looks like Qt only gives us copies
+        object["Entities"] = entityList;
+    }
+
+    // set the "/" path to the avatar's current position
+    object["Paths"] = QJsonObject {
+        {
+            "/",
+            QString("/%1,%2,%3/%4,%5,%6,%7")
+            .arg(position[0])
+            .arg(position[1])
+            .arg(position[2])
+            .arg(rotation[0])
+            .arg(rotation[1])
+            .arg(rotation[2])
+            .arg(rotation[3])
+        }
+    };
+
+    // weirdly QJsonDocument::object returns a copy and not a reference
+    jsonDocument.setObject(object);
+
+    // Octree::writeToJSONFile
+    QSaveFile persistFile(filename);
+    if (persistFile.open(QIODevice::WriteOnly)) {
+        if (persistFile.write(jsonDocument.toJson()) != -1) {
+            success = persistFile.commit();
+            if (!success) {
+                qCritical() << "Failed to commit to JSON save file:" << persistFile.errorString();
+            }
+        } else {
+            qCritical("Failed to write to JSON file.");
+        }
+    } else {
+        qCritical("Failed to open JSON file for writing.");
+    }
+
+    qCDebug(interfaceapp) << "World export done";
+
+    // restore the main window's active state
+    _window->activateWindow();
+
+    return success;
 }
 
 bool Application::importEntities(const QString& urlOrFilename, const bool isObservable, const qint64 callerId) {

--- a/interface/src/Application_Entities.cpp
+++ b/interface/src/Application_Entities.cpp
@@ -147,13 +147,14 @@ bool Application::exportWorldEntities(const QString& filename, const QVector<QSt
         const vec3 vec3_inf(FLT_MAX, FLT_MAX, FLT_MAX);
 
         QVector<QUuid> entityIDs;
-        entityTree->evalEntitiesInCube(AACube(Extents(-vec3_inf, vec3_inf)), PickFilter(), entityIDs);
+        entityTree->evalEntitiesInCube(
+            AACube(Extents(-vec3_inf, vec3_inf)),
+            PickFilter::Flags(PickFilter::getBitMask(PickFilter::DOMAIN_ENTITIES)),
+            entityIDs
+        );
 
         for (auto entityID : entityIDs) {
             auto entityItem = entityTree->findEntityByEntityItemID(entityID);
-
-            // only export domain entities
-            if (!entityItem->isDomainEntity()) { continue; }
 
             exportTree->addEntity(entityID, entityItem->getProperties());
         }

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -25,16 +25,18 @@ float ClipboardScriptingInterface::getClipboardContentsLargestDimension() {
     return qApp->getEntityClipboard()->getContentsLargestDimension();
 }
 
-bool ClipboardScriptingInterface::exportEntities(const QString& filename, const QVector<QUuid>& entityIDs) {
+bool ClipboardScriptingInterface::exportEntities(const QString& filename, const QVector<QUuid>& entityIDs, const QVariantMap& options) {
     bool retVal;
     BLOCKING_INVOKE_METHOD(qApp, "exportEntities",
                               Q_RETURN_ARG(bool, retVal),
                               Q_ARG(const QString&, filename),
-                              Q_ARG(const QVector<QUuid>&, entityIDs));
+                              Q_ARG(const QVector<QUuid>&, entityIDs),
+                              Q_ARG(const glm::vec3*, nullptr),
+                              Q_ARG(const QVariantMap&, options));
     return retVal;
 }
 
-bool ClipboardScriptingInterface::exportEntities(const QString& filename, float x, float y, float z, float scale) {
+bool ClipboardScriptingInterface::exportEntities(const QString& filename, float x, float y, float z, float scale, const QVariantMap& options) {
     bool retVal;
     BLOCKING_INVOKE_METHOD(qApp, "exportEntities",
                               Q_RETURN_ARG(bool, retVal),
@@ -42,16 +44,8 @@ bool ClipboardScriptingInterface::exportEntities(const QString& filename, float 
                               Q_ARG(float, x),
                               Q_ARG(float, y),
                               Q_ARG(float, z),
-                              Q_ARG(float, scale));
-    return retVal;
-}
-
-bool ClipboardScriptingInterface::exportWorldEntities(const QString& filename, const QVector<QString>& propertiesToPrune) {
-    bool retVal;
-    BLOCKING_INVOKE_METHOD(qApp, "exportWorldEntities",
-                              Q_RETURN_ARG(bool, retVal),
-                              Q_ARG(const QString&, filename),
-                              Q_ARG(const QVector<QString>&, propertiesToPrune));
+                              Q_ARG(float, scale),
+                              Q_ARG(const QVariantMap&, options));
     return retVal;
 }
 

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -46,6 +46,15 @@ bool ClipboardScriptingInterface::exportEntities(const QString& filename, float 
     return retVal;
 }
 
+bool ClipboardScriptingInterface::exportWorldEntities(const QString& filename, const QVector<QString>& propertiesToPrune) {
+    bool retVal;
+    BLOCKING_INVOKE_METHOD(qApp, "exportWorldEntities",
+                              Q_RETURN_ARG(bool, retVal),
+                              Q_ARG(const QString&, filename),
+                              Q_ARG(const QVector<QString>&, propertiesToPrune));
+    return retVal;
+}
+
 bool ClipboardScriptingInterface::importEntities(
     const QString& filename,
     const bool isObservable,

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -78,6 +78,10 @@ public:
      * @function Clipboard.exportEntities
      * @param {string} filename - Path and name of the file to export the entities to. Should have the extension ".json".
      * @param {Uuid[]} entityIDs - The IDs of the entities to export.
+    * @param {object} [options] - Export options
+    * @param {boolean} [options.domainOnly] - Only export persistent domain entities.
+    * @param {boolean} [options.globalPositions] - Export with global positions, rather than relative to {@link MyAvatar}
+    * @param {object} [options.paths] - Place paths to export. The key being the path name, and the value being an object containing a {@link Vec3} <code>position</code> and {@link Quat}<code>orientation</code>.
      * @returns {boolean} <code>true</code> if entities were found and the file was written, otherwise <code>false</code>.
      * @example <caption>Create and export a cube and a sphere.</caption>
      * // Create entities.
@@ -98,7 +102,7 @@ public:
      *     Clipboard.exportEntities(filename, [box, sphere]);
      * }
      */
-    Q_INVOKABLE bool exportEntities(const QString& filename, const QVector<QUuid>& entityIDs);
+    Q_INVOKABLE bool exportEntities(const QString& filename, const QVector<QUuid>& entityIDs, const QVariantMap& options = QVariantMap());
     
     /*@jsdoc
     * Exports all entities that have centers within a cube to a JSON file.
@@ -109,20 +113,13 @@ public:
     * @param {number} y - Y-coordinate of the cube center.
     * @param {number} z - Z-coordinate of the cube center.
     * @param {number} scale - Half dimension of the cube.
+    * @param {object} [options] - Export options
+    * @param {boolean} [options.domainOnly] - Only export persistent domain entities.
+    * @param {boolean} [options.globalPositions] - Export with global positions, rather than relative to {@link MyAvatar}
+    * @param {object} [options.paths] - Place paths to export. The key being the path name, and the value being an object containing a {@link Vec3} <code>position</code> and {@link Quat}<code>orientation</code>.
     * @returns {boolean} <code>true</code> if entities were found and the file was written, otherwise <code>false</code>.
     */
-    Q_INVOKABLE bool exportEntities(const QString& filename, float x, float y, float z, float scale);
-
-    /*@jsdoc
-    * Exports all loaded domain entities to a JSON file, with their original global position.
-    * Saves as a serverless-compatible JSON file, with the default "/" path being your avatar's current position and rotation.
-    * Note: You must have permissions for modifying locks, viewing private userdata, and viewing asset URLs, or this function will fail and return <code>false</code>.
-    * @function Clipboard.exportWorldEntities
-    * @param {string} filename - Path and name of the file to export the entities to. Should have the extension ".json".
-    * @param {string[]} [propertiesToPrune] - Entity properties to exclude from the JSON export.
-    * @returns {boolean} <code>true</code> if permissions allow and the file was written, otherwise <code>false</code>.
-    */
-    Q_INVOKABLE bool exportWorldEntities(const QString& filename, const QVector<QString>& propertiesToPrune = QVector<QString>());
+    Q_INVOKABLE bool exportEntities(const QString& filename, float x, float y, float z, float scale, const QVariantMap& options = QVariantMap());
 
     /*@jsdoc
      * Pastes the contents of the clipboard into the domain.

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -114,6 +114,17 @@ public:
     Q_INVOKABLE bool exportEntities(const QString& filename, float x, float y, float z, float scale);
 
     /*@jsdoc
+    * Exports all loaded domain entities to a JSON file, with their original global position.
+    * Saves as a serverless-compatible JSON file, with the default "/" path being your avatar's current position and rotation.
+    * Note: You must have permissions for modifying locks, viewing private userdata, and viewing asset URLs, or this function will fail and return <code>false</code>.
+    * @function Clipboard.exportWorldEntities
+    * @param {string} filename - Path and name of the file to export the entities to. Should have the extension ".json".
+    * @param {string[]} [propertiesToPrune] - Entity properties to exclude from the JSON export.
+    * @returns {boolean} <code>true</code> if permissions allow and the file was written, otherwise <code>false</code>.
+    */
+    Q_INVOKABLE bool exportWorldEntities(const QString& filename, const QVector<QString>& propertiesToPrune = QVector<QString>());
+
+    /*@jsdoc
      * Pastes the contents of the clipboard into the domain.
      * @function Clipboard.pasteEntities
      * @param {Vec3} position -  The position to paste the clipboard contents at.

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -18,6 +18,18 @@
 #include <EntityItemID.h>
 
 /*@jsdoc
+ * @typedef {object} Clipboard.ExportPlace
+ * @property {Vec3} position
+ * @property {Quat} orientation
+ */
+
+/*@jsdoc
+ * @typedef {object} Clipboard.ExportOptions
+ * @property {boolean} [globalPositions=false] - If <code>true</code>, then export with global entity positions. If <code>false</code>, then entity positions are exported relative to {@link MyAvatar}.
+ * @property {Object.<string, Clipboard.ExportPlace>} [paths] - Place paths to export. The object keys are the path name, starting with <code>/</code>.
+ */
+
+/*@jsdoc
  * The <code>Clipboard</code> API enables you to export and import entities to and from JSON files.
  *
  * @namespace Clipboard
@@ -78,10 +90,7 @@ public:
      * @function Clipboard.exportEntities
      * @param {string} filename - Path and name of the file to export the entities to. Should have the extension ".json".
      * @param {Uuid[]} entityIDs - The IDs of the entities to export.
-    * @param {object} [options] - Export options
-    * @param {boolean} [options.domainOnly] - Only export persistent domain entities.
-    * @param {boolean} [options.globalPositions] - Export with global positions, rather than relative to {@link MyAvatar}
-    * @param {object} [options.paths] - Place paths to export. The key being the path name, and the value being an object containing a {@link Vec3} <code>position</code> and {@link Quat}<code>orientation</code>.
+    * @param {Clipboard.ExportOptions} [options] - Export options
      * @returns {boolean} <code>true</code> if entities were found and the file was written, otherwise <code>false</code>.
      * @example <caption>Create and export a cube and a sphere.</caption>
      * // Create entities.
@@ -113,10 +122,7 @@ public:
     * @param {number} y - Y-coordinate of the cube center.
     * @param {number} z - Z-coordinate of the cube center.
     * @param {number} scale - Half dimension of the cube.
-    * @param {object} [options] - Export options
-    * @param {boolean} [options.domainOnly] - Only export persistent domain entities.
-    * @param {boolean} [options.globalPositions] - Export with global positions, rather than relative to {@link MyAvatar}
-    * @param {object} [options.paths] - Place paths to export. The key being the path name, and the value being an object containing a {@link Vec3} <code>position</code> and {@link Quat}<code>orientation</code>.
+    * @param {Clipboard.ExportOptions} [options] - Export options
     * @returns {boolean} <code>true</code> if entities were found and the file was written, otherwise <code>false</code>.
     */
     Q_INVOKABLE bool exportEntities(const QString& filename, float x, float y, float z, float scale, const QVariantMap& options = QVariantMap());


### PR DESCRIPTION
Adds export options to `Clipboard.exportEntities` for global positioning, excluding non-domain entities, and pathnames for serverless JSONs.

[Example script that binds Ctrl+S to open a save dialog](https://raw.githubusercontent.com/ada-tv/overte-scripts/refs/heads/main/exportServerless.js)

Closes #1411