### PR TITLE
Fix desktop grab attempts spamming errors in some cases

### DIFF
--- a/scripts/system/libraries/controllerDispatcherUtils.js
+++ b/scripts/system/libraries/controllerDispatcherUtils.js
@@ -257,6 +257,8 @@ var getGrabbableData = function (ggdProps) {
         grabbableData = ggdProps.grab;
     }
 
+    if (!grabbableData) { return {}; }
+
     // extract grab-related properties, provide defaults if any are missing
     if (!grabbableData.hasOwnProperty("grabbable")) {
         grabbableData.grabbable = true;


### PR DESCRIPTION
In some cases, like clicking options on [my context menu (T to open)](https://raw.githubusercontent.com/ada-tv/overte-scripts/refs/heads/main/contextMenu.js), there'd be a huge block of backtraces from the grab script trying to check for object properties on an `undefined`. Nothing should behave any differently, but those errors shouldn't come up anymore.

`Object.hasOwn` is a newer alternative to `hasOwnProperty` that correctly handles `null` and `undefined`, but if there's already an `undefined` we don't need to check if it has any properties anyway.