### PR TITLE
'OpenXR not supported on Wayland' message box

### DIFF
--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -12,6 +12,10 @@
 #include <QString>
 #include <QGuiApplication>
 
+#if defined(Q_OS_LINUX)
+#include <QMessageBox>
+#endif
+
 #include <sstream>
 
 Q_DECLARE_LOGGING_CATEGORY(xr_context_cat)
@@ -67,12 +71,13 @@ OpenXrContext::~OpenXrContext() {
 }
 
 bool OpenXrContext::initInstance() {
-    auto myApp = static_cast<QGuiApplication*>(qApp);
-    if (myApp->platformName() == "wayland") {
-        auto msg = QString::fromUtf8("The OpenXR plugin does not support Wayland yet! Use the QT_QPA_PLATFORM=xcb environment variable to force Overte to launch with X11.");
-        qCCritical(xr_context_cat) << msg;
+#if defined(Q_OS_LINUX)
+    if (qApp->platformName() == "wayland") {
+        qCCritical(xr_context_cat) << "The OpenXR plugin can't run on Wayland yet. This will hopefully be resolved with Qt 6.";
+        QMessageBox::warning(nullptr, "Warning", "Overte cannot use OpenXR on Wayland yet. Use the QT_QPA_PLATFORM=xcb environment variable to launch Overte through XWayland.");
         return false;
     }
+#endif
 
     uint32_t count = 0;
     XrResult result = xrEnumerateInstanceExtensionProperties(nullptr, 0, &count, nullptr);

--- a/plugins/openxr/src/OpenXrContext.h
+++ b/plugins/openxr/src/OpenXrContext.h
@@ -22,6 +22,8 @@
     #undef Unsorted
     // MappingPointer from X11 conflicts with one from controllers/Forward.h
     #undef MappingPointer
+    // CursorShape conflicts with QCursor
+    #undef CursorShape
 #elif defined(Q_OS_WIN)
     #define XR_USE_PLATFORM_WIN32
     #include <Unknwn.h>


### PR DESCRIPTION
It was too easy to miss the log line explaining that OpenXR can't start on Wayland yet, so now there's a message box making it more obvious why the plugin wasn't starting