### PR TITLE
Remove qtaudio_windows.dll QtMultimedia plugin

### DIFF
--- a/cmake/macros/PackageLibrariesForDeployment.cmake
+++ b/cmake/macros/PackageLibrariesForDeployment.cmake
@@ -42,5 +42,14 @@ macro(PACKAGE_LIBRARIES_FOR_DEPLOYMENT)
                 -DLIB_PATHS="${CMAKE_BINARY_DIR}/conanlibs/$<CONFIGURATION>"
                 -P "${CMAKE_SOURCE_DIR}/cmake/FixupBundlePostBuild.cmake"
         )
+
+        # Remove Windows Audio Service QtMultimedia plugin, so we only use Windows Media Foundation (WASAPI).
+        # We do this to avoid having two audio plugins available and all audio devices duplicated.
+        add_custom_command(
+                TARGET ${TARGET_NAME}
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E remove "$<TARGET_FILE_DIR:${TARGET_NAME}>/audio/qtaudio_windowsd.dll"
+                COMMAND ${CMAKE_COMMAND} -E remove "$<TARGET_FILE_DIR:${TARGET_NAME}>/audio/qtaudio_windows.dll"
+        )
     endif ()
 endmacro()

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -1210,6 +1210,11 @@ Section "-Core installation"
   ; Delete old hifiNeuron.dll, since we dropped support for it and it causes a crash on startup.
   Delete "$INSTDIR\plugins\hifiNeuron.dll"
 
+  ; Delete old audioWin7 and audioWin8 folders, since we dropped support for Windows 7.
+  ; This isn't necessary, but saves disk space.
+  RMDir /r "$INSTDIR\audioWin7"
+  RMDir /r "$INSTDIR\audioWin8"
+
   ;Use the entire tree produced by the INSTALL target.  Keep the
   ;list of directories here in sync with the RMDir commands below.
   SetOutPath "$INSTDIR"

--- a/interface/src/Application_Setup.cpp
+++ b/interface/src/Application_Setup.cpp
@@ -296,17 +296,6 @@ bool setupEssentials(const QCommandLineParser& parser, bool runningMarkerExisted
 
     PROFILE_SET_THREAD_NAME("Main Thread");
 
-#if defined(Q_OS_WIN)
-    // Select appropriate audio DLL
-    QString audioDLLPath = QCoreApplication::applicationDirPath();
-    if (IsWindows8OrGreater()) {
-        audioDLLPath += "/audioWin8";
-    } else {
-        audioDLLPath += "/audioWin7";
-    }
-    QCoreApplication::addLibraryPath(audioDLLPath);
-#endif
-
     QString defaultScriptsOverrideOption = parser.value("defaultScriptsOverride");
 
     DependencyManager::registerInheritance<LimitedNodeList, NodeList>();


### PR DESCRIPTION
Remove qtaudio_windows.dll QtMultimedia plugin to avoid having two plugins and duplicated audio devices.
This breaks support with Windows 7.

Fixes: https://github.com/overte-org/overte/issues/1555

I haven't tested this yet.