### PR TITLE
Snap app: Right-thumbstick trigger with openxr support

### DIFF
--- a/scripts/system/html/SnapshotReview.html
+++ b/scripts/system/html/SnapshotReview.html
@@ -27,7 +27,7 @@
                 <input type="radio" name="cameraCaptures" id="stillOnly" value="stillOnly" /><label for="stillOnly"><span><span></span></span>Still Only</label>
             </form>
         </div>
-        <input type="button" id="snap-button" onclick="takeSnapshot()" />
+        <button id="snap-button" onclick="takeSnapshot();"><u>CLICK</u><br>or press<br>R-STICK<br>in VR</button>
         <div id="snap-settings-right">
             <button type="image" class="blueButton" id="print-button" onclick="printToPolaroid()">
                 <div id="print-icon" class="print-icon print-icon-default">

--- a/scripts/system/html/css/SnapshotReview.css
+++ b/scripts/system/html/css/SnapshotReview.css
@@ -1,8 +1,9 @@
 /*
 //  SnapshotReview.css
 //
-//  Created by Howard Stearns for David Rowe 8/22/2016.
+//  Created by Howard Stearns for David Rowe on August 22nd, 2016.
 //  Copyright 2016 High Fidelity, Inc.
+//  Copyright 2025 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -267,6 +268,8 @@ input[type=button].naked:active {
     box-sizing: content-box;
     display: inline;
     outline:none;
+    color: #f59da7;
+    font-size: 11px;
 }
 #snap-button:disabled {
     background: gray;

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -1,8 +1,9 @@
 //
 // snapshot.js
 //
-// Created by David Kelly on 1 August 2016
-// Copyright 2016 High Fidelity, Inc
+// Created by David Kelly on August 1st, 2016
+// Copyright 2016 High Fidelity, Inc.
+// Copyright 2025 Overte e.V.
 //
 // Distributed under the Apache License, Version 2.0
 // See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -307,7 +308,7 @@ function printToPolaroid(image_url) {
         "shapeType": 'box',
 
         "name": "Snapshot by " + MyAvatar.sessionDisplayName,
-        "description": "Printed from SNAP app",                               
+        "description": "Printed from SNAP app",
         "modelURL": POLAROID_MODEL_URL,
 
         "dimensions": { "x": 0.5667, "y": 0.042, "z": 0.4176 },
@@ -317,7 +318,7 @@ function printToPolaroid(image_url) {
         "textures": JSON.stringify( { "tex.picture": polaroid_url } ),
 
         "density": 200,
-        "restitution": 0.15,                            
+        "restitution": 0.15,
         "gravity": { "x": 0, "y": -2.0, "z": 0 },
         "damping": 0.45,
 
@@ -373,6 +374,7 @@ function fillImageDataFromPrevious() {
             errorPath: Script.resourcesPath() + 'snapshot/img/no-image.jpg'
         });
     }
+    setTakePhotoControllerMappingStatus(true);
 }
 
 function snapshotUploaded(isError, reply) {
@@ -474,6 +476,8 @@ function takeSnapshot() {
             volume: 1.0
         });
         HMD.closeTablet();
+        setTakePhotoControllerMappingStatus(false);
+        
         var DOUBLE_RENDER_TIME_TO_MS = 2000; // If rendering is bogged down, allow double the render time to close the tablet.
         Script.setTimeout(function () {
             Window.takeSnapshot(false, includeAnimated, 1.91);
@@ -530,7 +534,11 @@ function stillSnapshotTaken(pathStillSnapshot, notify) {
     Settings.setValue("previousStillSnapPath", pathStillSnapshot);
 
     HMD.openTablet();
-
+    var includeAnimated = Settings.getValue("alsoTakeAnimatedSnapshot", true);
+    if (!includeAnimated) {
+        setTakePhotoControllerMappingStatus(true);
+    }
+    
     isDomainOpen(snapshotDomainID, function (canShare) {
         snapshotOptions = {
             containsGif: false,
@@ -614,6 +622,7 @@ function processingGifCompleted(pathAnimatedSnapshot) {
             image_data: imageData
         });
     });
+    setTakePhotoControllerMappingStatus(true);
 }
 function maybeDeleteSnapshotStories() {
     storyIDsToMaybeDelete.forEach(function (element, idx, array) {
@@ -703,20 +712,83 @@ function processRezPermissionChange(canRez) {
     });
 }
 
+function setTakePhotoControllerMappingStatus(status) {
+    if (!takePhotoControllerMapping) {
+        return;
+    }
+    if (status) {
+        takePhotoControllerMapping.enable();
+    } else {
+        takePhotoControllerMapping.disable();
+    }
+}
+
+var takePhotoControllerMapping;
+var takePhotoControllerMappingName = 'Hifi-SnapshotApp-Mapping-TakePhoto';
+function registerTakePhotoControllerMapping() {
+    takePhotoControllerMapping = Controller.newMapping(takePhotoControllerMappingName);
+    if (controllerType === "OculusTouch" || controllerType === "OpenXR") {
+        takePhotoControllerMapping.from(Controller.Standard.RS).to(function (value) {
+            if (value === 1.0) {
+                takeSnapshot();
+            }
+            return;
+        });
+    } else if (controllerType === "Vive") {
+        takePhotoControllerMapping.from(Controller.Standard.RightPrimaryThumb).to(function (value) {
+            if (value === 1.0) {
+                takeSnapshot();
+            }
+            return;
+        });
+    }
+}
+
+var controllerType = "Other";
+function registerButtonMappings() {
+    var VRDevices = Controller.getDeviceNames().toString();
+    if (VRDevices) {
+        if (VRDevices.indexOf("Vive") !== -1) {
+            controllerType = "Vive";
+        } else if (VRDevices.indexOf("OculusTouch") !== -1) {
+            controllerType = "OculusTouch";
+        } else if (VRDevices.indexOf("OpenXR") !== -1) {
+            controllerType = "OpenXR";
+        } else {
+            return; // Neither Vive nor Touch detected
+        }
+    }
+
+    if (!takePhotoControllerMapping) {
+        registerTakePhotoControllerMapping();
+    }
+}
+
+function onHMDChanged(isHMDMode) {
+    registerButtonMappings();
+}
+
+function onClosingWindow () {
+    setTakePhotoControllerMappingStatus(false);
+}
+
 function startup() {
     ui = new AppUi({
         buttonName: "SNAP",
         sortOrder: 5,
         home: Script.resolvePath("html/SnapshotReview.html"),
         onOpened: fillImageDataFromPrevious,
-        onMessage: onMessage
+        onMessage: onMessage,
+        onClosed: onClosingWindow
     });
 
+    HMD.displayModeChanged.connect(onHMDChanged);
     Entities.canRezChanged.connect(updatePrintPermissions);
     Entities.canRezTmpChanged.connect(updatePrintPermissions);
     GlobalServices.myUsernameChanged.connect(onUsernameChanged);
     Snapshot.snapshotLocationSet.connect(snapshotLocationSet);
     Window.snapshotShared.connect(snapshotUploaded);
+    registerButtonMappings();
 }
 startup();
 
@@ -726,6 +798,7 @@ function shutdown() {
     GlobalServices.myUsernameChanged.disconnect(onUsernameChanged);
     Entities.canRezChanged.disconnect(updatePrintPermissions);
     Entities.canRezTmpChanged.disconnect(updatePrintPermissions);
+    HMD.displayModeChanged.disconnect(onHMDChanged);
 }
 Script.scriptEnding.connect(shutdown);
 


### PR DESCRIPTION
This PR adds a photo trigger when we press the thumbstick of the right controller.

<img width="482" height="707" alt="image" src="https://github.com/user-attachments/assets/5b8287d3-e811-4fc9-bd79-7c3758377848" />

I added a notice directly on the button.


The code is supposed to support OPEN-XR, But I have not tested this. 
(I reuse what has been done recently in the spectator Camera by ada) 
PLEASE TEST IT.
