### PR TITLE
Permission-protected LocationBookmarks API extension

### DIFF
--- a/interface/resources/qml/hifi/dialogs/security/ScriptSecurity.qml
+++ b/interface/resources/qml/hifi/dialogs/security/ScriptSecurity.qml
@@ -28,13 +28,19 @@ Rectangle {
     id: parentBody;
 
     function getAllowlistAsText() {
-        var allowlist = Settings.getValue("private/scriptPermissionGetAvatarURLSafeURLs");
-        var arrayAllowlist = allowlist.replace(",", "\n");
+        var allowlist = [
+            Settings.getValue("private/scriptPermissionGetAvatarURLSafeURLs"),
+            Settings.getValue("private/scriptPermissionBookmarksSafeURLs"),
+        ].join();
+
+        // trimEnd so blank permissions lists will show the placeholder text
+        var arrayAllowlist = allowlist.replace(",", "\n").trimEnd();
         return arrayAllowlist;
     }
 
     function setAllowlistAsText(allowlistText) {
         Settings.setValue("private/scriptPermissionGetAvatarURLSafeURLs", allowlistText.text);
+        Settings.setValue("private/scriptPermissionBookmarksSafeURLs", allowlistText.text);
         notificationText.text = "Allowlist saved.";
     }
 
@@ -43,13 +49,18 @@ Rectangle {
         console.info("Setting Protect Avatar URLs to:", enabled);
     }
 
+    function setBookmarkProtection(enabled) {
+        Settings.setValue("private/scriptPermissionBookmarksEnable", enabled);
+        console.info("Setting Protect Bookmarks to:", enabled);
+    }
+
     anchors.fill: parent
     width: parent.width;
     height: 120;
     color: "#80010203";
 
     HifiStylesUit.RalewayRegular {
-        id: titleText;
+        id: protectAvatars;
         text: "Protect Avatar URLs"
         // Text size
         size: 24;
@@ -65,7 +76,7 @@ Rectangle {
         height: 60;
 
         CheckBox {
-            id: allowlistEnabled;
+            id: avatarsAllowlistEnabled;
 
             checked: Settings.getValue("private/scriptPermissionGetAvatarURLEnable", true);
 
@@ -73,7 +84,7 @@ Rectangle {
             anchors.top: parent.top;
             anchors.topMargin: 10;
             onToggled: {
-                setAvatarProtection(allowlistEnabled.checked)
+                setAvatarProtection(avatarsAllowlistEnabled.checked)
             }
 
             Label {
@@ -87,18 +98,74 @@ Rectangle {
         }
     }
 
+    HifiStylesUit.RalewayRegular {
+        id: protectBookmarks;
+        text: "Protect Bookmarks"
+        // Text size
+        size: 24;
+        // Style
+        color: "white";
+        elide: Text.ElideRight;
+        // Anchors
+        anchors.top: protectAvatars.bottom;
+        anchors.left: parent.left;
+        anchors.leftMargin: 20;
+        anchors.right: parent.right;
+        anchors.rightMargin: 20;
+        height: 60;
+
+        CheckBox {
+            id: bookmarksAllowlistEnabled;
+
+            checked: Settings.getValue("private/scriptPermissionBookmarksEnable", true);
+
+            anchors.right: parent.right;
+            anchors.top: parent.top;
+            anchors.topMargin: 10;
+            onToggled: {
+                setBookmarkProtection(bookmarksAllowlistEnabled.checked)
+            }
+
+            Label {
+                text: "Enabled"
+                color: "white"
+                font.pixelSize: 18;
+                anchors.right: parent.left;
+                anchors.top: parent.top;
+                anchors.topMargin: 10;
+            }
+        }
+    }
+
+    HifiStylesUit.RalewayRegular {
+        id: allowedURLsTitle;
+        text: "Trusted Scripts";
+        // Text size
+        size: 24;
+        // Style
+        color: "white";
+        elide: Text.ElideRight;
+        // Anchors
+        anchors.top: protectBookmarks.bottom;
+        anchors.left: parent.left;
+        anchors.leftMargin: 20;
+        anchors.right: parent.right;
+        anchors.rightMargin: 20;
+        height: 60;
+    }
+
     Rectangle {
         id: textAreaRectangle;
         color: "black";
         width: parent.width;
-        height: 250;
-        anchors.top: titleText.bottom;
-    
+        anchors.top: allowedURLsTitle.bottom;
+        anchors.bottom: saveChanges.top;
+        anchors.bottomMargin: 20;
+
         ScrollView {
             id: textAreaScrollView
             anchors.fill: parent;
             width: parent.width
-            height: parent.height
             contentWidth: parent.width
             contentHeight: parent.height
             clip: false;
@@ -106,6 +173,7 @@ Rectangle {
             TextArea {
                 id: allowlistTextArea
                 text: getAllowlistAsText();
+                placeholderText: "https://example.com/allowedScript.js\nhttps://example.com/anotherAllowedScript.js";
                 onTextChanged: notificationText.text = "";
                 width: parent.width;
                 height: parent.height;
@@ -114,39 +182,40 @@ Rectangle {
                 color: "white";
             }
         }
-        
-        Button {
-            id: saveChanges
-            anchors.topMargin: 5;
-            anchors.leftMargin: 20;
-            anchors.rightMargin: 20;
-            x: textAreaRectangle.x + textAreaRectangle.width - width - 15;
-            y: textAreaRectangle.y + textAreaRectangle.height - height;
-            contentItem: Text {
-                text: saveChanges.text
-                font.family: "Ubuntu";
-                font.pointSize: 12;
-                opacity: enabled ? 1.0 : 0.3
-                color: "black"
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                elide: Text.ElideRight
-            }
-            text: "Save Changes"
-            onClicked: setAllowlistAsText(allowlistTextArea)
-          
-            HifiStylesUit.RalewayRegular {
-                id: notificationText;
-                text: ""
-                // Text size
-                size: 16;
-                // Style
-                color: "white";
-                elide: Text.ElideLeft;
-                // Anchors
-                anchors.right: parent.left;
-                anchors.rightMargin: 10;
-            }
+    }
+
+    Button {
+        id: saveChanges
+        anchors.topMargin: 20;
+        anchors.leftMargin: 20;
+        anchors.rightMargin: 20;
+        anchors.bottomMargin: 20;
+        anchors.right: parent.right;
+        anchors.bottom: parent.bottom;
+        contentItem: Text {
+            text: saveChanges.text
+            font.family: "Ubuntu";
+            font.pointSize: 12;
+            opacity: enabled ? 1.0 : 0.3
+            color: "black"
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+        }
+        text: "Save Changes"
+        onClicked: setAllowlistAsText(allowlistTextArea)
+
+        HifiStylesUit.RalewayRegular {
+            id: notificationText;
+            text: ""
+            // Text size
+            size: 16;
+            // Style
+            color: "white";
+            elide: Text.ElideLeft;
+            // Anchors
+            anchors.right: parent.left;
+            anchors.rightMargin: 10;
         }
     }
 }

--- a/interface/src/AvatarBookmarks.h
+++ b/interface/src/AvatarBookmarks.h
@@ -20,6 +20,10 @@
  * The <code>AvatarBookmarks</code> API provides facilities for working with avatar bookmarks ("favorites" in the Avatar app). 
  * An avatar bookmark associates a name with an avatar model, scale, and avatar entities (wearables).
  *
+ * <p><strong>Note:</strong> This is a protected API and it is only available
+ * to scripts with the appropriate permissions. Without them, the functions in
+ * this namespace won't do anything and will return empty values.</p>
+ *
  * @namespace AvatarBookmarks
  *
  * @hifi-interface

--- a/interface/src/LocationBookmarks.cpp
+++ b/interface/src/LocationBookmarks.cpp
@@ -20,6 +20,7 @@
 #include <OffscreenUi.h>
 
 #include "Menu.h"
+#include "ScriptPermissions.h"
 
 const QString LocationBookmarks::HOME_BOOKMARK = "Home";
 
@@ -61,16 +62,28 @@ void LocationBookmarks::setHomeLocation() {
 }
 
 void LocationBookmarks::setHomeLocationToAddress(const QVariant& address) {
+    if (!ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission::SCRIPT_PERMISSION_BOOKMARKS)) {
+        return;
+    }
+
     Bookmarks::insert(HOME_BOOKMARK, address);
 }
 
 
 QString LocationBookmarks::getHomeLocationAddress() {
-    return addressForBookmark(HOME_BOOKMARK);
+    if (ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission::SCRIPT_PERMISSION_BOOKMARKS)) {
+        return addressForBookmark(HOME_BOOKMARK);
+    } else {
+        return {};
+    }
 }
 
 QString LocationBookmarks::getAddress(const QString& bookmarkName) {
-    return addressForBookmark(bookmarkName);
+    if (ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission::SCRIPT_PERMISSION_BOOKMARKS)) {
+        return addressForBookmark(bookmarkName);
+    } else {
+        return {};
+    }
 }
 
 void LocationBookmarks::teleportToBookmark() {
@@ -81,6 +94,10 @@ void LocationBookmarks::teleportToBookmark() {
 }
 
 void LocationBookmarks::addBookmark() {
+    if (!ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission::SCRIPT_PERMISSION_BOOKMARKS)) {
+        return;
+    }
+
     ModalDialogListener* dlg = OffscreenUi::getTextAsync(OffscreenUi::ICON_PLACEMARK, "Bookmark Location", "Name", QString());
 
     connect(dlg, &ModalDialogListener::response, this, [=] (QVariant response) {
@@ -108,5 +125,13 @@ void LocationBookmarks::addBookmarkToMenu(Menu* menubar, const QString& name, co
         // TODO: this is aggressive but other alternatives have proved less fruitful so far.
         menubar->addActionToQMenuAndActionHash(_bookmarksMenu, teleportAction, name, 0, QAction::NoRole);
         Bookmarks::sortActions(menubar, _bookmarksMenu);
+    }
+}
+
+QVariantMap LocationBookmarks::getBookmarks() {
+    if (ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission::SCRIPT_PERMISSION_BOOKMARKS)) {
+        return _bookmarks;
+    } else {
+        return {};
     }
 }

--- a/interface/src/LocationBookmarks.cpp
+++ b/interface/src/LocationBookmarks.cpp
@@ -135,3 +135,19 @@ QVariantMap LocationBookmarks::getBookmarks() {
         return {};
     }
 }
+
+void LocationBookmarks::addBookmark(const QString& name, const QString& url) {
+    if (!ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission::SCRIPT_PERMISSION_BOOKMARKS)) {
+        return;
+    }
+
+    Bookmarks::insert(name, url);
+}
+
+void LocationBookmarks::removeBookmark(const QString& name) {
+    if (!ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission::SCRIPT_PERMISSION_BOOKMARKS)) {
+        return;
+    }
+
+    Bookmarks::remove(name);
+}

--- a/interface/src/LocationBookmarks.h
+++ b/interface/src/LocationBookmarks.h
@@ -88,6 +88,22 @@ public slots:
      */
     QVariantMap getBookmarks();
 
+    /*@jsdoc
+     * Adds a new bookmark or replaces an existing one.
+     * @function LocationBookmarks.addBookmark
+     * @param {string} name - The name of the bookmark.
+     * @param {string} url - The bookmark's URL.
+     */
+    void addBookmark(const QString& name, const QString& url);
+
+
+    /*@jsdoc
+     * Deletes a bookmark, if it exists.
+     * @function LocationBookmarks.removeBookmark
+     * @param {string} name - The name of the bookmark.
+     */
+    void removeBookmark(const QString& name);
+
 protected:
     void addBookmarkToMenu(Menu* menubar, const QString& name, const QVariant& address) override;
 

--- a/interface/src/LocationBookmarks.h
+++ b/interface/src/LocationBookmarks.h
@@ -20,6 +20,10 @@
  * The <code>LocationBookmarks</code> API provides facilities for working with location bookmarks. A location bookmark 
  * associates a name with a directory services address.
  *
+ * <p><strong>Note:</strong> This is a protected API and it is only available
+ * to scripts with the appropriate permissions. Without them, the functions in
+ * this namespace won't do anything and will return empty values.</p>
+ *
  * @namespace LocationBookmarks
  *
  * @hifi-client-entity
@@ -69,6 +73,20 @@ public slots:
      * @returns {string} The directory services address for the "Home" bookmark.
      */
     QString getHomeLocationAddress();
+
+    /*@jsdoc
+     * Gets the details of all bookmarks.
+     * @function LocationBookmarks.getBookmarks
+     * @returns {object} The current bookmarks in an object where the keys
+     * are the bookmark names and the values are the bookmark URLs.
+     * @example <caption>List the names and URLs of all the bookmarks.</caption>
+     * var bookmarks = LocationBookmarks.getBookmarks();
+     * print("Location bookmarks:");
+     * for (const [name, url] of Object.entries(bookmarks)) {
+     *     print(`- ${name} ${url}`);
+     * }
+     */
+    QVariantMap getBookmarks();
 
 protected:
     void addBookmarkToMenu(Menu* menubar, const QString& name, const QVariant& address) override;

--- a/libraries/script-engine/src/ScriptPermissions.cpp
+++ b/libraries/script-engine/src/ScriptPermissions.cpp
@@ -21,19 +21,31 @@
 static const bool PERMISSIONS_DEBUG_ENABLED = false;
 
 extern const std::array<QString, static_cast<int>(ScriptPermissions::Permission::SCRIPT_PERMISSIONS_SIZE)> scriptPermissionNames {
-    "Permission to get user's avatar URL" //SCRIPT_PERMISSION_GET_AVATAR_URL
+    // SCRIPT_PERMISSION_GET_AVATAR_URL
+    "Permission to get user's avatar URL",
+    // SCRIPT_PERMISSION_BOOKMARKS
+    "Permission to view user's bookmarked locations",
 };
 
 extern const std::array<QString, static_cast<int>(ScriptPermissions::Permission::SCRIPT_PERMISSIONS_SIZE)> scriptPermissionSettingKeyNames {
-    "private/scriptPermissionGetAvatarURLSafeURLs" //SCRIPT_PERMISSION_GET_AVATAR_URL
+    // SCRIPT_PERMISSION_GET_AVATAR_URL
+    "private/scriptPermissionGetAvatarURLSafeURLs",
+    // SCRIPT_PERMISSION_BOOKMARKS
+    "private/scriptPermissionBookmarksSafeURLs",
 };
 
 extern const std::array<QString, static_cast<int>(ScriptPermissions::Permission::SCRIPT_PERMISSIONS_SIZE)> scriptPermissionSettingEnableKeyNames {
-    "private/scriptPermissionGetAvatarURLEnable" //SCRIPT_PERMISSION_GET_AVATAR_URL
+    // SCRIPT_PERMISSION_GET_AVATAR_URL
+    "private/scriptPermissionGetAvatarURLEnable",
+    // SCRIPT_PERMISSION_BOOKMARKS
+    "private/scriptPermissionBookmarksEnable",
 };
 
 extern const std::array<bool, static_cast<int>(ScriptPermissions::Permission::SCRIPT_PERMISSIONS_SIZE)> scriptPermissionSettingEnableDefaultValues {
-    true //SCRIPT_PERMISSION_GET_AVATAR_URL
+    // SCRIPT_PERMISSION_GET_AVATAR_URL
+    true,
+    // SCRIPT_PERMISSION_BOOKMARKS
+    true,
 };
 
 bool ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission permission) {

--- a/libraries/script-engine/src/ScriptPermissions.h
+++ b/libraries/script-engine/src/ScriptPermissions.h
@@ -20,6 +20,7 @@ class ScriptPermissions {
 public:
     enum class Permission {
         SCRIPT_PERMISSION_GET_AVATAR_URL,
+        SCRIPT_PERMISSION_BOOKMARKS,
         SCRIPT_PERMISSIONS_SIZE
     };
 


### PR DESCRIPTION
Adds a new script permission for bookmark access and adds some functions to `LocationBookmarks` so the bookmarks can be manipulated from scripts, outside of C++. I've also added a comment to the top of the docs for both `LocationBookmarks` and `AvatarBookmarks` mentioning that they need special permissions to work.

* `LocationBookmarks.getBookmarks(): object`
* `LocationBookmarks.addBookmark(name: string, url: string): void`
* `LocationBookmarks.removeBookmark(name: string): void`

Makes #1721 possible to implement