### PR TITLE
Swap out Reinhard and Filmic tonemaps for nicer looking variants

### DIFF
--- a/libraries/render-utils/src/toneMapping.slf
+++ b/libraries/render-utils/src/toneMapping.slf
@@ -13,6 +13,32 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+//  ---
+//  https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/ACES.hlsl
+//  Copyright (c) 2022 @64
+//
+//  https://github.com/64/64.github.io/blob/src/code/tonemapping/tonemap.cpp
+//  Copyright (c) 2016 MJP
+//  ---
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
 
 <@include render-utils/ShaderConstants.h@>
 
@@ -43,8 +69,6 @@ LAYOUT(binding=RENDER_UTILS_TEXTURE_TM_COLOR) uniform sampler2D colorMap;
 layout(location=0) in vec2 varTexCoord0;
 layout(location=0) out vec4 outFragColor;
 
-// https://64.github.io/tonemapping/
-// MIT License
 float luminance(vec3 v) {
     return dot(v, vec3(0.2126, 0.7152, 0.722));
 }
@@ -67,8 +91,6 @@ void main(void) {
     int toneCurve = getToneCurve();
     vec3 tonedColor = srcColor;
     if (toneCurve == ToneCurveFilmic) {
-        // https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/ACES.hlsl
-        // MIT License
         const mat3 acesInput = mat3(
             0.59719, 0.07600, 0.02840,
             0.35458, 0.90834, 0.13383,
@@ -89,8 +111,6 @@ void main(void) {
         tonedColor = acesOutput * tonedColor;
         tonedColor = clamp(tonedColor, vec3(0.0), vec3(1.0));
     } else if (toneCurve == ToneCurveReinhard) {
-        // https://64.github.io/tonemapping/
-        // MIT License
         const float whitePoint = 2.0;
         float luminanceOld = luminance(srcColor);
         float numerator = luminanceOld * (1.0 + (luminanceOld / (whitePoint * whitePoint)));
@@ -103,10 +123,10 @@ void main(void) {
         // Since the conversion happens automatically, we don't need to do anything in this shader
     } else {
         // toneCurve == ToneCurveNone
-        // For debugging purposes, we may want to see what the colors look like before the automatic OpenGL 
+        // For debugging purposes, we may want to see what the colors look like before the automatic OpenGL
         // conversion mentioned above, so we undo it here
         tonedColor = pow(srcColor, vec3(GAMMA_22));
-    } 
+    }
 
     outFragColor = vec4(tonedColor, 1.0);
 }

--- a/libraries/render-utils/src/toneMapping.slf
+++ b/libraries/render-utils/src/toneMapping.slf
@@ -8,6 +8,7 @@
 //
 //  Created by Sam Gateau on 6/22/2015
 //  Copyright 2015 High Fidelity, Inc.
+//  Copyright 2025 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -42,6 +43,17 @@ LAYOUT(binding=RENDER_UTILS_TEXTURE_TM_COLOR) uniform sampler2D colorMap;
 layout(location=0) in vec2 varTexCoord0;
 layout(location=0) out vec4 outFragColor;
 
+// https://64.github.io/tonemapping/
+// MIT License
+float luminance(vec3 v) {
+    return dot(v, vec3(0.2126, 0.7152, 0.722));
+}
+
+vec3 changeLuminance(vec3 colorIn, float luminanceOut) {
+    float luminanceIn = luminance(colorIn);
+    return colorIn * (luminanceOut / luminanceIn);
+}
+
 void main(void) {
 <@if HIFI_USE_MIRRORED@>
     vec4 fragColorRaw = texture(colorMap, vec2(1.0 - varTexCoord0.x, varTexCoord0.y));
@@ -55,10 +67,35 @@ void main(void) {
     int toneCurve = getToneCurve();
     vec3 tonedColor = srcColor;
     if (toneCurve == ToneCurveFilmic) {
-        vec3 x = max(vec3(0.0), srcColor-0.004);
-        tonedColor = pow((x * (6.2 * x + 0.5)) / (x * (6.2 * x + 1.7) + 0.06), vec3(GAMMA_22));
+        // https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/ACES.hlsl
+        // MIT License
+        const mat3 acesInput = mat3(
+            0.59719, 0.07600, 0.02840,
+            0.35458, 0.90834, 0.13383,
+            0.04823, 0.01566, 0.83777
+        );
+        const mat3 acesOutput = mat3(
+            1.60475, -0.10208, -0.00327,
+            -0.53108, 1.10813, -0.07276,
+            -0.07367, -0.00605, 1.07602
+        );
+
+        tonedColor = acesInput * tonedColor;
+
+        vec3 a = tonedColor * (tonedColor + 0.0245786) - 0.000090537;
+        vec3 b = tonedColor * (0.983729 * tonedColor + 0.4329510) + 0.238081;
+        tonedColor = a / b;
+
+        tonedColor = acesOutput * tonedColor;
+        tonedColor = clamp(tonedColor, vec3(0.0), vec3(1.0));
     } else if (toneCurve == ToneCurveReinhard) {
-        tonedColor = srcColor/(1.0 + srcColor);
+        // https://64.github.io/tonemapping/
+        // MIT License
+        const float whitePoint = 2.0;
+        float luminanceOld = luminance(srcColor);
+        float numerator = luminanceOld * (1.0 + (luminanceOld / (whitePoint * whitePoint)));
+        float luminanceNew = numerator / (1.0 + luminanceOld);
+        tonedColor = changeLuminance(srcColor, luminanceNew);
     } else if (toneCurve == ToneCurveGamma22) {
         // We use glEnable(GL_FRAMEBUFFER_SRGB), which automatically converts textures from RGB to SRGB
         // when writing from an RGB framebuffer to an SRGB framebuffer (note that it doesn't do anything


### PR DESCRIPTION
* [Extended Reinhard tonemap on luminance](https://64.github.io/tonemapping/#extended-reinhard-luminance-tone-map), [MIT licensed](https://github.com/64/64.github.io/blob/src/LICENSE.md)
* [ACES tonemap](https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/ACES.hlsl), MIT licensed, translated from HLSL to GLSL

I'm not quite sure how we should attribute these sources, any tips would be appreciated. For now, the shader snippets have comments linking to the originals.

## Before, Currently on Master
| sRGB (Identity) | Reinhard on RGB | Filmic
| --- | --- | ---
| <img width="1280" height="960" alt="overte-snap-by-ada-tv-on-2025-08-30_15-57-10" src="https://github.com/user-attachments/assets/12267381-bc84-4fcd-9dc6-c1e6a16d035c" /> | <img width="1280" height="960" alt="overte-snap-by-ada-tv-on-2025-08-30_15-57-13" src="https://github.com/user-attachments/assets/8f6b39ed-5b96-4668-9215-c0b2d0f488d4" /> | <img width="1280" height="960" alt="overte-snap-by-ada-tv-on-2025-08-30_15-57-16" src="https://github.com/user-attachments/assets/dc8d190c-ebf0-44cc-9e51-99efdcc0771b" />

## After, This PR
| sRGB (Idenity) | Reinhard on Luminance, Max white 2.0 | ACES
| --- | --- | ---
| <img width="1280" height="960" alt="overte-snap-by-ada-tv-on-2025-08-30_17-03-04" src="https://github.com/user-attachments/assets/1cae451d-b675-498d-940d-6c7088c15871" /> | <img width="1280" height="960" alt="overte-snap-by-ada-tv-on-2025-08-30_17-03-19" src="https://github.com/user-attachments/assets/dfc0635c-2c2c-459c-8a22-a2544cd84913" /> | <img width="1280" height="960" alt="overte-snap-by-ada-tv-on-2025-08-30_17-03-30" src="https://github.com/user-attachments/assets/f42dd8a2-9280-471d-9717-37dc78488a0e" />
