### PR TITLE
Enable default audio device in VR

### DIFF
--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -311,7 +311,7 @@ void AudioDeviceList::onDevicesChanged(QAudio::Mode mode, const QList<HifiAudioD
         device.info = deviceInfo;
 
         if (deviceInfo.isDefault()) {
-            if (deviceInfo.getDeviceType() == HifiAudioDeviceInfo::desktop) {
+            if (deviceInfo.getDeviceType() == HifiAudioDeviceInfo::desktop || deviceInfo.getDeviceType() == HifiAudioDeviceInfo::both) {
                 if (deviceInfo.getMode() == QAudio::AudioInput) {
                     device.display = "Computer's default microphone (recommended)";
                 } else {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -111,7 +111,7 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString&
     for (auto& device : devices) {
         newDevices.push_back(HifiAudioDeviceInfo(device, false, mode));
         if (device.deviceName() == defDeviceName.trimmed()) {
-            defaultDesktopDevice = HifiAudioDeviceInfo(device, true, mode, HifiAudioDeviceInfo::desktop);
+            defaultDesktopDevice = HifiAudioDeviceInfo(device, true, mode, HifiAudioDeviceInfo::both);
         }
     }
 
@@ -119,7 +119,7 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString&
         if (devices.size() > 0) {
             qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list:" << defDeviceName
                 << "Setting Default to: " << devices.first().deviceName();
-            newDevices.push_front(HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::desktop));
+            newDevices.push_front(HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::both));
         } else {
             //current audio list is empty for some reason.
             qCWarning(audioclient) << __FUNCTION__ << "Default device not found in list and no alternative selection available";


### PR DESCRIPTION
This fixes missing default audio device in VR, and should hopefully help with audio device issues in VR on first run. If it doesn't, we will need to look into how default audio device for VR mode is selected.
Please don't test on Windows yet, we need to first fix Qt-related audio issues on master branch.