### PR TITLE
Gray out anti-aliasing on forward renderer

### DIFF
--- a/scripts/system/settings/qml/SettingComboBox.qml
+++ b/scripts/system/settings/qml/SettingComboBox.qml
@@ -10,6 +10,7 @@ Item {
     property var _optionText: "";
     readonly property string optionText: _optionText;
 	property var options: [""];
+    property bool disabled: false;
 
 	signal valueChanged(int index);
 
@@ -92,7 +93,7 @@ Item {
 
 				background: Rectangle {
 					id: comboBoxBackground;
-					color: "#333";
+					color: disabled ? "gray" : "#333";
 					radius: 10;
 					width: parent.width;
 				}
@@ -152,15 +153,18 @@ Item {
             propagateComposedEvents: true;
 
             onPressed: {
-                mouse.accepted = false
+                if (disabled) return;
+                mouse.accepted = false;
             }
 
             onEntered: {
+                if (disabled) return;
                 backgroundElement.color = "#333";
 				comboBoxBackground.color = "#444";
             }
 
             onExited: {
+                if (disabled) return;
                 backgroundElement.color = "transparent";
 				comboBoxBackground.color = "#333";
             }
@@ -172,6 +176,11 @@ Item {
 				easing.type: Easing.InOutCubic
 			}
 		}
+    }
+
+    onDisabledChanged: {
+        if (disabled) comboBoxBackground.color = "gray";
+        else comboBoxBackground.color = "#333";
     }
 
 	// Updates the contents of a combobox.

--- a/scripts/system/settings/qml/pages/GraphicsSettings.qml
+++ b/scripts/system/settings/qml/pages/GraphicsSettings.qml
@@ -311,9 +311,14 @@ Flickable {
             settingText: "Anti-aliasing";
             optionIndex: Render.antialiasingMode;
             options: ["None", "TAA", "FXAA"];
+            disabled: Render.renderMethod;
 
             onValueChanged: {
                 Render.antialiasingMode = index;
+            }
+
+            onDisabledChanged: {
+                if (disabled) setOptionIndex(0);
             }
         }
     }


### PR DESCRIPTION
This disables the anti-aliasing option when using the forward renderer.
<img width="489" height="752" alt="image" src="https://github.com/user-attachments/assets/90bcf1f0-616d-4af6-a7eb-d2c8af3e9718" />

Closes #1521 