### PR TITLE
Add LOD settings to Settings 'Graphics' page

### DIFF
--- a/scripts/system/settings/qml/pages/GraphicsSettings.qml
+++ b/scripts/system/settings/qml/pages/GraphicsSettings.qml
@@ -262,7 +262,7 @@ Flickable {
 
         SettingComboBox {
             settingText: "LOD Settings";
-            options: ["High Detail", "Medium Detail",  "Low Detail" ];
+            options: ["Low Detail", "Medium Detail",  "High Detail" ];
             optionIndex: LODManager.worldDetailQuality;
 
             onValueChanged: {

--- a/scripts/system/settings/qml/pages/GraphicsSettings.qml
+++ b/scripts/system/settings/qml/pages/GraphicsSettings.qml
@@ -260,6 +260,20 @@ Flickable {
             }
         }
 
+        SettingComboBox {
+            settingText: "LOD Settings";
+            options: ["High Detail", "Medium Detail",  "Low Detail" ];
+            optionIndex: LODManager.worldDetailQuality;
+
+            onValueChanged: {
+                LODManager.worldDetailQuality = index;
+            }
+
+            Component.onCompleted: {
+                optionIndex = LODManager.worldDetailQuality;
+            }
+        }
+
         // Fullscreen Display
         SettingComboBox {
             settingText: "Fullscreen Display";


### PR DESCRIPTION
Fixes #1683
Adds LOD settings to the settings page.
<img width="525" height="160" alt="image" src="https://github.com/user-attachments/assets/62b1b0b8-8c1d-405d-8a20-ca844145b25a" />
