### PR TITLE
Chat bubble and simplifiedNametag fixes

### DIFF
--- a/scripts/communityScripts/chatBubbles/chatBubbles.js
+++ b/scripts/communityScripts/chatBubbles/chatBubbles.js
@@ -184,8 +184,8 @@ function ChatBubbles_SpawnBubble(data, senderID) {
             canCastShadow: false,
             billboardMode: "yaw",
             alignment: "center",
-            verticalAlignment: "top",
-            topMargin: 0.015,
+            verticalAlignment: "center",
+            topMargin: -0.004 * scale, // center isn't exactly centered?
             grab: {grabbable: false},
             renderLayer: "front",
             script: (link === undefined && !linkIsImage) ? undefined :
@@ -200,11 +200,10 @@ function ChatBubbles_SpawnBubble(data, senderID) {
         }, "local");
 
         Script.setTimeout(() => {
-            const { dimensions, text } = Entities.getEntityProperties(bubbleEntity, ["dimensions", "text"]);
             const size = Entities.textSize(bubbleEntity, text);
             Entities.editEntity(bubbleEntity, {
                 visible: true,
-                dimensions: [size.width + 0.06, dimensions.y, 0.01],
+                dimensions: [size.width + (0.06 * scale), size.height + (0.04 * scale), 0.01],
             });
         }, 100);
         // this wait time is annoyingly inconsistent,
@@ -213,7 +212,7 @@ function ChatBubbles_SpawnBubble(data, senderID) {
 
     for (const bubble of Object.values(currentBubbles[senderID])) {
         let { localPosition } = Entities.getEntityProperties(bubble.entity, "localPosition");
-        localPosition = Vec3.sum(localPosition, [0, height + 0.05, 0]);
+        localPosition = Vec3.sum(localPosition, [0, height + (0.05 * scale), 0]);
         Entities.editEntity(bubble.entity, { localPosition: localPosition });
     }
 

--- a/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/nameTagListManager.js
+++ b/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/nameTagListManager.js
@@ -389,6 +389,7 @@ function makeNameTag(uuid) {
         .add("localPosition", localPosition)
         .add("grab", { grabbable: false })
         .add("ignorePickIntersection", true)
+        .add("renderLayer", "front")
         .add("alignment", "center")
         .add("textEffect", "outline fill")
         .add("textEffectColor", [0, 0, 0])

--- a/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/nameTagListManager.js
+++ b/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/nameTagListManager.js
@@ -388,6 +388,11 @@ function makeNameTag(uuid) {
         .add("parentID", parentID)
         .add("localPosition", localPosition)
         .add("grab", { grabbable: false })
+        .add("ignorePickIntersection", true)
+        .add("alignment", "center")
+        .add("textEffect", "outline fill")
+        .add("textEffectColor", [0, 0, 0])
+        .add("textEffectThickness", 0.4)
         .create(CLEAR_ENTITY_EDIT_PROPS);
 
     Script.setTimeout(function () {


### PR DESCRIPTION
* `simplifiedNametag` now center-aligns its text and has a thin black outline so the text appears antialiased without being transparent. It was also given `ignorePickIntersection` so it doesn't block the VR lasers.

Before
<img width="89" height="55" alt="image" src="https://github.com/user-attachments/assets/4d118802-78c4-4113-9b58-55b1a0240324" />
After
<img width="83" height="57" alt="image" src="https://github.com/user-attachments/assets/f528566b-37c0-4acb-a67a-c9ab444a093b" />

* The chat bubbles are are now positioned relative to the avatar's head, so the bubbles should appear at the same height above the avatar's head regardless of scale or rig shape. The bubbles are now scaled to `MyAvatar.scale` too.
* The chat bubbles now render on the `front` render layer, so they won't be occluded by ceilings or walls.
* The chat bubbles were moved up a little bit so they're mostly out of the way of the `simplifiedNametag` with an avatar scale of 1. The nametag scales itself based on its distance to the camera and isn't always the same height across different avatar scales anyway, so there might still be a bit of clashing in a few cases.

Fixes #1672