### PR TITLE
Fix chat notification height on VR HUD

### DIFF
--- a/scripts/communityScripts/notificationCore/notificationCore.js
+++ b/scripts/communityScripts/notificationCore/notificationCore.js
@@ -138,7 +138,7 @@ function notif(text, colour) {
         text: '',
         font: {size: sizeData[DEFAULT_SIZE].size},
         x: 0,
-        y: Window.innerHeight,
+        y: Overlays.height(),
         color: colour.text,
         backgroundColor: colour.bg,
         backgroundAlpha: noti.alpha.bg,
@@ -148,14 +148,14 @@ function notif(text, colour) {
     var ts = Overlays.textSize(noti.id, noti.text);
     ts.height *= sizeData[DEFAULT_SIZE].heightMul;
     ts.width *= sizeData[DEFAULT_SIZE].widthMul;
-    ts.y = Window.innerHeight - (sizeData[DEFAULT_SIZE].split * (notificationList.length)) - offset;
+    ts.y = Overlays.height() - (sizeData[DEFAULT_SIZE].split * (notificationList.length)) - offset;
     ts.text = noti.text;
     Overlays.editOverlay(noti.id, ts);
 
     noti.update = function () {
         var i = notificationList.length - findIndex(noti.id);
         Overlays.editOverlay(noti.id, {
-            y: Window.innerHeight - (sizeData[DEFAULT_SIZE].split * (i)) - offset
+            y: Overlays.height() - (sizeData[DEFAULT_SIZE].split * (i)) - offset
         });
     };
 


### PR DESCRIPTION
The notifications were using the desktop window size, which most of the time isn't the same as the VR HUD's size. This fixes it by using `Overlays.height` instead of `Window.innerHeight`.

Closes #703