### PR TITLE
add initial support for vrm extension

### DIFF
--- a/interface/resources/qml/hifi/AssetServer.qml
+++ b/interface/resources/qml/hifi/AssetServer.qml
@@ -148,7 +148,7 @@ Windows.ScrollingWindow {
     }
 
     function canAddToWorld(path) {
-        var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i, /\.jpg\b/i, /\.png\b/i, /\.gltf\b/i, /\.glb\b/i];
+        var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i, /\.jpg\b/i, /\.png\b/i, /\.gltf\b/i, /\.glb\b/i, /\.vrm\b/i];
 
         if (selectedItemCount > 1) {
             return false;

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -148,7 +148,7 @@ Rectangle {
     }
 
     function canAddToWorld(path) {
-        var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i, /\.jpg\b/i, /\.png\b/i, /\.gltf\b/i, /\.glb\b/i];
+        var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i, /\.jpg\b/i, /\.png\b/i, /\.gltf\b/i, /\.glb\b/i, /\.vrm\b/i];
 
         if (selectedItemCount > 1) {
             return false;

--- a/interface/src/Application_Assets.cpp
+++ b/interface/src/Application_Assets.cpp
@@ -36,6 +36,7 @@ static const QString FBX_EXTENSION = ".fbx";
 static const QString OBJ_EXTENSION = ".obj";
 static const QString GLTF_EXTENSION = ".gltf";
 static const QString GLB_EXTENSION = ".glb";
+static const QString VRM_EXTENSION = ".vrm";
 static const QString JSON_GZ_EXTENSION = ".json.gz";
 static const QString CONTENT_ZIP_EXTENSION = ".content.zip";
 static const QString ZIP_EXTENSION = ".zip";
@@ -264,9 +265,9 @@ void Application::addAssetToWorldSetMapping(QString filePath, QString mapping, Q
         } else {
             // to prevent files that aren't models or texture files from being loaded into world automatically
             if ((filePath.toLower().endsWith(OBJ_EXTENSION) || filePath.toLower().endsWith(FBX_EXTENSION) ||
-                 filePath.toLower().endsWith(GLTF_EXTENSION) || filePath.toLower().endsWith(GLB_EXTENSION)) ||
-                ((filePath.toLower().endsWith(JPG_EXTENSION) || filePath.toLower().endsWith(PNG_EXTENSION)) &&
-                !isZip)) {
+                 filePath.toLower().endsWith(GLTF_EXTENSION) || filePath.toLower().endsWith(GLB_EXTENSION) ||
+                 filePath.toLower().endsWith(VRM_EXTENSION)) || ((filePath.toLower().endsWith(JPG_EXTENSION) ||
+                 filePath.toLower().endsWith(PNG_EXTENSION)) && !isZip)) {
                 addAssetToWorldAddEntity(filePath, mapping);
             } else {
                 qCDebug(interfaceapp) << "Zipped contents are not supported entity files";

--- a/libraries/baking/src/ModelBaker.h
+++ b/libraries/baking/src/ModelBaker.h
@@ -35,6 +35,7 @@ static const QString FBX_EXTENSION { ".fbx" };
 static const QString BAKED_FBX_EXTENSION { ".baked.fbx" };
 static const QString OBJ_EXTENSION { ".obj" };
 static const QString GLTF_EXTENSION { ".gltf" };
+static const QString VRM_EXTENSION { ".vrm" };
 
 class ModelBaker : public Baker {
     Q_OBJECT

--- a/libraries/baking/src/baking/BakerLibrary.cpp
+++ b/libraries/baking/src/baking/BakerLibrary.cpp
@@ -23,7 +23,8 @@ QUrl getBakeableModelURL(const QUrl& url) {
         FBX_EXTENSION,
         BAKED_FBX_EXTENSION,
         OBJ_EXTENSION,
-        GLTF_EXTENSION
+        GLTF_EXTENSION,
+        VRM_EXTENSION
     };
 
     QString filename = url.fileName();
@@ -72,7 +73,7 @@ std::unique_ptr<ModelBaker> getModelBakerWithOutputDirectories(const QUrl& bakea
         baker = std::make_unique<FBXBaker>(bakeableModelURL, bakedOutputDirectory, originalOutputDirectory, filename.endsWith(BAKED_FBX_EXTENSION, Qt::CaseInsensitive));
     } else if (filename.endsWith(OBJ_EXTENSION, Qt::CaseInsensitive)) {
         baker = std::make_unique<OBJBaker>(bakeableModelURL, bakedOutputDirectory, originalOutputDirectory);
-    //} else if (filename.endsWith(GLTF_EXTENSION, Qt::CaseInsensitive)) {
+    //} else if (filename.endsWith(GLTF_EXTENSION, Qt::CaseInsensitive) || filename.endsWith(VRM_EXTENSION, Qt::CaseInsensitive)) {
         //baker = std::make_unique<GLTFBaker>(bakeableModelURL, inputTextureThreadGetter, bakedOutputDirectory, originalOutputDirectory);
     } else {
         qDebug() << "Could not create ModelBaker for url" << bakeableModelURL;

--- a/libraries/entities/src/EntityItemPropertiesDocs.cpp
+++ b/libraries/entities/src/EntityItemPropertiesDocs.cpp
@@ -346,7 +346,7 @@
  */
 
 /*@jsdoc
- * The <code>"Model"</code> {@link Entities.EntityType|EntityType} displays a glTF, FBX, or OBJ model. When adding an entity,
+ * The <code>"Model"</code> {@link Entities.EntityType|EntityType} displays a glTF, VRM, FBX, or OBJ model. When adding an entity,
  * if no <code>dimensions</code> value is specified then the model is automatically sized to its
  * <code>{@link Entities.EntityProperties|naturalDimensions}</code>. It has properties in addition to the common
  * {@link Entities.EntityProperties|EntityProperties}.
@@ -355,7 +355,7 @@
  * @property {Vec3} dimensions=0.1,0.1,0.1 - The dimensions of the entity. When adding an entity, if no <code>dimensions</code>
  *     value is specified then the model is automatically sized to its
  *     <code>{@link Entities.EntityProperties|naturalDimensions}</code>.
- * @property {string} modelURL="" - The URL of the glTF, FBX, or OBJ model. glTF models may be in JSON or binary format
+ * @property {string} modelURL="" - The URL of the glTF, VRM, FBX, or OBJ model. glTF models may be in JSON or binary format
  *     (".gltf" or ".glb" URLs respectively). Baked models' URLs have ".baked" before the file type. Model files may also be
  *     compressed in GZ format, in which case the URL ends in ".gz".
  * @property {Vec3} modelScale - The scale factor applied to the model's dimensions.

--- a/libraries/entities/src/EntityTypes.h
+++ b/libraries/entities/src/EntityTypes.h
@@ -60,7 +60,7 @@ public:
      *       <code>"Sphere"</code>. If an entity of type <code>Box</code> or <code>Shape</code> has its <code>shape</code> set
      *       to <code>"Sphere"</code> then its <code>type</code> will be reported as <code>"Sphere"</code>.</td>
      *       <td>{@link Entities.EntityProperties-Sphere|EntityProperties-Sphere}</td></tr>
-     *     <tr><td><code>"Model"</code></td><td>A mesh model from a glTF, FBX, or OBJ file.</td>
+     *     <tr><td><code>"Model"</code></td><td>A mesh model from a glTF, VRM, FBX, or OBJ file.</td>
      *       <td>{@link Entities.EntityProperties-Model|EntityProperties-Model}</td></tr>
      *     <tr><td><code>"Text"</code></td><td>A pane of text oriented in space.</td>
      *       <td>{@link Entities.EntityProperties-Text|EntityProperties-Text}</td></tr>

--- a/libraries/model-serializers/src/GLTFSerializer.cpp
+++ b/libraries/model-serializers/src/GLTFSerializer.cpp
@@ -1164,6 +1164,8 @@ MediaType GLTFSerializer::getMediaType() const {
     mediaType.extensions.push_back("glb");
     mediaType.webMediaTypes.push_back("model/gltf-binary");
 
+    mediaType.extensions.push_back("vrm");
+
     return mediaType;
 }
 
@@ -1365,7 +1367,7 @@ HFMTexture GLTFSerializer::getHFMTexture(const cgltf_texture *texture, cgltf_int
         hfmTex.name = fileName;
         hfmTex.filename = textureUrl.toEncoded();
 
-        if (_url.path().endsWith("glb")) {
+        if (_url.path().endsWith("glb") || _url.path().endsWith("vrm")) {
             cgltf_buffer_view *bufferView = image->buffer_view;
 
             size_t offset = bufferView->offset;

--- a/scripts/system/create/qml/NewModelDialog.qml
+++ b/scripts/system/create/qml/NewModelDialog.qml
@@ -55,7 +55,7 @@ Rectangle {
 
         Text {
             id: text1
-            text: qsTr("Model URL <i>(.fbx, .fst, .glb, .gltf, .obj, .gz)</i>&nbsp;&nbsp;&nbsp;")
+            text: qsTr("Model URL <i>(.fbx, .fst, .glb, .gltf, .vrm, .obj, .gz)</i>&nbsp;&nbsp;&nbsp;")
             color: "#ffffff"
             font.pixelSize: 12
         }

--- a/tools/oven/src/ui/ModelBakeWidget.cpp
+++ b/tools/oven/src/ui/ModelBakeWidget.cpp
@@ -116,7 +116,7 @@ void ModelBakeWidget::chooseFileButtonClicked() {
         startDir = QDir::homePath();
     }
 
-    auto selectedFiles = QFileDialog::getOpenFileNames(this, "Choose Model", startDir, "Models (*.fbx *.obj *.gltf *.fst)");
+    auto selectedFiles = QFileDialog::getOpenFileNames(this, "Choose Model", startDir, "Models (*.fbx *.obj *.gltf *.fst *.vrm)");
 
     if (!selectedFiles.isEmpty()) {
         // set the contents of the model file text box to be the path to the selected file


### PR DESCRIPTION
testing with some models from https://github.com/madjin/vrm-samples/tree/master, these appear to load (mostly?) as model entities, but trying to use them as avatars triggers a warning popup about missing skeletons so seems we're still missing something