### PR TITLE
Default to high graphics setting on Linux on first start

### DIFF
--- a/libraries/platform/src/platform/Profiler.cpp
+++ b/libraries/platform/src/platform/Profiler.cpp
@@ -39,8 +39,13 @@ Profiler::Tier Profiler::profilePlatform() {
         return platformTier;
     }
 
+#ifdef Q_OS_LINUX
+    // GPUIdent.cpp is missing GPU detection on Linux and most currently available GPUs should handle high detail mode.
+    return Profiler::Tier::HIGH;
+#else
     // Default answer is 
     return Profiler::Tier::LOW;
+#endif
 }
 
 // tier filter on computer info

--- a/libraries/shared/src/GPUIdent.cpp
+++ b/libraries/shared/src/GPUIdent.cpp
@@ -310,6 +310,8 @@ GPUIdent* GPUIdent::ensureQuery(const QString& vendor, const QString& renderer) 
         _isValid = true;
     }
 
+    // TODO: Linux is not handled here
+
 #endif
     return this;
 }


### PR DESCRIPTION
Currently graphics setting on Linux on first start will always default to "Low", since GPU detection is not implemented. This PR makes it default to "High" instead, since "Low" setting is missing local lights and shadows, and makes really bad first impression, especially with current tutorial world being very dark without local lights.