### PR TITLE
ContextMenu disable/enable API, Snap app tweaks

### DIFF
--- a/scripts/communityScripts/contextMenu.js
+++ b/scripts/communityScripts/contextMenu.js
@@ -177,6 +177,7 @@ let currentMenuTargetIsAvatar = false;
 let currentMenuInSubmenu = false;
 let currentMenuTargetLine = Uuid.NULL;
 let mouseWasCaptured = false;
+let disableCounter = 0;
 
 function ContextMenu_DeleteMenu() {
 	currentMenuEntities.forEach((_, e) => Entities.deleteEntity(e));
@@ -714,7 +715,7 @@ function ContextMenu_KeyEvent(event) {
 			ContextMenu_DeleteMenu();
 
 			if (!(CONTEXT_MENU_SETTINGS.noSfx ?? false)) { Audio.playSystemSound(SOUND_CLOSE); }
-		} else {
+		} else if (disableCounter === 0) {
 			if (mouseButtonHeld) { ContextMenu_FindTarget(); }
 			ContextMenu_OpenRoot();
 		}
@@ -732,7 +733,7 @@ function ContextMenu_ActionEvent(action, value) {
 			ContextMenu_DeleteMenu();
 
 			if (!(CONTEXT_MENU_SETTINGS.noSfx ?? false)) { Audio.playSystemSound(SOUND_CLOSE); }
-		} else {
+		} else if (disableCounter === 0) {
 			if (controllerHovering[1]) { ContextMenu_FindTarget(1); }
 			else if (controllerHovering[0]) { ContextMenu_FindTarget(0); }
 			ContextMenu_OpenRoot();
@@ -762,6 +763,18 @@ function ContextMenu_ActionEvent(action, value) {
 }*/
 
 function ContextMenu_Message(channel, msg, _senderID, _localOnly) {
+	if (channel === MAIN_CHANNEL) {
+		let data; try { data = JSON.parse(msg); } catch (e) {}
+
+		if (data?.func === "disable") {
+			disableCounter += 1;
+		} else if (data?.func === "enable" && disableCounter > 0) {
+			disableCounter -= 1;
+		}
+
+		return;
+	}
+
 	if (channel !== ACTIONS_CHANNEL) { return; }
 
 	let data; try { data = JSON.parse(msg); } catch (e) {}

--- a/scripts/modules/contextMenu.js
+++ b/scripts/modules/contextMenu.js
@@ -175,12 +175,22 @@ module.exports = {
 	/*
 	 * Disables the context menu open action so the bound buttons can be reused.
 	 *
-	 * NOTE: Call @link{ContextMenu.enable} in @link{Script.scriptEnding} to prevent deadlocks.
+	 * The context menu will stay disabled if another script
+	 * has disabled it and hasn't re-enabled it yet.
+	 *
+	 * NOTE: If your script uses @link{ContextMenu.disable}, you should
+	 * call @link{ContextMenu.enable} in @link{Script.scriptEnding}.
 	 */
 	disable: ContextMenu_disable,
 
 	/**
 	 * Re-enables the context menu open action, after @link{ContextMenu.disable} has been called.
+	 *
+	 * The context menu will stay disabled if another script
+	 * has disabled it and hasn't re-enabled it yet.
+	 *
+	 * NOTE: If your script uses @link{ContextMenu.disable}, you should
+	 * call @link{ContextMenu.enable} in @link{Script.scriptEnding}.
 	 */
 	enable: ContextMenu_enable,
 };

--- a/scripts/system/html/SnapshotReview.html
+++ b/scripts/system/html/SnapshotReview.html
@@ -27,11 +27,11 @@
                 <input type="radio" name="cameraCaptures" id="stillOnly" value="stillOnly" /><label for="stillOnly"><span><span></span></span>Still Only</label>
             </form>
         </div>
-        <button id="snap-button" onclick="takeSnapshot();"><u>CLICK</u><br>or press<br>L-STICK<br>in VR</button>
+        <button id="snap-button" onclick="takeSnapshot();"><u>CLICK</u><br>or press<br>R-STICK<br>in VR</button>
         <div id="snap-settings-right">
-            <button type="image" class="blueButton" id="print-button" onclick="printToPolaroid()">
+            <!--<button type="image" class="blueButton" id="print-button" onclick="printToPolaroid()">
                 <div id="print-icon" class="print-icon print-icon-default">
-            </button>
+            </button>-->
         </div>
     </div>
 </body>

--- a/scripts/system/html/css/SnapshotReview.css
+++ b/scripts/system/html/css/SnapshotReview.css
@@ -268,11 +268,12 @@ input[type=button].naked:active {
     box-sizing: content-box;
     display: inline;
     outline:none;
-    color: #f59da7;
+    color: #f5bdc7;
     font-size: 11px;
 }
 #snap-button:disabled {
     background: gray;
+    color: #eee;
 }
 #snap-button:hover:enabled {
     background: #C62147;

--- a/scripts/system/html/js/SnapshotReview.js
+++ b/scripts/system/html/js/SnapshotReview.js
@@ -313,7 +313,7 @@ function addImage(image_data, isLoggedIn, canShare, isGifLoading, isShowingPrevi
         if (isGif) {
             imageContainer.innerHTML += '<span class="gifLabel">GIF</span>';
         }
-        if (!isGifLoading) {
+        /*if (!isGifLoading) {
             appendShareBar(id, isLoggedIn, canShare, isGif, blastButtonDisabled, hifiButtonDisabled, canBlast);
         }
         if ((!isShowingPreviousImages && ((isGif && !isGifLoading) || !isGif)) || (isShowingPreviousImages && !image_data.story_id)) {
@@ -324,7 +324,7 @@ function addImage(image_data, isLoggedIn, canShare, isGifLoading, isShowingPrevi
         }
         if (isShowingPreviousImages) {
             requestPrintButtonUpdate();  
-        } 
+        }*/
     };
     img.onerror = function () {
         img.onload = null;
@@ -675,8 +675,8 @@ window.onload = function () {
                             p1img.src = gifPath;
 
                             paths[1] = gifPath;
-                            shareForUrl("p1");
-                            appendShareBar("p1", messageOptions.isLoggedIn, messageOptions.canShare, true, false, false, messageOptions.canBlast);
+                            //shareForUrl("p1");
+                            //appendShareBar("p1", messageOptions.isLoggedIn, messageOptions.canShare, true, false, false, messageOptions.canBlast);
                             document.getElementById("p1").classList.remove("processingGif");
                             document.getElementById("snap-button").disabled = false;
                         }

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -15,6 +15,9 @@
 (function () { // BEGIN LOCAL_SCOPE
 Script.include("/~/system/libraries/accountUtils.js");
 var AppUi = Script.require('appUi');
+
+// The context menu uses the thumbstick click button on some controllers,
+// temporarily block it so it doesn't conflict with the snap app shortcut
 var ContextMenu = Script.require('contextMenu');
 
 var SNAPSHOT_DELAY = 500; // 500ms
@@ -803,7 +806,7 @@ function shutdown() {
     Entities.canRezTmpChanged.disconnect(updatePrintPermissions);
     HMD.displayModeChanged.disconnect(onHMDChanged);
 
-    // prevent deadlock
+    // release the context menu if we disabled it
     ContextMenu.enable();
 }
 Script.scriptEnding.connect(shutdown);

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -15,6 +15,7 @@
 (function () { // BEGIN LOCAL_SCOPE
 Script.include("/~/system/libraries/accountUtils.js");
 var AppUi = Script.require('appUi');
+var ContextMenu = Script.require('contextMenu');
 
 var SNAPSHOT_DELAY = 500; // 500ms
 var FINISH_SOUND_DELAY = 350;
@@ -718,8 +719,10 @@ function setTakePhotoControllerMappingStatus(status) {
     }
     if (status) {
         takePhotoControllerMapping.enable();
+        ContextMenu.disable();
     } else {
         takePhotoControllerMapping.disable();
+        ContextMenu.enable();
     }
 }
 
@@ -728,14 +731,14 @@ var takePhotoControllerMappingName = 'Hifi-SnapshotApp-Mapping-TakePhoto';
 function registerTakePhotoControllerMapping() {
     takePhotoControllerMapping = Controller.newMapping(takePhotoControllerMappingName);
     if (controllerType === "OculusTouch" || controllerType === "OpenXR") {
-        takePhotoControllerMapping.from(Controller.Standard.LS).to(function (value) {
+        takePhotoControllerMapping.from(Controller.Standard.RS).to(function (value) {
             if (value === 1.0) {
                 takeSnapshot();
             }
             return;
         });
     } else if (controllerType === "Vive") {
-        takePhotoControllerMapping.from(Controller.Standard.LeftPrimaryThumb).to(function (value) {
+        takePhotoControllerMapping.from(Controller.Standard.RightPrimaryThumb).to(function (value) {
             if (value === 1.0) {
                 takeSnapshot();
             }
@@ -799,6 +802,9 @@ function shutdown() {
     Entities.canRezChanged.disconnect(updatePrintPermissions);
     Entities.canRezTmpChanged.disconnect(updatePrintPermissions);
     HMD.displayModeChanged.disconnect(onHMDChanged);
+
+    // prevent deadlock
+    ContextMenu.enable();
 }
 Script.scriptEnding.connect(shutdown);
 


### PR DESCRIPTION
* The Snap app now temporarily disables opening the context menu so they don't conflict with the thumbstick clicks. On controllers with a primary button this wasn't an issue, but on WMR and Vive controllers, or OpenVR, the thumbstick click is also mapped to the primary button.
* Moved the Snap shortcut button back to the right thumbstick
* Commented out the print and share buttons from the snap app, they haven't worked for years and relied on centralised HiFi stuff that's long dead