### PR TITLE
Update SDL2 to 2.32.8. 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -71,7 +71,7 @@ class Overte(ConanFile):
         self.requires("polyvox/0.2.1@overte/stable")
         self.requires("quazip/1.4")
         self.requires("scribe/2019.02@overte/stable")
-        self.requires("sdl/2.30.3")
+        self.requires("sdl/2.32.8")
         self.requires("spirv-cross/1.3.268.0")
         self.requires("spirv-tools/1.3.268.0")
         self.requires("steamworks/158a@overte/prebuild")


### PR DESCRIPTION
Fixes: https://github.com/overte-org/overte/issues/1762

This is waiting on Conan Center accepting SDL being updated to 2.32.8.

I don't think this requires QA, since there appear to be no breaking changes in SDL (https://github.com/libsdl-org/SDL/releases/tag/release-2.32.0) and this is just a minor dependency update.