### PR TITLE
Fix GitHub Actions cache miss

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -39,6 +39,7 @@ jobs:
           - os: Windows 2022
             # We use a third-party runner hosted by depot.dev to avoid timing out in case Qt has to be built from source.
             runner: depot-windows-2022-8
+            arch: x86_64
             build_type: full
             qt_source: source
           #- os: macOS 10.15

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -195,6 +195,13 @@ jobs:
       run: conan cache clean "*" -sbd
       shell: bash
 
+    - name: Save Conan cache
+      if: always() && steps.conan-cache.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: conan-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('conanfile.py') }}
+        path: ~/.conan2/
+
     - name: Configure CMake
       shell: bash
       run: |

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -32,9 +32,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2022
+          - os: Windows 2022
             # We use a third-party runner hosted by depot.dev to avoid timing out in case Qt has to be built from source.
             runner: depot-windows-2022-8
+            arch: x86_64
             build_type: full
             qt_source: source
       fail-fast: false
@@ -67,7 +68,7 @@ jobs:
         echo "SYMBOLS_ARCHIVE=$RELEASE_NUMBER-${{ github.sha }}-win-symbols.zip" >> $GITHUB_ENV
         # echo "HF_PFX_PASSPHRASE=${{secrets.pfx_key}}" >> $GITHUB_ENV
         # echo "HF_PFX_FILE=${{runner.workspace}}\build\codesign.pfx" >> $GITHUB_ENV
-        if [[ "${{ matrix.os }}" = "windows-2022" ]]; then
+        if [[ "${{ matrix.os }}" = "Windows 2022" ]]; then
           echo "CONAN_PROFILE='./tools/conan-profiles/vs-22-release'" >> $GITHUB_ENV
         else
           echo "Not sure which Conan profile to use. Exiting." && exit 1

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -85,6 +85,12 @@ jobs:
         submodules: false
         fetch-depth: 1
 
+    - name: Cache conan
+      uses: actions/cache@v4
+      with:
+        key: conan-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('conanfile.py') }}
+        path: ~/.conan2/
+
     - name: Override Windows package versions
       shell: pwsh
       if: startsWith(matrix.os, 'windows')
@@ -122,6 +128,17 @@ jobs:
       run: |
         conan list --graph=build.json --graph-binaries=build --format=json > pkglist.json
         conan upload --list=pkglist.json -r=overte -c
+
+    - name: Cleanup Conan dependencies
+      run: conan cache clean "*" -sbd
+      shell: bash
+
+    - name: Save Conan cache
+      if: always() && steps.conan-cache.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        key: conan-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('conanfile.py') }}
+        path: ~/.conan2/
 
     - name: Configure CMake
       shell: bash


### PR DESCRIPTION
This PR fixes a GitHub Actions cache miss due to a missing architecture key.
It also enables the cache for nightly and release builds.