### PR TITLE
PLACES App: Add connected domain's place use count

### DIFF
--- a/scripts/system/places/places.css
+++ b/scripts/system/places/places.css
@@ -654,21 +654,21 @@ div.placeDetail-event {
 }
 
 td.presenceOfLife-LIFE {
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     color: #00FF00;
     text-align: right;
 }
 
 td.presenceOfLife-FULL {
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     color: #ff0000;
     text-align: right;    
 }
 
 td.presenceOfLife-NOBODY {
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     color: #555555;
     text-align: right;    
@@ -708,16 +708,16 @@ td.domainTitle {
 font.domain-capacity {
     font-size: 10px;
     font-weight: 600;
-    color: #999999;    
+    color: #999999;
 }
 
 font.domain-nbrUser {
     font-size: 18px;
-    font-weight: 500;    
+    font-weight: 500;
 }
 
 font.NOBODY {
-    color: #555555;    
+    color: #555555;
 }
 
 font.LIFE {
@@ -858,7 +858,7 @@ font.domain-nbrUser_small {
 }
 
 #placeDetail-users {
-    font-size: 30px;
+    font-size: 18px;
     font-weight: 600;
 }
 
@@ -1022,3 +1022,27 @@ button.externalFilterOn:hover {
     font-size: 18px;
     text-align: center;
 }
+
+table.detailUserCount {
+    width: 90%;
+    border-collapse: collapse;
+}
+
+td.detailUserCount {
+    padding: 2px;
+    width: 50%;
+    border: 1px solid #999999;
+    text-align: center;
+}
+
+td.detailUserCountHeader {
+    padding: 2px;
+    width: 50%;
+    font-size: 10px;
+    font-weight: 600;
+    color: #000000;
+    border: 1px solid #999999;
+    background-color: #999999;
+    text-align: center;
+}
+

--- a/scripts/system/places/places.html
+++ b/scripts/system/places/places.html
@@ -320,6 +320,12 @@
                                 //This indicate if there are presence of people or not, and if the domain is full capacity.
                                 //This will be used to display "Life" indicator (green) or "Full" (red)
                                 
+                            placeRecords[i].domainAccessStatus
+                                //String (Possible values: FULL/LIFE/NOBODY 
+                                //This indicate if there are presence of people or not, and if the domain is full capacity.
+                                //This will be used to display "Life" indicator (green) or "Full" (red)
+                                //But this one is never overriden in case there is a place specific count to 0.
+                                
                             placeRecords[i].name
                                 //String (This is the name of the Place. We might want a keyword filter based on this content)
                                 
@@ -339,6 +345,9 @@
                             placeRecords[i].current_attendance
                                 Number (The number of people currently in the Domain. domain.num_users)
                                 
+                            placeRecords[i].place_attendance
+                                Number (The number of people currently in this spacific Domain. Default -1, available only if the place is in the domain where the user is currently connected to. In that cause it must be 0 or greater)
+                            
                             placeRecords[i].id
                                 String (This is the place ID, this can be used for any external storage)
                                 
@@ -406,7 +415,7 @@
                                             formatedList = formatedList + "<tr>";
                                             formatedList = formatedList + "<td width='5%'>&nbsp;</td>";
                                             formatedList = formatedList + "<td width='70%' valign='top' class='domainTitle'>" + placeRecords[i].domain + "</td>";
-                                            formatedList = formatedList + "<td width='25%' align='right' valign='top'><font class='domain-nbrUser " + placeRecords[i].accessStatus + "'><font class='domain-nbrUser_small'>USERS:</font> " + placeRecords[i].current_attendance + "</font>";
+                                            formatedList = formatedList + "<td width='25%' align='right' valign='top'><font class='domain-nbrUser " + placeRecords[i].domainAccessStatus + "'><font class='domain-nbrUser_small'>USERS:</font> " + placeRecords[i].current_attendance + "</font>";
                                             formatedList = formatedList + "<font class='domain-capacity'><br>CAPACITY: " + capacity + "</font></td>";
                                             formatedList = formatedList + "</tr>";
                                             formatedList = formatedList + "</table>";
@@ -470,11 +479,15 @@
                                         formatedList = formatedList + "    </tr>";
                                         formatedList = formatedList + "</table>";
                                         if (placeRecords[i].category !== "Z") {
+                                            var indicator = "&#9603;";
+                                            if (placeRecords[i].accessStatus !== "NOBODY" && placeRecords[i].place_attendance > 0) {
+                                                indicator = "" + placeRecords[i].place_attendance;
+                                            }
                                             formatedList = formatedList + "<table class='placeTable'" + prompotionDescHeight + ">";
                                             formatedList = formatedList + "    <tr valign = 'bottom'>";
                                             formatedList = formatedList + "        <td width='2%'></td>";
                                             formatedList = formatedList + "        <td align='left' width='88%' class='place-entry-description' onclick='teleport(" + '"' + placeRecords[i].id + '"' + ", " + '"' + placeUrl + '"' + "); return false;'>" + shortenedDescription + "</td>";
-                                            formatedList = formatedList + "        <td align='right' class='presenceOfLife-" + placeRecords[i].accessStatus + "'>&#9603;</td>";
+                                            formatedList = formatedList + "        <td align='right' class='presenceOfLife-" + placeRecords[i].accessStatus + "'>" + indicator + "</td>";
                                             formatedList = formatedList + "    </tr>";
                                             formatedList = formatedList + "</table>";
                                         }
@@ -808,7 +821,18 @@
                 document.getElementById("placeDetail-maturity").innerHTML = placeDetail.maturity.toUpperCase();
                 document.getElementById("placeDetail-maturity").className = placeDetail.maturity + "FilterOn placeMaturity";
                 document.getElementById("placeDetail-domain").innerHTML = placeDetail.domain.toUpperCase();
-                document.getElementById("placeDetail-users").innerHTML = "<font class='" + placeDetail.accessStatus + "'>" + placeDetail.current_attendance + "</font>";
+                var placeAttendance = "" + placeDetail.place_attendance;
+                if (placeDetail.place_attendance === -1) {
+                    placeAttendance = "-";
+                }
+                var userBlock = "<table class='detailUserCount'><tr>";
+                userBlock += "<td class='detailUserCountHeader'>PLACE</td>";
+                userBlock += "<td class='detailUserCountHeader'>DOMAIN</td>";
+                userBlock += "</tr><tr>";
+                userBlock += "<td class='detailUserCount'><font class='" + placeDetail.accessStatus + "'>" + placeAttendance + "</font></td>";
+                userBlock += "<td class='detailUserCount'><font class='" + placeDetail.domainAccessStatus + "'>" + placeDetail.current_attendance + "</font></td>";
+                userBlock += "</tr></table>";
+                document.getElementById("placeDetail-users").innerHTML = userBlock;
                 var capacity = "UNDEFINED";
                 if (placeDetail.capacity !== 0) {
                     capacity = placeDetail.capacity;


### PR DESCRIPTION
This PR adds the place specific count when the data is available (when you are in that specific domain)

<img width="483" height="707" alt="image" src="https://github.com/user-attachments/assets/cab4bbe0-3730-4121-8759-380abf7e9d8a" />

The count is available also in the details
here when the count is available:
<img width="484" height="708" alt="image" src="https://github.com/user-attachments/assets/9c0183ee-83eb-456c-be49-b97eae111b62" />

Here if available but  clearly 0
<img width="485" height="708" alt="image" src="https://github.com/user-attachments/assets/3d4f3f58-71d3-4e10-acb3-aa8968d43090" />

here if the data is not available:
<img width="482" height="708" alt="image" src="https://github.com/user-attachments/assets/67da5b23-3602-42bb-93d6-5c35fb4a55a9" />

The count is computed based of the nearest place for each user in the domain.
The color is based on if there is still capacity available or not on that domain (also true for the places of that domain)
(green or red)

This feature could help to find where people are among the different place of a domain.

