### PR TITLE
Use Depot.dev for Windows CI builds

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -37,7 +37,8 @@ jobs:
       matrix:
         include:
           - os: Windows 2022
-            runner: windows-2022
+            # We use a third-party runner hosted by depot.dev to avoid timing out in case Qt has to be built from source.
+            runner: depot-windows-2022-8
             build_type: full
             qt_source: source
           #- os: macOS 10.15

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -46,7 +46,8 @@ jobs:
         matrix:
           include:
             - os: Windows 2022
-              runner: windows-2022
+              # We use a third-party runner hosted by depot.dev to avoid timing out in case Qt has to be built from source.
+              runner: depot-windows-2022-8
               arch: x86_64
               build_type: full
               qt_source: source
@@ -134,7 +135,7 @@ jobs:
           else
             echo "CMAKE_EXTRA=-A x64 -DJSDOC_ENABLED:BOOL=TRUE -DCLIENT_ONLY=1" >> $GITHUB_ENV
           fi
-          if [[ "${{ matrix.runner }}" = "windows-2022" ]]; then
+          if [[ "${{ matrix.os }}" = "Windows 2022" ]]; then
             echo "CONAN_PROFILE='./tools/conan-profiles/vs-22-release'" >> $GITHUB_ENV
           else
             echo "Not sure which Conan profile to use. Exiting." && exit 1

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -33,10 +33,12 @@ jobs:
       matrix:
         include:
           - os: windows-2022
+            # We use a third-party runner hosted by depot.dev to avoid timing out in case Qt has to be built from source.
+            runner: depot-windows-2022-8
             build_type: full
             qt_source: source
       fail-fast: false
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.runner}}
     steps:
     - name: Configure build environment 1
       shell: bash

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ SPDX-License-Identifier: Apache-2.0
     <a href="https://github.com/overte-org/overte/network"><img alt="GitHub forks" src="https://img.shields.io/github/forks/overte-org/overte"></a>
     <a href="https://www.apache.org/licenses/LICENSE-2.0"><img alt="Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-%230A7BBB?style=flat"></a>
     <a href="https://matrix.to/#/#overte:matrix.org"><img alt="Matrix" src="https://img.shields.io/matrix/overte:matrix.org?label=Matrix%20chat"></a>
+    <a href="https://depot.dev/?utm_source=Overte"><img alt="Built with Depot" src="https://depot.dev/badges/built-with-depot.svg"></a>
 </p>
 <h3 align="center">Build Status</h3>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <!--
 Copyright 2013-2019 High Fidelity, Inc.
 Copyright 2019-2021 Vircadia contributors
-Copyright 2021-2022 Overte e.V.
+Copyright 2021-2025 Overte e.V.
 SPDX-License-Identifier: Apache-2.0
 -->
 
 <p align="center"><a href="https://overte.org/"><picture><source srcset="interface/resources/images/brand-banner.svg" alt="Overte" width="350" media="(prefers-color-scheme: dark)"><img src="interface/resources/images/brand-banner-black.svg" alt="Overte" width="350"></picture></a></p>
 
-<h3 align="center"><a href="https://overte.org/">Website</a> | <a href="https://matrix.to/#/#overte:matrix.org">Matrix</a> | <a href="https://overte.org/#download">Download</a></h3>
+<h3 align="center"><a href="https://overte.org/">Website</a> | <a href="https://matrix.to/#/#overte:matrix.org">Matrix</a> | <a href="https://overte.org/downloads.html">Download</a></h3>
 <p align="center">
     <a href="https://docs.overte.org/en/latest/contribute.html"><img alt="GitHub contributors" src="https://img.shields.io/github/contributors/overte-org/overte"></a>
     <a href="https://github.com/overte-org/overte/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/overte-org/overte"></a>
@@ -17,10 +17,9 @@ SPDX-License-Identifier: Apache-2.0
 </p>
 <h3 align="center">Build Status</h3>
 <p align="center">
-    <a href="https://github.com/overte-org/overte/actions/workflows/master_build.yml"><img alt="Master CI Build" src="https://github.com/overte-org/overte/actions/workflows/master_build.yml/badge.svg"></a>
+    <a href="https://github.com/overte-org/overte/actions/workflows/nightly_build.yml"><img alt="Nightly CI Build" src="https://github.com/overte-org/overte/actions/workflows/nightly_build.yml/badge.svg"></a>
     <a href="https://github.com/overte-org/overte/actions/workflows/master_deploy_apidocs.yml"><img alt="API-docs CI Build & Deploy" src="https://github.com/overte-org/overte/actions/workflows/master_deploy_apidocs.yml/badge.svg"></a>
     <a href="https://github.com/overte-org/overte/actions/workflows/master_deploy_doxygen.yml"><img alt="Doxygen CI Build & Deploy" src="https://github.com/overte-org/overte/actions/workflows/master_deploy_doxygen.yml/badge.svg"></a>
-    <a href="https://api.reuse.software/info/github.com/overte-org/overte"><img alt="REUSE status" src="https://api.reuse.software/badge/github.com/overte-org/overte"></a>
 </p>
 
 ### What is this?
@@ -39,8 +38,7 @@ Overte is a free and open source 3D social virtual worlds software.
 
 ### Releases
 
-[View Releases here](https://github.com/overte-org/overte/releases/)
-[Pre-releases for testing are available here](https://public.overte.org/index.html#build/overte/)
+[View Releases (and pre-releases) here](https://github.com/overte-org/overte/releases/)
 
 ### How to deploy a Server
 
@@ -64,13 +62,12 @@ Overte is a free and open source 3D social virtual worlds software.
 #### How to generate an Installer
 
 - [For Windows - Interface & Server](https://github.com/overte-org/overte/blob/master/INSTALLER.md)
-- [For Mac - Interface](https://github.com/overte-org/overte/blob/master/INSTALLER.md#os-x)
-- [For Linux - Server .deb - Overte Builder](INSTALLER.md#ubuntu-1804--deb)
-- [For Linux - Interface AppImage - Overte Builder](https://github.com/overte-org/overte-builder/blob/master/README.md#building-appimages)
+- [For Mac - Interface](https://github.com/overte-org/overte/blob/master/INSTALLER.md)
+- [For Linux - Interface AppImage & Server .deb/.rpm - Overte Builder](https://github.com/overte-org/overte/blob/master/INSTALLER.md)
 
 ### Mission statement
 
-Overte aims to provide social virtual worlds experience with entitely free and open source infrastructure.
+Overte aims to provide social virtual worlds experiences with entirely free and open source infrastructure.
 
 ### Technical details
 
@@ -80,15 +77,18 @@ Overte consists of many projects and codebases with its unifying structure's goa
 - The Server - You are also here!
 - [The Directory Server (Codename Iamus)](https://github.com/overte-org/overte-metaverse/)
 - [The Directory Server Dashboard (Codename Iamus)](https://github.com/overte-org/metaverse-dashboard/)
-- [The Launcher (Codename Pantheon)](https://github.com/overte-org/pantheon-launcher/) - Currently Windows only.
+- [Our downstream Conan recipies](https://github.com/overte-org/overte-conan-recipes)
 
 #### Tools
 - [Overte Builder for Linux](https://github.com/overte-org/overte-builder/)
 
 #### Documentation
 - [User Documentation](https://github.com/overte-org/overte-docs-sphinx/)
-- [Developer Documentation](https://github.com/overte-org/overte-dev-docs/)
+- [API Documentation (JavaScript)](https://apidocs.overte.org/) - Generated using JSDoc [here](https://github.com/overte-org/overte/tree/master/tools/jsdoc).
+- [Doxygen (C++)](https://doxygen.overte.org/)
 
 ### Contribution
 
-There are many contributors to Overte. Code writers, reviewers, testers, documentation writers, modellers, and general supporters of the project are all integral to its development and success towards its goals. Find out how you can [contribute](https://docs.overte.org/en/latest/contribute.html)!
+There are many contributors to Overte.
+Code writers, reviewers, testers, documentation writers, modellers, and general supporters of the project are all integral to its development and success towards its goals.
+Find out how you can [contribute](https://docs.overte.org/en/latest/contribute.html)!


### PR DESCRIPTION
Use depot.dev for Windows builds. Our Windows builds time out on GitHub's hosted runners if we are building Qt from source.
They are sponsoring us, hence the "Built with Depot" addition to the README.

This PR also updates our README.