### PR TITLE
Make "failed to load script" message less intrusive

### DIFF
--- a/interface/src/Application_Setup.cpp
+++ b/interface/src/Application_Setup.cpp
@@ -1476,7 +1476,8 @@ void Application::setupSignalsAndOperators() {
 
             connect(scriptEngines, &ScriptEngines::scriptLoadError,
                 this, [](const QString& filename, const QString& error) {
-                OffscreenUi::asyncWarning(nullptr, "Error Loading Script", filename + " failed to load.");
+                auto windowInterface = DependencyManager::get<WindowScriptingInterface>();
+                windowInterface->displayAnnouncement(QString("Failed to load script\n%1").arg(filename));
             }, Qt::QueuedConnection);
 
             auto entityScriptServerLog = DependencyManager::get<EntityScriptServerLogClient>();

--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -579,6 +579,11 @@ void ScriptManager::loadURL(const QUrl& scriptURL, bool reload) {
         if (!success) {
             scriptErrorMessage("ERROR Loading file (" + status + "):" + url, url, -1);
             emit errorLoadingScript(_fileNameString);
+
+            // emitting scriptLoaded will keep Interface from discarding
+            // scripts that might only be temporarily unavailable
+            emit scriptLoaded(url);
+
             return;
         }
 


### PR DESCRIPTION
* The "failed to load" message is now a notification instead of a modal popup window

  **Note:** `notifications.js` is a script too, and it might load after any scripts that emit the "failed to load" notification
* The failed script stays in the interface script list, in case the script couldn't load because of temporary network issues