### PR TITLE
Restore previous behaviour of only copying libraries on next to executable on Windows.

### DIFF
--- a/cmake/macros/PackageLibrariesForDeployment.cmake
+++ b/cmake/macros/PackageLibrariesForDeployment.cmake
@@ -3,6 +3,7 @@
 #  cmake/macros
 #
 #  Copyright 2015 High Fidelity, Inc.
+#  Copyright 2025 Overte e.V.
 #  Created by Stephen Birarda on February 17, 2014
 #
 #  Distributed under the Apache License, Version 2.0.
@@ -31,16 +32,15 @@ macro(PACKAGE_LIBRARIES_FOR_DEPLOYMENT)
                 COMMAND "${CMAKE_CURRENT_BINARY_DIR}/windeploy-${TARGET_NAME}.bat" $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>,$<CONFIG:RelWithDebInfo>>:--release> \"$<TARGET_FILE:${TARGET_NAME}>\"
         )
 
+        # Add a post-build command to copy the DLLs beside the executable
+        add_custom_command(
+                TARGET ${TARGET_NAME}
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND}
+                -DBUNDLE_EXECUTABLE="$<TARGET_FILE:${TARGET_NAME}>"
+                -DBUNDLE_PLUGIN_DIR="$<TARGET_FILE_DIR:${TARGET_NAME}>/${PLUGIN_PATH}"
+                -DLIB_PATHS="${CMAKE_BINARY_DIR}/conanlibs/$<CONFIGURATION>"
+                -P "${CMAKE_SOURCE_DIR}/cmake/FixupBundlePostBuild.cmake"
+        )
     endif ()
-
-    # Add a post-build command to copy the libraries beside the executable
-    add_custom_command(
-            TARGET ${TARGET_NAME}
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND}
-            -DBUNDLE_EXECUTABLE="$<TARGET_FILE:${TARGET_NAME}>"
-            -DBUNDLE_PLUGIN_DIR="$<TARGET_FILE_DIR:${TARGET_NAME}>/${PLUGIN_PATH}"
-            -DLIB_PATHS="${CMAKE_BINARY_DIR}/conanlibs/$<CONFIGURATION>"
-            -P "${CMAKE_SOURCE_DIR}/cmake/FixupBundlePostBuild.cmake"
-    )
 endmacro()


### PR DESCRIPTION
Should fix: https://github.com/overte-org/overte/issues/1653

I cannot test it right now, but this should be pretty safe. As far as I can tell, our previous behaviour was to only do this on Windows, which is exactly what I have restored here.
On Linux, there is no point in copying the libraries next to the executable, as all of our packaging tools get the library locations either from CMake or by just looking up the libraries that Interface uses.