### PR TITLE
Move CMake defaults to conanfile.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,39 +26,19 @@ if (APPLE)
 endif()
 
 
-#
-# Default compiler flags
-#
-# Compiler flags need to be set before calling project().
+project(overte)
+include("cmake/init.cmake")
+include("cmake/compiler.cmake")
+
+# Guard against missing `-falign-functions`.
 if( NOT WIN32 )
-    # Function alignment is necessary for V8.
+    # Function alignment is necessary for V8 scripting engine! We will run into random crashes otherwise.
     # SetAlignedPointerInInternalField requires at least 2 byte alignment and -falign-functions will set alignment
     # to machine specific value which should be greater than 2.
-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        set(CMAKE_CXX_FLAGS "-falign-functions -fPIC -m64 -msse3" CACHE STRING "C++ compiler flags for all build types.")
-        set(CMAKE_C_FLAGS "-falign-functions -fPIC -m64 -msse3" CACHE STRING "C compiler flags for all build types.")
-    elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-        # TODO: Find out which architecture optimizations to use on aarch64.
-        # We should probably target the 64bit version of the Raspberry Pi 2 as minimum.
-        set(CMAKE_CXX_FLAGS "-falign-functions -fPIC" CACHE STRING "C++ compiler flags for all build types.")
-        set(CMAKE_C_FLAGS "-falign-functions -fPIC" CACHE STRING "C++ compiler flags for all build types.")
-    endif()
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        message("Clang compiler detected, setting default flags.")
-        set(CMAKE_CXX_FLAGS_DEBUG "-Og -g" CACHE STRING "C++ compiler flags for Debug builds.")
-        set(CMAKE_C_FLAGS_DEBUG "-Og -g" CACHE STRING "C compiler flags for Debug builds.")
-        set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -g" CACHE STRING "C++ compiler flags for RelWithDebInfo builds.")
-        set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -g" CACHE STRING "C compiler flags for RelWithDebInfo builds.")
-        set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "C++ compiler flags for Release builds.")
-        set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "C compiler flags for Release builds.")
-    elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        message("GCC compiler detected, setting default flags")
-        set(CMAKE_CXX_FLAGS_DEBUG "-Og -ggdb3" CACHE STRING "C++ compiler flags for Debug builds.")
-        set(CMAKE_C_FLAGS_DEBUG "-Og -ggdb3" CACHE STRING "C compiler flags for Debug builds.")
-        set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -ggdb2" CACHE STRING "C++ compiler flags for RelWithDebInfo builds.")
-        set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -ggdb2" CACHE STRING "C compiler flags for RelWithDebInfo builds.")
-        set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "C++ compiler flags for Release builds.")
-        set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG" CACHE STRING "C compiler flags for Release builds.")
+    string(FIND "${CMAKE_CXX_FLAGS}" "-falign-functions" falign-functions_INDEX)
+    if(${falign-functions_INDEX} EQUAL -1)
+        # Substring not found
+        message(FATAL_ERROR "CMAKE_CXX_FLAGS is missing -falign-functions. This is required to avoid crashes in relation to the V8 scripting engine and should have been set by Conan.")
     endif()
 endif()
 
@@ -93,22 +73,6 @@ if(OVERTE_WARNINGS_ALLOWLIST)
         message("We don't know yet how to allowlist warnings for ${CMAKE_CXX_COMPILER_ID}")
     endif()
 endif()
-
-# Enabling warnings-as-errors by default on our Linux target and on Windows.
-# Our current Linux development target is Ubuntu 22.04, which uses GCC 11.2.
-# TODO: Enable warnings-as-errors once we stop throwing warnings on the relevant platforms.
-if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND (CMAKE_CXX_COMPILER_VERSION MATCHES "11"))
-    set(CMAKE_COMPILE_WARNING_AS_ERROR OFF CACHE BOOL "")
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC") # Windows
-    set(CMAKE_COMPILE_WARNING_AS_ERROR OFF CACHE BOOL "")
-endif()
-
-
-project(overte)
-include("cmake/init.cmake")
-include("cmake/compiler.cmake")
-
-
 
 #
 # Overte build variables

--- a/conanfile.py
+++ b/conanfile.py
@@ -112,21 +112,21 @@ class Overte(ConanFile):
                 tc.cache_variables.update({
                     # Enable function alignment to fix crashes in relation to V8 scripting engine and enable SSE3 architecture optimization.
                     # TODO: Use `-fmin-function-alignment=16` once we switch to GCC 14 as minimum, which would be once we switch to Ubuntu 26.04 as our target.
-                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=16 -fPIC -m64 -msse3",
-                    "CMAKE_C_FLAGS_INIT": "-falign-functions=16 -fPIC -m64 -msse3",
+                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=32 -fPIC -m64 -msse3",
+                    "CMAKE_C_FLAGS_INIT": "-falign-functions=32 -fPIC -m64 -msse3",
                     })
             elif self.settings.arch == "armv8":
                 self.output.status("aarch64 architecture detected, setting default flags.")
                 # TODO: What architecture optimizations should we use on aarch64? We should target the 64 bit version of the Raspberry Pi 2 as a minimum.
                 tc.cache_variables.update({
-                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=16 -fPIC",
-                    "CMAKE_C_FLAGS_INIT": "-falign-functions=16 -fPIC",
+                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=32 -fPIC",
+                    "CMAKE_C_FLAGS_INIT": "-falign-functions=32 -fPIC",
                     })
             else:
                 self.output.warning(f"Architecture '{self.settings.arch}' isn't supported by Overte. Falling back to defaults.", warn_tag=None)
                 tc.cache_variables.update({
-                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=16 -fPIC",
-                    "CMAKE_C_FLAGS_INIT": "-falign-functions=16 -fPIC",
+                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=32 -fPIC",
+                    "CMAKE_C_FLAGS_INIT": "-falign-functions=32 -fPIC",
                     })
 
             if self.settings.compiler == "gcc":

--- a/conanfile.py
+++ b/conanfile.py
@@ -103,6 +103,67 @@ class Overte(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+
+        # Settings a whole bunch of defaults for CMake.
+        # These are only defaults and can be changed at any point using the CMake GUI (or your preferred IDE).
+        if self.settings.compiler != "msvc":
+            if self.settings.arch == "x86_64":
+                self.output.status("x86_64 architecture detected, setting default flags.")
+                tc.cache_variables.update({
+                    # Enable function alignment to fix crashes in relation to V8 scripting engine and enable SSE3 architecture optimization.
+                    # TODO: Use `-fmin-function-alignment=16` once we switch to GCC 14 as minimum, which would be once we switch to Ubuntu 26.04 as our target.
+                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=16 -fPIC -m64 -msse3",
+                    "CMAKE_C_FLAGS_INIT": "-falign-functions=16 -fPIC -m64 -msse3",
+                    })
+            elif self.settings.arch == "armv8":
+                self.output.status("aarch64 architecture detected, setting default flags.")
+                # TODO: What architecture optimizations should we use on aarch64? We should target the 64 bit version of the Raspberry Pi 2 as a minimum.
+                tc.cache_variables.update({
+                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=16 -fPIC",
+                    "CMAKE_C_FLAGS_INIT": "-falign-functions=16 -fPIC",
+                    })
+            else:
+                self.output.warning(f"Architecture '{self.settings.arch}' isn't supported by Overte. Falling back to defaults.", warn_tag=None)
+                tc.cache_variables.update({
+                    "CMAKE_CXX_FLAGS_INIT": "-falign-functions=16 -fPIC",
+                    "CMAKE_C_FLAGS_INIT": "-falign-functions=16 -fPIC",
+                    })
+
+            if self.settings.compiler == "gcc":
+                self.output.status("GCC compiler detected, setting default flags.")
+                tc.cache_variables.update({
+                    "CMAKE_CXX_FLAGS_DEBUG_INIT": "-Og -ggdb3",
+                    "CMAKE_C_FLAGS_DEBUG_INIT": "-Og -ggdb3",
+                    "CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT": "-O2 -DNDEBUG -ggdb2",
+                    "CMAKE_C_FLAGS_RELWITHDEBINFO_INIT": "-O2 -DNDEBUG -ggdb2",
+                    "CMAKE_CXX_FLAGS_RELEASE_INIT": "-O3 -DNDEBUG",
+                    "CMAKE_C_FLAGS_RELEASE_INIT": "-O3 -DNDEBUG",
+                    })
+            elif self.settings.compiler == "clang":
+                self.output.status("Clang compiler detected, setting default flags.")
+                tc.cache_variables.update({
+                    "CMAKE_CXX_FLAGS_DEBUG_INIT": "-Og -g",
+                    "CMAKE_C_FLAGS_DEBUG_INIT": "-Og -g",
+                    "CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT": "-O2 -DNDEBUG -g",
+                    "CMAKE_C_FLAGS_RELWITHDEBINFO_INIT": "-O2 -DNDEBUG -g",
+                    "CMAKE_CXX_FLAGS_RELEASE_INIT": "-O3 -DNDEBUG",
+                    "CMAKE_C_FLAGS_RELEASE_INIT": "-O3 -DNDEBUG",
+                    })
+            else:
+                self.output.warning(f"Unknown compiler '{self.settings.compiler}'. Not setting default optimization flags.", warn_tag=None)
+
+        # Enabling warnings-as-errors by default on our Linux target and on Windows.
+        # Our current Linux development target is Ubuntu 22.04, which uses GCC 11.2.
+        # TODO: Enable warnings-as-errors once we stop throwing warnings on the relevant platforms.
+        if self.settings.compiler == "gcc" and self.settings.compiler.version == "11":
+            tc.cache_variables.update({
+                "CMAKE_COMPILE_WARNING_AS_ERROR": "OFF",
+            })
+        elif self.settings.compiler == "msvc":
+            tc.cache_variables.update({
+                "CMAKE_COMPILE_WARNING_AS_ERROR": "OFF",
+            })
+
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
Move CMake defaults to conanfile.py to be applied as part of the Conan CMake toolchain *before* CMake uses its own defaults.

The way to set default CMAKE_CXX_FLAGS and similar is to use CMake toolchain files. While this is considered bad practice by the CMake community, it is pretty much necessary for us. CMake doesn't know what compiler, architecture, et cetera it is using in its toolchain; So instead we get all this information from Conan and add our defaults to Conan's CMake toolchain.

This fixes our defaults not being applied at all (oops).
This should also fix some crashes that would have popped up due to `-falign-functions` being missing.
74 suggested setting `-falign-functions` to 16 bytes, which I have done here. I have no idea what GCC sets `-falign-functions` to by default, so I might have lowered it by setting it to 16.

It builds and runs on my machine and seems to do what it is supposed to.