### PR TITLE
API to hide desktop menu bar while keeping menu items

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1237,6 +1237,7 @@ void Application::loadSettings(const QCommandLineParser& parser) {
     // dictated that we should be in first person
     Menu::getInstance()->setIsOptionChecked(MenuOption::FirstPersonLookAt, isFirstPerson);
     Menu::getInstance()->setIsOptionChecked(MenuOption::ThirdPerson, !isFirstPerson);
+    Menu::getInstance()->setVisible(_menuBarVisible.get());
     _myCamera.setMode((isFirstPerson) ? CAMERA_MODE_FIRST_PERSON_LOOK_AT : CAMERA_MODE_LOOK_AT);
     cameraMenuChanged();
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -387,6 +387,7 @@ signals:
     void awayStateWhenFocusLostInVRChanged(bool enabled);
 
     void darkThemePreferenceChanged(bool useDarkTheme);
+    void menuBarVisibilityChanged(bool visible);
 
 public slots:
     void updateThreadPoolCount() const;
@@ -464,6 +465,9 @@ public slots:
 
     bool getDarkThemePreference() const { return _darkTheme.get(); }
     void setDarkThemePreference(bool value);
+
+    bool getMenuBarVisible() const { return _menuBarVisible.get(); }
+    void setMenuBarVisible(bool visible);
 
     /**
      * @brief Shows/hides VR keyboard input for Overlay windows
@@ -811,6 +815,7 @@ private:
     Setting::Handle<bool> _darkTheme;
     Setting::Handle<bool> _miniTabletEnabledSetting;
     Setting::Handle<bool> _keepLogWindowOnTop { "keepLogWindowOnTop", false };
+    Setting::Handle<bool> _menuBarVisible { "menuBarVisible", true };
 
     void updateThemeColors();
 

--- a/interface/src/Application_UI.cpp
+++ b/interface/src/Application_UI.cpp
@@ -1449,3 +1449,19 @@ void Application::addAssetToWorldError(QString modelName, QString errorText) {
 
     _addAssetToWorldErrorTimer.start();
 }
+
+void Application::setMenuBarVisible(bool visible) {
+    if (QThread::currentThread() != qApp->thread()) {
+        QMetaObject::invokeMethod(this, "setMenuBarVisible", Q_ARG(bool, visible));
+        return;
+    }
+
+    auto* menuBar = qApp->getWindow()->menuBar();
+    bool wasVisible = menuBar->isVisible();
+
+    if (visible != wasVisible) {
+        _menuBarVisible.set(visible);
+        menuBar->setVisible(visible);
+        emit menuBarVisibilityChanged(visible);
+    }
+}

--- a/interface/src/scripting/MenuScriptingInterface.cpp
+++ b/interface/src/scripting/MenuScriptingInterface.cpp
@@ -20,6 +20,10 @@
 #include <MenuItemProperties.h>
 #include "Menu.h"
 
+MenuScriptingInterface::MenuScriptingInterface() {
+    connect(qApp, &Application::menuBarVisibilityChanged, this, &MenuScriptingInterface::visibilityChanged);
+}
+
 MenuScriptingInterface* MenuScriptingInterface::getInstance() {
     static MenuScriptingInterface sharedInstance;
     return &sharedInstance;
@@ -220,21 +224,9 @@ void MenuScriptingInterface::triggerOption(const QString& menuOption) {
 }
 
 void MenuScriptingInterface::setVisible(bool visible) {
-    if (QThread::currentThread() != qApp->thread()) {
-        QMetaObject::invokeMethod(this, "setVisible", Q_ARG(bool, visible));
-        return;
-    }
-
-    auto* menuBar = qApp->getWindow()->menuBar();
-    bool wasVisible = menuBar->isVisible();
-
-    if (visible != wasVisible) {
-        menuBar->setVisible(visible);
-
-        emit visibilityChanged(visible);
-    }
+    qApp->setMenuBarVisible(visible);
 }
 
 bool MenuScriptingInterface::isVisible() {
-    return qApp->getWindow()->menuBar()->isVisible();
+    return qApp->getMenuBarVisible();
 }

--- a/interface/src/scripting/MenuScriptingInterface.cpp
+++ b/interface/src/scripting/MenuScriptingInterface.cpp
@@ -220,6 +220,11 @@ void MenuScriptingInterface::triggerOption(const QString& menuOption) {
 }
 
 void MenuScriptingInterface::setVisible(bool visible) {
+    if (QThread::currentThread() != qApp->thread()) {
+        QMetaObject::invokeMethod(this, "setVisible", Q_ARG(bool, visible));
+        return;
+    }
+
     auto* menuBar = qApp->getWindow()->menuBar();
     bool wasVisible = menuBar->isVisible();
 

--- a/interface/src/scripting/MenuScriptingInterface.cpp
+++ b/interface/src/scripting/MenuScriptingInterface.cpp
@@ -10,6 +10,8 @@
 //
 
 #include "MenuScriptingInterface.h"
+#include "Application.h"
+#include "MainWindow.h"
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QThread>
@@ -215,4 +217,19 @@ void MenuScriptingInterface::triggerOption(const QString& menuOption) {
     }
 
     QMetaObject::invokeMethod(menuInstance, "triggerOption", Q_ARG(const QString&, menuOption));
+}
+
+void MenuScriptingInterface::setVisible(bool visible) {
+    auto* menuBar = qApp->getWindow()->menuBar();
+    bool wasVisible = menuBar->isVisible();
+
+    if (visible != wasVisible) {
+        menuBar->setVisible(visible);
+
+        emit visibilityChanged(visible);
+    }
+}
+
+bool MenuScriptingInterface::isVisible() {
+    return qApp->getWindow()->menuBar()->isVisible();
 }

--- a/interface/src/scripting/MenuScriptingInterface.h
+++ b/interface/src/scripting/MenuScriptingInterface.h
@@ -50,9 +50,9 @@ class MenuItemProperties;
 
 class MenuScriptingInterface : public QObject {
     Q_OBJECT
-    Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibilityChanged)
+    Q_PROPERTY(bool visible READ isVisible WRITE setVisible)
 
-    MenuScriptingInterface() { };
+    MenuScriptingInterface();
 public:
     static MenuScriptingInterface* getInstance();
 

--- a/interface/src/scripting/MenuScriptingInterface.h
+++ b/interface/src/scripting/MenuScriptingInterface.h
@@ -34,6 +34,8 @@ class MenuItemProperties;
  * @hifi-interface
  * @hifi-client-entity
  * @hifi-avatar
+ *
+ * @property {boolean} visible - <code>true</code> if the menu bar is visible on the desktop window.
  */
 
 /**
@@ -48,6 +50,8 @@ class MenuItemProperties;
 
 class MenuScriptingInterface : public QObject {
     Q_OBJECT
+    Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibilityChanged)
+
     MenuScriptingInterface() { };
 public:
     static MenuScriptingInterface* getInstance();
@@ -218,6 +222,20 @@ public slots:
      */
     void setMenuEnabled(const QString& menuName, bool isEnabled);
 
+    /*@jsdoc
+     * Sets the visibility of the desktop menubar.
+     * @function Menu.setVisible
+     * @param {boolean} visible - If <code>true</code>, the menubar is visible on the desktop window.
+     */
+    void setVisible(bool visible);
+
+    /*@jsdoc
+     * Gets the visibility of the desktop menubar.
+     * @function Menu.isVisible
+     * @returns {boolean} <code>true</code> if the menubar is visible on the desktop window.
+     */
+    bool isVisible();
+
 signals:
     /*@jsdoc
      * Triggered when a menu item is clicked or triggered by {@link Menu.triggerOption}.
@@ -232,6 +250,14 @@ signals:
      * Menu.menuItemEvent.connect(onMenuItemEvent);
      */
     void menuItemEvent(const QString& menuItem);
+
+    /*@jsdoc
+     * Triggered when <code>Menu.visible</code> is changed.
+     * @function Menu.visibilityChanged
+     * @param {boolean} visible - <code>true</code> if the menubar is visible on the desktop window.
+     * @returns {Signal}
+     */
+    void visibilityChanged(bool visible);
 };
 
 #endif // hifi_MenuScriptingInterface_h

--- a/scripts/system/menu.js
+++ b/scripts/system/menu.js
@@ -27,10 +27,13 @@ var HOME_BUTTON_TEXTURE = Script.getExternalPath(Script.ExternalPaths.HF_Content
     var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
     var button = null;
 
-    if (HMD.active) {
+    if (HMD.active || !Menu.visible) {
         button = tablet.addButton(buttonProperties);
         button.clicked.connect(onClicked);
-        lastHMDStatus = true;
+
+        if (HMD.active) {
+            lastHMDStatus = true;
+        }
     }
 
     var onMenuScreen = false;
@@ -47,18 +50,28 @@ var HOME_BUTTON_TEXTURE = Script.getExternalPath(Script.ExternalPaths.HF_Content
         }
     }
 
-    HMD.displayModeChanged.connect(function(isHMDMode) {
-        if (lastHMDStatus !== isHMDMode) {
-            if (isHMDMode) {
+    function buttonVisibilityChanged() {
+        if (HMD.active || !Menu.visible) {
+            if (!button) {
                 button = tablet.addButton(buttonProperties);
                 button.clicked.connect(onClicked);
-            } else if (button) {
-                button.clicked.disconnect(onClicked);
-                tablet.removeButton(button);
-                button = null;
             }
+        } else if (button) {
+            button.clicked.disconnect(onClicked);
+            tablet.removeButton(button);
+            button = null;
+        }
+    }
+
+    HMD.displayModeChanged.connect(function(isHMDMode) {
+        if (lastHMDStatus !== isHMDMode) {
+            buttonVisibilityChanged();
             lastHMDStatus = isHMDMode;
         }
+    });
+
+    Menu.visibilityChanged.connect(function(_visible) {
+        buttonVisibilityChanged();
     });
 
     function onScreenChanged(type, url) {


### PR DESCRIPTION
Adds `Menu.visible` to hide the menu bar on the desktop window and put it into a button on the taskbar, like on the VR tablet.