### PR TITLE
Disable domain check-in on serverless, disable setKeyboardRaised debug logging

### DIFF
--- a/interface/src/Application_Setup.cpp
+++ b/interface/src/Application_Setup.cpp
@@ -1364,7 +1364,11 @@ void Application::setupSignalsAndOperators() {
 
         // setup a timer for domain-server check ins
         QTimer* domainCheckInTimer = new QTimer(this);
-        connect(domainCheckInTimer, &QTimer::timeout, nodeList.data(), &NodeList::sendDomainServerCheckIn);
+        connect(domainCheckInTimer, &QTimer::timeout, [this, nodeList] {
+            if (!isServerlessMode()) {
+                nodeList->sendDomainServerCheckIn();
+            }
+        });
         domainCheckInTimer->start(DOMAIN_SERVER_CHECK_IN_MSECS);
         connect(this, &QCoreApplication::aboutToQuit, [domainCheckInTimer] {
             domainCheckInTimer->stop();

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -701,8 +701,10 @@ void OffscreenQmlSurface::lowerKeyboard() {
 }
 
 void OffscreenQmlSurface::setKeyboardRaised(QObject* object, bool raised, bool numeric, bool passwordField) {
+#if 0
     qCDebug(uiLogging) << "setKeyboardRaised: " << object << ", raised: " << raised << ", numeric: " << numeric
                        << ", password: " << passwordField;
+#endif
 
     if (!object) {
         return;


### PR DESCRIPTION
These two are big sources of log lines that clog up the log history.

* The domain check-in still attempting on serverless was the cause of #1753.
* The `qCDebug` call at the top of `OffscreenQmlSurface::setKeyboardRaised` was being logged every time the mouse is clicked on main Interface view.

Fixes #1753