### PR TITLE
Fix switching to desktop from OpenXR

### DIFF
--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -390,6 +390,7 @@ bool OpenXrContext::updateSessionState(XrSessionState newState) {
                 _isSessionRunning = true;
             }
             _shouldRunFrameCycle = true;
+            _isValid = true;
             break;
         }
 
@@ -414,6 +415,7 @@ bool OpenXrContext::updateSessionState(XrSessionState newState) {
             _shouldQuit = true;
             _shouldRunFrameCycle = false;
             _session = XR_NULL_HANDLE;
+            _isValid = false;
             qCDebug(xr_context_cat, "Destroyed session");
             break;
         }
@@ -433,6 +435,7 @@ bool OpenXrContext::pollEvents() {
                 const auto& instanceLossPending = *reinterpret_cast<XrEventDataInstanceLossPending*>(&event);
                 qCCritical(xr_context_cat, "Instance loss pending at %lu! Destroying instance.", instanceLossPending.lossTime);
                 _shouldQuit = true;
+                _isValid = false;
                 continue;
             }
             case XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED: {
@@ -480,6 +483,7 @@ bool OpenXrContext::pollEvents() {
 
     if (result != XR_EVENT_UNAVAILABLE) {
         qCCritical(xr_context_cat, "Failed to poll events!");
+        _isValid = false;
         return false;
     }
 

--- a/plugins/openxr/src/OpenXrContext.h
+++ b/plugins/openxr/src/OpenXrContext.h
@@ -61,8 +61,10 @@ public:
     controller::Pose _lastHeadPose;
     std::optional<XrTime> _lastPredictedDisplayTime;
 
+    bool _isValid = true; // set to false when the context is lost
     bool _shouldQuit = false;
     bool _shouldRunFrameCycle = false;
+    bool _isDisplayActive = false;
 
     bool _isSupported = false;
 


### PR DESCRIPTION
Switching between the desktop and OpenXR display plugins works properly now without breaking the input plugin.

This is a bit of a hacky workaround that leaves the XR plugin running dormant when in desktop mode because the `activate` and `deactivate` methods don't seem to be getting called.

OpenXR session loss will currently also bring down desktop mode too if you start Interface with an XR runtime running and then close it while Interface is open. Things already break if you shut down the OpenXR or OpenVR runtime mid-session anyway without this PR, so that behavior isn't too unexpected.