### PR TITLE
Fix About.buildDate

### DIFF
--- a/interface/src/AboutUtil.cpp
+++ b/interface/src/AboutUtil.cpp
@@ -23,11 +23,7 @@
 #include "scripting/HMDScriptingInterface.h"
 #include "Application.h"
 
-AboutUtil::AboutUtil(QObject *parent) : QObject(parent) {
-    QLocale locale;
-    _dateConverted = QDate::fromString(BuildInfo::BUILD_TIME, "dd/MM/yyyy").
-            toString(locale.dateFormat(QLocale::ShortFormat));
-}
+AboutUtil::AboutUtil(QObject *parent) : QObject(parent) {}
 
 AboutUtil *AboutUtil::getInstance() {
     static AboutUtil instance;
@@ -35,7 +31,7 @@ AboutUtil *AboutUtil::getInstance() {
 }
 
 QString AboutUtil::getBuildDate() const {
-    return _dateConverted;
+    return BuildInfo::BUILD_TIME;
 }
 
 QString AboutUtil::getBuildVersion() const {

--- a/interface/src/AboutUtil.h
+++ b/interface/src/AboutUtil.h
@@ -94,7 +94,6 @@ public slots:
     void openUrl(const QString &url) const;
 private:
     AboutUtil(QObject* parent = nullptr);
-    QString _dateConverted;
 };
 
 #endif // hifi_AboutUtil_h


### PR DESCRIPTION
Closes #1662

Uses the build date string verbatim (i.e. `"2025-08-10"`) rather than converting it to the current locale date format.