### PR TITLE
fix layered material vertex coloring

### DIFF
--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -642,7 +642,7 @@ EntityRenderer::Pipeline EntityRenderer::getPipelineType(const graphics::MultiMa
     }
 
     graphics::MaterialKey drawMaterialKey = materials.getMaterialKey();
-    if (materials.isMToon() || drawMaterialKey.isEmissive() || drawMaterialKey.isMetallic() || drawMaterialKey.isScattering()) {
+    if (materials.isMToon() || materials.getLayers() > 1 || drawMaterialKey.isEmissive() || drawMaterialKey.isMetallic() || drawMaterialKey.isScattering()) {
         return Pipeline::MATERIAL;
     }
 

--- a/libraries/entities-renderer/src/RenderableImageEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableImageEntityItem.cpp
@@ -131,10 +131,10 @@ void ImageEntityRenderer::doRender(RenderArgs* args) {
         materials = _materials["0"];
     }
 
-    glm::vec4 color = materials.getColor();
+    glm::vec4 color = glm::vec4(_color, _alpha);
     color = EntityRenderer::calculatePulseColor(color, _pulseProperties, _created);
 
-    if (!_texture || !_texture->isLoaded() || color.a == 0.0f) {
+    if (!_texture || !_texture->isLoaded() || color.a == 0.0f || materials.isInvisible()) {
         return;
     }
 
@@ -203,6 +203,7 @@ void ImageEntityRenderer::doRender(RenderArgs* args) {
     } else if (pipelineType == Pipeline::SIMPLE) {
         batch->setResourceTexture(0, _texture->getGPUTexture());
     } else if (pipelineType == Pipeline::MATERIAL) {
+        color = glm::vec4(1.0f);  // for model shaders, albedo comes from the material instead of vertex colors
         if (RenderPipelines::bindMaterials(materials, *batch, args->_renderMode, args->_enableTexturing)) {
             args->_details._materialSwitches++;
         }

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1921,11 +1921,11 @@ void PolyVoxEntityRenderer::doRender(RenderArgs* args) {
         batch.setInputFormat(_vertexFormat);
         batch.setUniformBuffer(0, _params);
     } else {
-        glm::vec4 outColor = materials.getColor();
-
-        if (outColor.a == 0.0f) {
+        if (materials.isInvisible()) {
             return;
         }
+
+        glm::vec4 outColor = glm::vec4(1.0f); // albedo comes from the material instead of vertex colors
 
         Pipeline pipelineType = getPipelineType(materials);
         if (pipelineType == Pipeline::PROCEDURAL) {

--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -145,10 +145,10 @@ void TextEntityRenderer::doRender(RenderArgs* args) {
         materials = _materials["0"];
     }
 
-    glm::vec4 backgroundColor = materials.getColor();
+    glm::vec4 backgroundColor = glm::vec4(_backgroundColor, _backgroundAlpha);
     backgroundColor = EntityRenderer::calculatePulseColor(backgroundColor, _pulseProperties, _created);
 
-    if (backgroundColor.a <= 0.0f) {
+    if (backgroundColor.a <= 0.0f || materials.isInvisible()) {
         return;
     }
 
@@ -175,6 +175,7 @@ void TextEntityRenderer::doRender(RenderArgs* args) {
         transparent |= procedural->isFading();
         procedural->prepare(batch, transform.getTranslation(), transform.getScale(), transform.getRotation(), _created, ProceduralProgramKey(transparent));
     } else if (pipelineType == Pipeline::MATERIAL) {
+        backgroundColor = glm::vec4(1.0f); // for model shaders, albedo comes from the material instead of vertex colors
         if (RenderPipelines::bindMaterials(materials, batch, args->_renderMode, args->_enableTexturing)) {
             args->_details._materialSwitches++;
         }

--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -339,6 +339,24 @@ void MultiMaterial::calculateMaterialInfo() const {
     }
 }
 
+bool MultiMaterial::isInvisible() const {
+    for (uint8_t i = 0; i < _layers; i++) {
+        float opacity;
+        if (_isMToon) {
+            const auto& schema = _schemaBuffer.get<graphics::MultiMaterial::MToonSchema>(i);
+            opacity = schema._opacity;
+        } else {
+            const auto& schema = _schemaBuffer.get<graphics::MultiMaterial::Schema>(i);
+            opacity = schema._opacity;
+        }
+
+        if (opacity > 0.0f) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void MultiMaterial::resetReferenceTexturesAndMaterials() {
     _referenceTextures.clear();
     _referenceMaterials.clear();

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -656,20 +656,7 @@ public:
     void setMaterialKey(const graphics::MaterialKey& materialKey) { _materialKey = materialKey; }
     graphics::MaterialKey getMaterialKey() const { return _materialKey; }
     gpu::BufferView& getSchemaBuffer() { return _schemaBuffer; }
-    glm::vec4 getColor() const {
-        glm::vec3 albedo;
-        float opacity;
-        if (_isMToon) {
-            const auto& schema = _schemaBuffer.get<graphics::MultiMaterial::MToonSchema>();
-            albedo = schema._albedo;
-            opacity = schema._opacity;
-        } else {
-            const auto& schema = _schemaBuffer.get<graphics::MultiMaterial::Schema>();
-            albedo = schema._albedo;
-            opacity = schema._opacity;
-        }
-        return glm::vec4(ColorUtils::tosRGBVec3(albedo), opacity);
-    }
+    bool isInvisible() const;
     const std::array<gpu::TextureTablePointer, 3>& getTextureTables() const { return _textureTables; }
 
     void setCullFaceMode(graphics::MaterialKey::CullFaceMode cullFaceMode) { _cullFaceMode = cullFaceMode; }


### PR DESCRIPTION
I've never fully understood this code and with further inspection I think it was just wrong.  in these cases, we were getting the albedo from top material and using it as the vertex color for the whole object, which means albedo colors were actually getting double applied when we used the material pipelines.  it also meant that if you had multiple layers with different albedo colors, the layered color would get multiplied by the top color's albedo an extra time at the end, which would often zero out whole components.

for example, if your top layer was red, and your next layer was blue, all the layering calculations would be correct, but then we'd multiply by red (1, 0, 0) at the end, would would make all the blue areas black.

you can use @ksuprynowicz's json from https://github.com/overte-org/overte/pull/1592#issuecomment-3110846458 to test