### PR TITLE
Only capture relevant thumbstick for scrolling, remove trigger requirement for Web entity scrolling

### DIFF
--- a/interface/src/raypick/PathPointer.cpp
+++ b/interface/src/raypick/PathPointer.cpp
@@ -216,15 +216,16 @@ Pointer::PickedObject PathPointer::getHoveredObject(const PickResultPointer& pic
 }
 
 glm::vec2 PathPointer::getScroll(const PickResultPointer& pickResult) {
-    bool isActive = false;
+    bool isActive = true;
     glm::vec2 accum { 0.0f };
 
     for (const PointerTrigger& trigger : _triggers) {
         std::string button = trigger.getButton();
 
-        // don't activate scrolling if the laser isn't even on
-        if (button == "ScrollActive" && trigger.getEndpoint()->peek().value > 0.1f) {
-            isActive = true;
+        // if ScrollActive is available, use it to lock out accidental scrolls
+        // (like on the UI, where the lasers are always active even though they're invisible)
+        if (button == "ScrollActive" && trigger.getEndpoint()->peek().value < 0.1f) {
+            isActive = false;
         } else if (button == "ScrollX") {
             accum.x += trigger.getEndpoint()->peek().value;
         } else if (button == "ScrollY") {

--- a/scripts/system/controllers/controllerDispatcher.js
+++ b/scripts/system/controllers/controllerDispatcher.js
@@ -581,7 +581,6 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             filter: Picks.PICK_OVERLAYS | Picks.PICK_LOCAL_ENTITIES | Picks.PICK_ENTITIES | Picks.PICK_INCLUDE_NONCOLLIDABLE,
             triggers: [
                 {action: controllerStandard.LTClick, button: "Primary"},
-                {action: controllerStandard.LT, button: "ScrollActive"},
                 {action: controllerStandard.LX, button: "ScrollX"},
                 {action: controllerStandard.LY, button: "ScrollY"},
             ],
@@ -598,7 +597,6 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             filter: Picks.PICK_OVERLAYS | Picks.PICK_LOCAL_ENTITIES | Picks.PICK_ENTITIES | Picks.PICK_INCLUDE_NONCOLLIDABLE,
             triggers: [
                 {action: controllerStandard.RTClick, button: "Primary"},
-                {action: controllerStandard.RT, button: "ScrollActive"},
                 {action: controllerStandard.RX, button: "ScrollX"},
                 {action: controllerStandard.RY, button: "ScrollY"},
             ],

--- a/scripts/system/controllers/controllerModules/hudOverlayPointer.js
+++ b/scripts/system/controllers/controllerModules/hudOverlayPointer.js
@@ -76,23 +76,41 @@
             return this.hand === RIGHT_HAND ? leftHudOverlayPointer : rightHudOverlayPointer;
         };
 
+        const SCROLL_MAPPING_NAME = `overte.thumbstick_scroll_${this.hand}.hud`;
+        this.scrollMappingEnabled = false;
+        this.scrollMapping = Controller.newMapping(SCROLL_MAPPING_NAME);
+        this.stickXMapping = this.scrollMapping.from(
+            this.hand == LEFT_HAND ? Controller.Standard.LX : Controller.Standard.RX
+        ).to(function(_value) { /* dummy to temporarily eat stick input */ });
+        this.stickYMapping = this.scrollMapping.from(
+            this.hand == LEFT_HAND ? Controller.Standard.LY : Controller.Standard.RY
+        ).to(function(_value) { /* dummy to temporarily eat stick input */ });
+
         this.processLaser = function(controllerData) {
             var controllerLocation = controllerData.controllerLocations[this.hand];
-            if ((controllerData.triggerValues[this.hand] < ControllerDispatcherUtils.TRIGGER_ON_VALUE || !controllerLocation.valid) ||
-                this.pointingAtTablet(controllerData)) {
-                Controller.releaseActionEvents("hudOverlayPointer_" + this.hand);
-                return false;
-            }
             var hudRayPick = controllerData.hudRayPicks[this.hand];
             var point2d = this.calculateNewReticlePosition(hudRayPick.intersection);
-            if (!Window.isPointOnDesktopWindow(point2d) && !this.triggerClicked) {
-                Controller.releaseActionEvents("hudOverlayPointer_" + this.hand);
-                return false;
-            }
-
             this.triggerClicked = controllerData.triggerClicks[this.hand];
-            Controller.captureActionEvents("hudOverlayPointer_" + this.hand);
-            return true;
+
+            if (
+                (controllerData.triggerValues[this.hand] < ControllerDispatcherUtils.TRIGGER_ON_VALUE || !controllerLocation.valid) ||
+                this.pointingAtTablet(controllerData) ||
+                (!Window.isPointOnDesktopWindow(point2d) && !this.triggerClicked)
+            ) {
+                if (this.scrollMappingEnabled) {
+                    this.scrollMapping.disable();
+                    this.scrollMappingEnabled = false;
+                }
+
+                return false;
+            } else {
+                if (!this.scrollMappingEnabled) {
+                    this.scrollMapping.enable();
+                    this.scrollMappingEnabled = true;
+                }
+
+                return true;
+            }
         };
 
         this.isReady = function (controllerData) {


### PR DESCRIPTION
Replaces `Controller.captureActionEvents` with the controller mapping system to only disable the thumbstick on the hand that's scrolling, rather than all inputs on all controllers.

The trigger still has to be pulled to scroll on the HUD, but the HUD laser needs the trigger pulled to enable the laser anyway at the moment.