### PR TITLE
Fix build dates being used in the user data path.

### DIFF
--- a/cmake/macros/SetPackagingParameters.cmake
+++ b/cmake/macros/SetPackagingParameters.cmake
@@ -74,7 +74,7 @@ macro(SET_PACKAGING_PARAMETERS)
     # To not break our NSIS later down the line, we use `1` here instead of `ON`.
     set(PR_BUILD 1 CACHE INTERNAL "")
     set(BUILD_VERSION "PR${OVERTE_RELEASE_NUMBER}-${BUILD_DATE}")
-    set(BUILD_ORGANIZATION "Overte - ${BUILD_VERSION}")
+    set(BUILD_ORGANIZATION "Overte - PR${OVERTE_RELEASE_NUMBER}")
     set(INTERFACE_ICON_PREFIX "interface-beta")
 
     # add definition for this release type
@@ -84,7 +84,7 @@ macro(SET_PACKAGING_PARAMETERS)
     # To not break our NSIS later down the line, we use `1` here instead of `ON`.
     set(NIGHTLY_BUILD 1 CACHE INTERNAL "")
     set(BUILD_VERSION "Nightly-${BUILD_DATE}")
-    set(BUILD_ORGANIZATION "Overte - ${BUILD_VERSION}")
+    set(BUILD_ORGANIZATION "Overte - Nightly")
     set(INTERFACE_ICON_PREFIX "interface-beta")
 
     # add definition for this release type
@@ -94,7 +94,7 @@ macro(SET_PACKAGING_PARAMETERS)
     # To not break our NSIS later down the line, we use `1` here instead of `ON`.
     set(DEV_BUILD 1 CACHE INTERNAL "")
     set(BUILD_VERSION "Dev-${BUILD_DATE}")
-    set(BUILD_ORGANIZATION "Overte - ${BUILD_VERSION}")
+    set(BUILD_ORGANIZATION "Overte - Dev")
     set(INTERFACE_ICON_PREFIX "interface-beta")
 
     # add definition for this release type


### PR DESCRIPTION
Fixes: https://github.com/overte-org/overte/issues/1625

Thanks to @ada-tv for catching and reporting this.

I tested this on my machine on a dev build. Keep in mind that the folder is called `Overte - Dev` instead of `Overte - dev`.