### PR TITLE
Local lights on forward renderer

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -424,6 +424,9 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::AmbientOcclusion, 0, RenderScriptingInterface::getInstance()->getAmbientOcclusionEnabled(),
         RenderScriptingInterface::getInstance(), SLOT(setAmbientOcclusionEnabled(bool)));
 
+    addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::LocalLights, 0, RenderScriptingInterface::getInstance()->getLocalLightingEnabled(),
+        RenderScriptingInterface::getInstance(), SLOT(setLocalLightingEnabled(bool)));
+
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::WorldAxes);
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::DefaultSkybox, 0, true);
 

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -233,6 +233,7 @@ namespace MenuOption {
     const QString HMDTabletToToolbar = "HMD Tablet Becomes Toolbar";
     const QString Shadows = "Shadows";
     const QString AmbientOcclusion = "Ambient Occlusion";
+    const QString LocalLights = "Local Lights";
     const QString NotificationSounds = "play_notification_sounds";
     const QString NotificationSoundsSnapshot = "play_notification_sounds_snapshot";
     const QString NotificationSoundsTablet = "play_notification_sounds_tablet";

--- a/interface/src/scripting/RenderScriptingInterface.cpp
+++ b/interface/src/scripting/RenderScriptingInterface.cpp
@@ -244,6 +244,27 @@ void RenderScriptingInterface::forceAmbientOcclusionEnabled(bool enabled) {
     });
 }
 
+bool RenderScriptingInterface::getLocalLightingEnabled() const {
+    return _localLightingEnabled;
+}
+
+void RenderScriptingInterface::setLocalLightingEnabled(bool enabled) {
+    if (_localLightingEnabled != enabled) {
+        forceLocalLightingEnabled(enabled);
+        emit settingsChanged();
+    }
+}
+
+void RenderScriptingInterface::forceLocalLightingEnabled(bool enabled) {
+    _renderSettingLock.withWriteLock([&] {
+        _localLightingEnabled = (enabled);
+        _localLightingSetting.set(enabled);
+        Menu::getInstance()->setIsOptionChecked(MenuOption::LocalLights, enabled);
+
+        recursivelyUpdateLightingModel("", [enabled] (MakeLightingModelConfig *config) { config->setLocalLighting(enabled); });
+    });
+}
+
 bool RenderScriptingInterface::getProceduralMaterialsEnabled() const {
     return _proceduralMaterialsEnabled;
 }

--- a/interface/src/scripting/RenderScriptingInterface.cpp
+++ b/interface/src/scripting/RenderScriptingInterface.cpp
@@ -20,6 +20,7 @@
 #include "ScreenName.h"
 
 #include <procedural/Procedural.h>
+#include "LightClusters.h"
 
 STATIC_SCRIPT_TYPES_INITIALIZER((+[](ScriptManager* manager){
     auto scriptEngine = manager->engine().get();
@@ -261,7 +262,12 @@ void RenderScriptingInterface::forceLocalLightingEnabled(bool enabled) {
         _localLightingSetting.set(enabled);
         Menu::getInstance()->setIsOptionChecked(MenuOption::LocalLights, enabled);
 
-        recursivelyUpdateLightingModel("", [enabled] (MakeLightingModelConfig *config) { config->setLocalLighting(enabled); });
+        auto renderConfig = qApp->getRenderEngine()->getConfiguration();
+        auto config = renderConfig->getConfig<LightClusteringPass>("LightClustering");
+
+        if (config) {
+            config->setLocalLightingEnabled(enabled);
+        }
     });
 }
 

--- a/interface/src/scripting/RenderScriptingInterface.h
+++ b/interface/src/scripting/RenderScriptingInterface.h
@@ -31,8 +31,10 @@
  * @property {boolean} shadowsEnabled - <code>true</code> if shadows are enabled, <code>false</code> if they're disabled.
  * @property {boolean} hazeEnabled - <code>true</code> if haze (fog) is enabled, <code>false</code> if it's disabled.
  * @property {boolean} bloomEnabled - <code>true</code> if bloom is enabled, <code>false</code> if it's disabled.
- * @property {boolean} ambientOcclusionEnabled - <code>true</code> if ambient occlusion is enabled, <code>false</code> if it's
- *     disabled.
+ * @property {boolean} ambientOcclusionEnabled - <code>true</code> if ambient occlusion is enabled, <code>false</code> if it's disabled.
+ * @property {boolean} localLightingEnabled - <code>true</code> if local lights are enabled
+ * on the forward renderer, <code>false</code> if it's disabled. Local lights are always
+ * enabled on the deferred renderer.
  * @property {boolean} proceduralMaterialsEnabled - <code>true</code> if procedural shaders are enabled, <code>false</code> if
  *     they're disabled.
  * @property {integer} antialiasingMode - The active anti-aliasing mode.
@@ -46,6 +48,7 @@ class RenderScriptingInterface : public QObject {
     Q_PROPERTY(bool hazeEnabled READ getHazeEnabled WRITE setHazeEnabled NOTIFY settingsChanged)
     Q_PROPERTY(bool bloomEnabled READ getBloomEnabled WRITE setBloomEnabled NOTIFY settingsChanged)
     Q_PROPERTY(bool ambientOcclusionEnabled READ getAmbientOcclusionEnabled WRITE setAmbientOcclusionEnabled NOTIFY settingsChanged)
+    Q_PROPERTY(bool localLightingEnabled READ getLocalLightingEnabled WRITE setLocalLightingEnabled NOTIFY settingsChanged)
     Q_PROPERTY(AntialiasingSetupConfig::Mode antialiasingMode READ getAntialiasingMode WRITE setAntialiasingMode NOTIFY settingsChanged)
     Q_PROPERTY(bool proceduralMaterialsEnabled READ getProceduralMaterialsEnabled WRITE setProceduralMaterialsEnabled NOTIFY settingsChanged)
     Q_PROPERTY(float viewportResolutionScale READ getViewportResolutionScale WRITE setViewportResolutionScale NOTIFY settingsChanged)
@@ -186,6 +189,22 @@ public slots:
     void setAmbientOcclusionEnabled(bool enabled);
 
     /*@jsdoc
+     * Gets whether or not local lighting is enabled on the forward renderer.
+     * Local lights are always enabled on the deferred renderer.
+     * @function Render.getLocalLightingEnabled
+     * @returns {boolean} <code>true</code> if local lighting is enabled, <code>false</code> if it's disabled.
+     */
+    bool getLocalLightingEnabled() const;
+
+    /*@jsdoc
+     * Sets whether or not local lighting is enabled on the forward renderer.
+     * Has no effect when using the deferred renderer, where local lights are always enabled.
+     * @function Render.setLocalLightingEnabled
+     * @param {boolean} enabled - <code>true</code> to enable local lights, <code>false</code> to disable.
+     */
+    void setLocalLightingEnabled(bool enabled);
+
+    /*@jsdoc
      * Gets whether or not procedural materials are enabled.
      * @function Render.getProceduralMaterialsEnabled
      * @returns {boolean} <code>true</code> if procedural materials are enabled, <code>false</code> if they're disabled.
@@ -303,6 +322,7 @@ private:
     bool _hazeEnabled { true };
     bool _bloomEnabled { true };
     bool _ambientOcclusionEnabled { true };
+    bool _localLightingEnabled { true };
     bool _proceduralMaterialsEnabled { true };
     AntialiasingSetupConfig::Mode _antialiasingMode { AntialiasingSetupConfig::Mode::NONE };
     float _viewportResolutionScale { 1.0f };
@@ -314,6 +334,7 @@ private:
     Setting::Handle<bool> _hazeEnabledSetting { "hazeEnabled", true };
     Setting::Handle<bool> _bloomEnabledSetting { "bloomEnabled", true };
     Setting::Handle<bool> _ambientOcclusionEnabledSetting { "ambientOcclusionEnabled", true };
+    Setting::Handle<bool> _localLightingSetting { "localLightingEnabled", true };
     Setting::Handle<bool> _proceduralMaterialsEnabledSetting { "proceduralMaterialsEnabled", true };
     Setting::Handle<int> _antialiasingModeSetting { "antialiasingMode", (int)AntialiasingSetupConfig::Mode::NONE };
     Setting::Handle<float> _viewportResolutionScaleSetting { "viewportResolutionScale", 1.0f };
@@ -325,6 +346,7 @@ private:
     void forceHazeEnabled(bool enabled);
     void forceBloomEnabled(bool enabled);
     void forceAmbientOcclusionEnabled(bool enabled);
+    void forceLocalLightingEnabled(bool enabled);
     void forceProceduralMaterialsEnabled(bool enabled);
     void forceAntialiasingMode(AntialiasingSetupConfig::Mode mode);
     void forceViewportResolutionScale(float scale);

--- a/interface/src/scripting/RenderScriptingInterface.h
+++ b/interface/src/scripting/RenderScriptingInterface.h
@@ -32,9 +32,8 @@
  * @property {boolean} hazeEnabled - <code>true</code> if haze (fog) is enabled, <code>false</code> if it's disabled.
  * @property {boolean} bloomEnabled - <code>true</code> if bloom is enabled, <code>false</code> if it's disabled.
  * @property {boolean} ambientOcclusionEnabled - <code>true</code> if ambient occlusion is enabled, <code>false</code> if it's disabled.
- * @property {boolean} localLightingEnabled - <code>true</code> if local lights are enabled
- * on the forward renderer, <code>false</code> if it's disabled. Local lights are always
- * enabled on the deferred renderer.
+ * @property {boolean} localLightingEnabled - <code>true</code> if local lights are enabled,
+ * <code>false</code> if they're disabled.
  * @property {boolean} proceduralMaterialsEnabled - <code>true</code> if procedural shaders are enabled, <code>false</code> if
  *     they're disabled.
  * @property {integer} antialiasingMode - The active anti-aliasing mode.
@@ -189,16 +188,16 @@ public slots:
     void setAmbientOcclusionEnabled(bool enabled);
 
     /*@jsdoc
-     * Gets whether or not local lighting is enabled on the forward renderer.
-     * Local lights are always enabled on the deferred renderer.
+     * Gets whether or not local lighting is enabled.
+     * Ambient and key (sun) light is always enabled, regardless of this setting.
      * @function Render.getLocalLightingEnabled
      * @returns {boolean} <code>true</code> if local lighting is enabled, <code>false</code> if it's disabled.
      */
     bool getLocalLightingEnabled() const;
 
     /*@jsdoc
-     * Sets whether or not local lighting is enabled on the forward renderer.
-     * Has no effect when using the deferred renderer, where local lights are always enabled.
+     * Sets whether or not local lighting is enabled.
+     * Ambient and key (sun) light is always enabled, regardless of this setting.
      * @function Render.setLocalLightingEnabled
      * @param {boolean} enabled - <code>true</code> to enable local lights, <code>false</code> to disable.
      */

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -172,7 +172,8 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
         bool forward = _renderLayer != RenderLayer::WORLD || args->_renderMethod == Args::RenderMethod::FORWARD;
         bool fading = ShapeKey(args->_itemShapeKey).isFaded();
         if (geometryShape != GeometryCache::Shape::Torus) {
-            if (outColor.a >= 1.0f) {
+            // FIXME: How can we set up the lighting buffers on the instanced draw calls?
+            if (outColor.a >= 1.0f && !forward) {
                 render::ShapePipelinePointer pipeline = geometryCache->getShapePipelinePointer(false, wireframe || materials.top().material->isUnlit(),
                     forward, fading, materials.top().material->getCullFaceMode());
                 if (!fading) {

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -172,8 +172,7 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
         bool forward = _renderLayer != RenderLayer::WORLD || args->_renderMethod == Args::RenderMethod::FORWARD;
         bool fading = ShapeKey(args->_itemShapeKey).isFaded();
         if (geometryShape != GeometryCache::Shape::Torus) {
-            // FIXME: How can we set up the lighting buffers on the instanced draw calls?
-            if (outColor.a >= 1.0f && !forward) {
+            if (outColor.a >= 1.0f) {
                 render::ShapePipelinePointer pipeline = geometryCache->getShapePipelinePointer(false, wireframe || materials.top().material->isUnlit(),
                     forward, fading, materials.top().material->getCullFaceMode());
                 if (!fading) {

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -13,10 +13,10 @@
 
 #include <gpu/Batch.h>
 #include <DependencyManager.h>
+#include <GeometryCache.h>
 #include <PerfStat.h>
 
 #include "RenderPipelines.h"
-
 
 using namespace render;
 using namespace render::entities;

--- a/libraries/entities-renderer/src/polyvox.slf
+++ b/libraries/entities-renderer/src/polyvox.slf
@@ -26,10 +26,12 @@
     <@if not HIFI_USE_FORWARD@>
         <@include DeferredBufferWrite.slh@>
     <@else@>
+        <@include CullFace.slh@>
         <@include DefaultMaterials.slh@>
 
         <@include GlobalLight.slh@>
-        <$declareEvalSkyboxGlobalColor(_SCRIBE_NULL, 1)$>
+        <@include LightLocal.slh@>
+        <$declareEvalGlobalLightingAlphaBlended()$>
 
         <@include gpu/Transform.slh@>
         <$declareStandardCameraTransform()$>
@@ -37,6 +39,9 @@
 
     <@if HIFI_USE_FORWARD@>
         INPUT(RENDER_UTILS_ATTR_POSITION_ES, vec4, _positionES);
+        <@if not HIFI_USE_FADE@>
+            INPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
+        <@endif@>
     <@else@>
         INPUT(RENDER_UTILS_ATTR_PREV_POSITION_CS, vec4, _prevPositionCS);
     <@endif@>
@@ -105,18 +110,43 @@ void main(void) {
             DEFAULT_OCCLUSION,
             DEFAULT_SCATTERING);
     <@else@>
+        float metallic = DEFAULT_METALLIC;
+        vec3 fresnel = getFresnelF0(metallic, diffuse);
+
         TransformCamera cam = getTransformCamera();
-        _fragColor0 = vec4(evalSkyboxGlobalColor(
+
+        vec3 fragNormalWS = evalFrontOrBackFaceNormal(normalize(_normalWS));
+        vec3 fragPositionWS = _positionWS.xyz;
+        vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
+        vec3 fragToEyeDirWS = normalize(fragToEyeWS);
+        SurfaceData surfaceWS = initSurfaceData(DEFAULT_ROUGHNESS, fragNormalWS, fragToEyeDirWS);
+
+        vec4 localLighting = vec4(0.0);
+        <$fetchClusterInfo(_positionWS)$>
+        if (hasLocalLights(numLights, clusterPos, dims)) {
+            localLighting = evalLocalLighting(cluster, numLights, fragPositionWS, surfaceWS,
+                                              metallic, fresnel, diffuse, 0.0,
+                                              vec4(0), vec4(0), 1.0);
+        }
+
+        vec4 color = vec4(evalGlobalLightingAlphaBlended(
             cam._viewInverse,
             1.0,
             DEFAULT_OCCLUSION,
             _positionES.xyz,
-            normalize(_normalWS),
+            fragNormalWS,
             diffuse,
-            DEFAULT_FRESNEL,
-            DEFAULT_METALLIC,
-            DEFAULT_ROUGHNESS),
+            fresnel,
+            metallic,
+            DEFAULT_EMISSIVE
+        <@if HIFI_USE_FADE@>
+                + fadeEmissive
+        <@endif@>
+            ,
+            surfaceWS, 1.0, localLighting.rgb),
             1.0);
+
+        _fragColor0 = color;
     <@endif@>
 <@else@>
     _fragColor0 = vec4(1.0);

--- a/libraries/entities-renderer/src/polyvox.slf
+++ b/libraries/entities-renderer/src/polyvox.slf
@@ -39,6 +39,7 @@
 
     <@if HIFI_USE_FORWARD@>
         INPUT(RENDER_UTILS_ATTR_POSITION_ES, vec4, _positionES);
+        // workaround for scribe only supporting (A or B) and not (A or B or C)
         <@if not HIFI_USE_FADE@>
             INPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
         <@endif@>

--- a/libraries/entities-renderer/src/polyvox.slf
+++ b/libraries/entities-renderer/src/polyvox.slf
@@ -22,11 +22,11 @@
     <@include graphics/Material.slh@>
     <@include render-utils/ShaderConstants.h@>
     <@include entities-renderer/ShaderConstants.h@>
+    <@include CullFace.slh@>
 
     <@if not HIFI_USE_FORWARD@>
         <@include DeferredBufferWrite.slh@>
     <@else@>
-        <@include CullFace.slh@>
         <@include DefaultMaterials.slh@>
 
         <@include GlobalLight.slh@>
@@ -90,6 +90,7 @@ void main(void) {
     vec4 yzDiffuse = texture(zMap, vec2(inPositionZ, -inPositionY));
 
     vec3 normalMS = normalize(cross(dFdy(_positionMS.xyz), dFdx(_positionMS.xyz)));
+    vec3 fragNormalWS = evalFrontOrBackFaceNormal(normalize(_normalWS));
     vec3 xyDiffuseScaled = xyDiffuse.rgb * abs(normalMS.z);
     vec3 xzDiffuseScaled = xzDiffuse.rgb * abs(normalMS.y);
     vec3 yzDiffuseScaled = yzDiffuse.rgb * abs(normalMS.x);
@@ -98,7 +99,7 @@ void main(void) {
     <@if not HIFI_USE_FORWARD@>
         packDeferredFragment(
             _prevPositionCS,
-            normalize(_normalWS),
+            fragNormalWS,
             1.0,
             diffuse,
             DEFAULT_ROUGHNESS,
@@ -116,7 +117,6 @@ void main(void) {
 
         TransformCamera cam = getTransformCamera();
 
-        vec3 fragNormalWS = evalFrontOrBackFaceNormal(normalize(_normalWS));
         vec3 fragPositionWS = _positionWS.xyz;
         vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
         vec3 fragToEyeDirWS = normalize(fragToEyeWS);

--- a/libraries/entities-renderer/src/polyvox.slv
+++ b/libraries/entities-renderer/src/polyvox.slv
@@ -17,7 +17,7 @@
 <@include gpu/Transform.slh@>
 <$declareStandardTransform()$>
 
-<@if HIFI_USE_FADE@>
+<@if HIFI_USE_FADE or HIFI_USE_FORWARD@>
     OUTPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
 <@endif@>
 <@if not HIFI_USE_SHADOW@>
@@ -46,7 +46,7 @@ void main(void) {
     <$transformModelToWorldDir(obj, inNormal.xyz, _normalWS)$>
     _positionMS = inPosition.xyz;
 <@endif@>
-<@if HIFI_USE_FADE@>
+<@if HIFI_USE_FADE or HIFI_USE_FORWARD@>
     <$transformModelToWorldPos(obj, inPosition, _positionWS)$>
 <@endif@>
 }

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -93,6 +93,26 @@ void DeferredLightingEffect::unsetKeyLightBatch(gpu::Batch& batch) {
 }
 
 void DeferredLightingEffect::setupLocalLightsBatch(gpu::Batch& batch, const LightClustersPointer& lightClusters) {
+    auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
+    deferredLightingEffect->_lightClusters = lightClusters;
+
+    // Bind the global list of lights and the visible lights this frame
+    batch.setUniformBuffer(gr::Buffer::Light, lightClusters->_lightStage->getLightArrayBuffer());
+
+    batch.setUniformBuffer(ru::Buffer::LightClusterFrustumGrid, lightClusters->_frustumGridBuffer);
+    batch.setUniformBuffer(ru::Buffer::LightClusterGrid, lightClusters->_clusterGridBuffer);
+    batch.setUniformBuffer(ru::Buffer::LightClusterContent, lightClusters->_clusterContentBuffer);
+}
+
+void DeferredLightingEffect::setupLocalLightsBatch(gpu::Batch& batch) {
+    auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
+    auto lightClusters = deferredLightingEffect->_lightClusters;
+
+    if (!lightClusters) {
+        unsetLocalLightsBatch(batch);
+        return;
+    }
+
     // Bind the global list of lights and the visible lights this frame
     batch.setUniformBuffer(gr::Buffer::Light, lightClusters->_lightStage->getLightArrayBuffer());
 
@@ -102,6 +122,9 @@ void DeferredLightingEffect::setupLocalLightsBatch(gpu::Batch& batch, const Ligh
 }
 
 void DeferredLightingEffect::unsetLocalLightsBatch(gpu::Batch& batch) {
+    auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
+    deferredLightingEffect->_lightClusters = nullptr;
+
     batch.setUniformBuffer(gr::Buffer::Light, nullptr);
     batch.setUniformBuffer(ru::Buffer::LightClusterGrid, nullptr);
     batch.setUniformBuffer(ru::Buffer::LightClusterContent, nullptr);

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -122,9 +122,6 @@ void DeferredLightingEffect::setupLocalLightsBatch(gpu::Batch& batch) {
 }
 
 void DeferredLightingEffect::unsetLocalLightsBatch(gpu::Batch& batch) {
-    auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
-    deferredLightingEffect->_lightClusters = nullptr;
-
     batch.setUniformBuffer(gr::Buffer::Light, nullptr);
     batch.setUniformBuffer(ru::Buffer::LightClusterGrid, nullptr);
     batch.setUniformBuffer(ru::Buffer::LightClusterContent, nullptr);

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -51,6 +51,7 @@ public:
     static void unsetKeyLightBatch(gpu::Batch& batch);
 
     static void setupLocalLightsBatch(gpu::Batch& batch, const LightClustersPointer& lightClusters);
+    static void setupLocalLightsBatch(gpu::Batch& batch);
     static void unsetLocalLightsBatch(gpu::Batch& batch);
 
 private:
@@ -69,6 +70,8 @@ private:
 
     gpu::PipelinePointer _localLight;
     gpu::PipelinePointer _localLightOutline;
+
+    LightClustersPointer _lightClusters;
 
     friend class LightClusteringPass;
     friend class RenderDeferredSetup;

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -777,7 +777,9 @@ render::ShapePipelinePointer GeometryCache::getShapePipeline(bool textured, bool
     return std::make_shared<render::ShapePipeline>(getSimplePipeline(textured, transparent, unlit, depthBias, false, true, forward, cullFaceMode), nullptr,
         [](const render::ShapePipeline& pipeline, gpu::Batch& batch, render::Args* args) {
             batch.setResourceTexture(gr::Texture::MaterialAlbedo, DependencyManager::get<TextureCache>()->getWhiteTexture());
-            DependencyManager::get<DeferredLightingEffect>()->setupKeyLightBatch(args, batch);
+            auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
+            deferredLightingEffect->setupKeyLightBatch(args, batch);
+            deferredLightingEffect->setupLocalLightsBatch(batch);
         }
     );
 }
@@ -789,7 +791,9 @@ render::ShapePipelinePointer GeometryCache::getFadingShapePipeline(bool textured
     return std::make_shared<render::ShapePipeline>(getSimplePipeline(textured, transparent, unlit, depthBias, true, true, forward, cullFaceMode), nullptr,
         [fadeBatchSetter](const render::ShapePipeline& shapePipeline, gpu::Batch& batch, render::Args* args) {
             batch.setResourceTexture(gr::Texture::MaterialAlbedo, DependencyManager::get<TextureCache>()->getWhiteTexture());
-            DependencyManager::get<DeferredLightingEffect>()->setupKeyLightBatch(args, batch);
+            auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
+            deferredLightingEffect->setupKeyLightBatch(args, batch);
+            deferredLightingEffect->setupLocalLightsBatch(batch);
             fadeBatchSetter(shapePipeline, batch, args);
         },
         fadeItemSetter

--- a/libraries/render-utils/src/LightClusters.cpp
+++ b/libraries/render-utils/src/LightClusters.cpp
@@ -553,26 +553,6 @@ void LightClusteringPass::run(const render::RenderContextPointer& renderContext,
     auto surfaceGeometryFramebuffer = inputs.get3();
     auto localLightingEnabled = lightingModel->isLocalLightingEnabled();
 
-    // Only clear the light frame on forward where the sun and ambient lights
-    // are always set up properly, regardles of the light clustering. If we clear
-    // it on deferred too, then the key light and ambient light settings are reset
-    // to their defaults, while shadows follow the correct zone-specified key light settings.
-    if (
-        renderContext->args->_renderMethod == render::Args::FORWARD &&
-        !localLightingEnabled
-    ) {
-        // TODO: I think this should work. The clusters aren't updated
-        // if we enter here, and clearing lightFrame means we won't draw
-        // any lights in the areas covered by the now-unused light cluster
-        // data. The cluster data will be uninitialized if local lights are
-        // disabled at start, and will just have whatever was last set up
-        // before local lights were turned off otherwise. In both cases,
-        // the cluster data should be ignored because there's zero lights
-        // to handle. We should verify that this is actually the case.
-        lightFrame->clear();
-        return;
-    }
-
     // first update the Grid with the new frustum
     if (!_freeze) {
         _lightClusters->updateFrustum(args->getViewFrustum());

--- a/libraries/render-utils/src/LightClusters.h
+++ b/libraries/render-utils/src/LightClusters.h
@@ -111,6 +111,8 @@ public:
 
     bool _clusterResourcesInvalid { true };
     void updateClusterResource();
+
+    bool _localLightingEnabled { true };
 };
 
 using LightClustersPointer = std::shared_ptr<LightClusters>;
@@ -127,6 +129,7 @@ class LightClusteringPassConfig : public render::Job::Config {
     Q_PROPERTY(int dimZ MEMBER dimZ NOTIFY dirty)
     
     Q_PROPERTY(bool freeze MEMBER freeze NOTIFY dirty)
+    Q_PROPERTY(bool localLightingEnabled MEMBER localLightingEnabled NOTIFY dirty)
 
     Q_PROPERTY(int numClusteredLightReferences MEMBER numClusteredLightReferences NOTIFY dirty)
     Q_PROPERTY(int numInputLights MEMBER numInputLights NOTIFY dirty)
@@ -147,6 +150,7 @@ public:
 
 
     bool freeze{ false };
+    bool localLightingEnabled { true };
 
     int numClusteredLightReferences { 0 };
     int numInputLights { 0 };
@@ -155,6 +159,8 @@ public:
     void setNumClusteredLightReferences(int numRefs) { numClusteredLightReferences = numRefs; }
     void setNumInputLights(int numLights) { numInputLights = numLights; }
     void setNumClusteredLights(int numLights) { numClusteredLights = numLights; }
+
+    void setLocalLightingEnabled(bool enabled) { localLightingEnabled = enabled; emit dirty(); }
 
     int numSceneLights { 0 };
     int numFreeSceneLights { 0 };
@@ -181,6 +187,7 @@ public:
 protected:
     LightClustersPointer _lightClusters;
     bool _freeze;
+    bool _localLightingEnabled;
 };
 
 

--- a/libraries/render-utils/src/LightClusters.h
+++ b/libraries/render-utils/src/LightClusters.h
@@ -111,8 +111,6 @@ public:
 
     bool _clusterResourcesInvalid { true };
     void updateClusterResource();
-
-    bool _localLightingEnabled { true };
 };
 
 using LightClustersPointer = std::shared_ptr<LightClusters>;
@@ -129,7 +127,6 @@ class LightClusteringPassConfig : public render::Job::Config {
     Q_PROPERTY(int dimZ MEMBER dimZ NOTIFY dirty)
     
     Q_PROPERTY(bool freeze MEMBER freeze NOTIFY dirty)
-    Q_PROPERTY(bool localLightingEnabled MEMBER localLightingEnabled NOTIFY dirty)
 
     Q_PROPERTY(int numClusteredLightReferences MEMBER numClusteredLightReferences NOTIFY dirty)
     Q_PROPERTY(int numInputLights MEMBER numInputLights NOTIFY dirty)
@@ -150,7 +147,6 @@ public:
 
 
     bool freeze{ false };
-    bool localLightingEnabled { true };
 
     int numClusteredLightReferences { 0 };
     int numInputLights { 0 };
@@ -159,8 +155,6 @@ public:
     void setNumClusteredLightReferences(int numRefs) { numClusteredLightReferences = numRefs; }
     void setNumInputLights(int numLights) { numInputLights = numLights; }
     void setNumClusteredLights(int numLights) { numClusteredLights = numLights; }
-
-    void setLocalLightingEnabled(bool enabled) { localLightingEnabled = enabled; emit dirty(); }
 
     int numSceneLights { 0 };
     int numFreeSceneLights { 0 };
@@ -187,7 +181,6 @@ public:
 protected:
     LightClustersPointer _lightClusters;
     bool _freeze;
-    bool _localLightingEnabled;
 };
 
 

--- a/libraries/render-utils/src/LightingModel.cpp
+++ b/libraries/render-utils/src/LightingModel.cpp
@@ -276,6 +276,15 @@ bool LightingModel::isAmbientOcclusionEnabled() const {
     return (bool)_parametersBuffer.get<Parameters>().enableAmbientOcclusion;
 }
 
+void LightingModel::setLocalLighting(bool enable) {
+    if (enable != isLocalLightingEnabled()) {
+        _parametersBuffer.edit<Parameters>().enableLocalLighting = (float)enable;
+    }
+}
+bool LightingModel::isLocalLightingEnabled() const {
+    return (bool)_parametersBuffer.get<Parameters>().enableLocalLighting;
+}
+
 void LightingModel::setShadow(bool enable) {
     if (enable != isShadowEnabled()) {
         _parametersBuffer.edit<Parameters>().enableShadow = (float)enable;
@@ -324,6 +333,7 @@ void MakeLightingModel::configure(const Config& config) {
     _lightingModel->setBlendshape(config.enableBlendshape);
 
     _lightingModel->setAmbientOcclusion(config.enableAmbientOcclusion);
+    _lightingModel->setLocalLighting(config.enableLocalLighting);
     _lightingModel->setShadow(config.enableShadow);
 }
 

--- a/libraries/render-utils/src/LightingModel.cpp
+++ b/libraries/render-utils/src/LightingModel.cpp
@@ -276,6 +276,13 @@ bool LightingModel::isAmbientOcclusionEnabled() const {
     return (bool)_parametersBuffer.get<Parameters>().enableAmbientOcclusion;
 }
 
+void LightingModel::setLocalLightingEnabled(bool enable) {
+    _enableLocalLighting = enable;
+}
+bool LightingModel::isLocalLightingEnabled() const {
+    return _enableLocalLighting;
+}
+
 void LightingModel::setShadow(bool enable) {
     if (enable != isShadowEnabled()) {
         _parametersBuffer.edit<Parameters>().enableShadow = (float)enable;
@@ -324,6 +331,7 @@ void MakeLightingModel::configure(const Config& config) {
     _lightingModel->setBlendshape(config.enableBlendshape);
 
     _lightingModel->setAmbientOcclusion(config.enableAmbientOcclusion);
+    _lightingModel->setLocalLightingEnabled(config.enableLocalLighting);
     _lightingModel->setShadow(config.enableShadow);
 }
 

--- a/libraries/render-utils/src/LightingModel.cpp
+++ b/libraries/render-utils/src/LightingModel.cpp
@@ -276,15 +276,6 @@ bool LightingModel::isAmbientOcclusionEnabled() const {
     return (bool)_parametersBuffer.get<Parameters>().enableAmbientOcclusion;
 }
 
-void LightingModel::setLocalLighting(bool enable) {
-    if (enable != isLocalLightingEnabled()) {
-        _parametersBuffer.edit<Parameters>().enableLocalLighting = (float)enable;
-    }
-}
-bool LightingModel::isLocalLightingEnabled() const {
-    return (bool)_parametersBuffer.get<Parameters>().enableLocalLighting;
-}
-
 void LightingModel::setShadow(bool enable) {
     if (enable != isShadowEnabled()) {
         _parametersBuffer.edit<Parameters>().enableShadow = (float)enable;
@@ -333,7 +324,6 @@ void MakeLightingModel::configure(const Config& config) {
     _lightingModel->setBlendshape(config.enableBlendshape);
 
     _lightingModel->setAmbientOcclusion(config.enableAmbientOcclusion);
-    _lightingModel->setLocalLighting(config.enableLocalLighting);
     _lightingModel->setShadow(config.enableShadow);
 }
 

--- a/libraries/render-utils/src/LightingModel.h
+++ b/libraries/render-utils/src/LightingModel.h
@@ -78,6 +78,8 @@ public:
 
     void setAmbientOcclusion(bool enable);
     bool isAmbientOcclusionEnabled() const;
+    void setLocalLighting(bool enable);
+    bool isLocalLightingEnabled() const;
     void setShadow(bool enable);
     bool isShadowEnabled() const;
 
@@ -119,6 +121,7 @@ protected:
         float enableBlendshape { 1.0f };
 
         float enableAmbientOcclusion { 1.0f };
+        float enableLocalLighting { 1.0f };
         float enableShadow { 1.0f };
         float normalMapAttenuationMin { 1.0f };
         float normalMapAttenuationMax { 1.0f };
@@ -161,6 +164,7 @@ class MakeLightingModelConfig : public render::Job::Config {
     Q_PROPERTY(bool enableBlendshape MEMBER enableBlendshape NOTIFY dirty)
 
     Q_PROPERTY(bool enableAmbientOcclusion READ isAmbientOcclusionEnabled WRITE setAmbientOcclusion NOTIFY dirty)
+    Q_PROPERTY(bool enableLocalLighting READ isLocalLightingEnabled WRITE setLocalLighting NOTIFY dirty)
     Q_PROPERTY(bool enableShadow READ isShadowEnabled WRITE setShadow NOTIFY dirty)
 
 public:
@@ -193,10 +197,13 @@ public:
     bool enableBlendshape { true };
 
     bool enableAmbientOcclusion { true };
+    bool enableLocalLighting { true };
     bool enableShadow { true };
 
     void setAmbientOcclusion(bool enable) { enableAmbientOcclusion = enable; emit dirty();}
     bool isAmbientOcclusionEnabled() const { return enableAmbientOcclusion; }
+    void setLocalLighting(bool enable) { enableLocalLighting = enable; emit dirty();}
+    bool isLocalLightingEnabled() const { return enableLocalLighting; }
     void setShadow(bool enable) { enableShadow = enable; emit dirty(); }
     bool isShadowEnabled() const { return enableShadow; }
     void setHaze(bool enable) { enableHaze = enable; emit dirty(); }

--- a/libraries/render-utils/src/LightingModel.h
+++ b/libraries/render-utils/src/LightingModel.h
@@ -78,8 +78,6 @@ public:
 
     void setAmbientOcclusion(bool enable);
     bool isAmbientOcclusionEnabled() const;
-    void setLocalLighting(bool enable);
-    bool isLocalLightingEnabled() const;
     void setShadow(bool enable);
     bool isShadowEnabled() const;
 
@@ -121,7 +119,6 @@ protected:
         float enableBlendshape { 1.0f };
 
         float enableAmbientOcclusion { 1.0f };
-        float enableLocalLighting { 1.0f };
         float enableShadow { 1.0f };
         float normalMapAttenuationMin { 1.0f };
         float normalMapAttenuationMax { 1.0f };
@@ -164,7 +161,6 @@ class MakeLightingModelConfig : public render::Job::Config {
     Q_PROPERTY(bool enableBlendshape MEMBER enableBlendshape NOTIFY dirty)
 
     Q_PROPERTY(bool enableAmbientOcclusion READ isAmbientOcclusionEnabled WRITE setAmbientOcclusion NOTIFY dirty)
-    Q_PROPERTY(bool enableLocalLighting READ isLocalLightingEnabled WRITE setLocalLighting NOTIFY dirty)
     Q_PROPERTY(bool enableShadow READ isShadowEnabled WRITE setShadow NOTIFY dirty)
 
 public:
@@ -197,13 +193,10 @@ public:
     bool enableBlendshape { true };
 
     bool enableAmbientOcclusion { true };
-    bool enableLocalLighting { true };
     bool enableShadow { true };
 
     void setAmbientOcclusion(bool enable) { enableAmbientOcclusion = enable; emit dirty();}
     bool isAmbientOcclusionEnabled() const { return enableAmbientOcclusion; }
-    void setLocalLighting(bool enable) { enableLocalLighting = enable; emit dirty();}
-    bool isLocalLightingEnabled() const { return enableLocalLighting; }
     void setShadow(bool enable) { enableShadow = enable; emit dirty(); }
     bool isShadowEnabled() const { return enableShadow; }
     void setHaze(bool enable) { enableHaze = enable; emit dirty(); }

--- a/libraries/render-utils/src/LightingModel.h
+++ b/libraries/render-utils/src/LightingModel.h
@@ -78,6 +78,8 @@ public:
 
     void setAmbientOcclusion(bool enable);
     bool isAmbientOcclusionEnabled() const;
+    void setLocalLightingEnabled(bool enable);
+    bool isLocalLightingEnabled() const;
     void setShadow(bool enable);
     bool isShadowEnabled() const;
 
@@ -87,6 +89,8 @@ public:
     gpu::TexturePointer getAmbientFresnelLUT() const { return _ambientFresnelLUT; }
 
 protected:
+    bool _enableLocalLighting { true };
+
     // Class describing the uniform buffer with the transform info common to the AO shaders
     // It s changing every frame
     class Parameters {
@@ -161,6 +165,7 @@ class MakeLightingModelConfig : public render::Job::Config {
     Q_PROPERTY(bool enableBlendshape MEMBER enableBlendshape NOTIFY dirty)
 
     Q_PROPERTY(bool enableAmbientOcclusion READ isAmbientOcclusionEnabled WRITE setAmbientOcclusion NOTIFY dirty)
+    Q_PROPERTY(bool enableLocalLighting READ isLocalLightingEnabled WRITE setLocalLighting NOTIFY dirty)
     Q_PROPERTY(bool enableShadow READ isShadowEnabled WRITE setShadow NOTIFY dirty)
 
 public:
@@ -193,10 +198,13 @@ public:
     bool enableBlendshape { true };
 
     bool enableAmbientOcclusion { true };
+    bool enableLocalLighting { true };
     bool enableShadow { true };
 
     void setAmbientOcclusion(bool enable) { enableAmbientOcclusion = enable; emit dirty();}
     bool isAmbientOcclusionEnabled() const { return enableAmbientOcclusion; }
+    void setLocalLighting(bool enable) { enableLocalLighting = enable; emit dirty();}
+    bool isLocalLightingEnabled() const { return enableLocalLighting; }
     void setShadow(bool enable) { enableShadow = enable; emit dirty(); }
     bool isShadowEnabled() const { return enableShadow; }
     void setHaze(bool enable) { enableHaze = enable; emit dirty(); }

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -303,9 +303,11 @@ void DrawForward::run(const RenderContextPointer& renderContext, const Inputs& i
         batch.setResourceTexture(ru::Texture::AmbientFresnel, lightingModel->getAmbientFresnelLUT());
         batch.setUniformBuffer(ru::Buffer::DeferredFrameTransform, deferredFrameTransform->getFrameTransformBuffer());
 
+        // Set the light
         deferredLightingEffect->setupKeyLightBatch(args, batch);
         deferredLightingEffect->setupLocalLightsBatch(batch, lightClusters);
 
+        // Setup haze if current zone has haze
         if (haze) {
             batch.setUniformBuffer(graphics::slot::buffer::Buffer::HazeParams, haze->getHazeParametersBuffer());
         }
@@ -332,5 +334,3 @@ void DrawForward::run(const RenderContextPointer& renderContext, const Inputs& i
         deferredLightingEffect->unsetKeyLightBatch(batch);
     });
 }
-
-

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -305,7 +305,7 @@ void DrawForward::run(const RenderContextPointer& renderContext, const Inputs& i
 
         // Set the light
         deferredLightingEffect->setupKeyLightBatch(args, batch);
-        if (lightClusters) {
+        if (lightingModel->isLocalLightingEnabled()) {
             deferredLightingEffect->setupLocalLightsBatch(batch, lightClusters);
         }
 

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -305,9 +305,7 @@ void DrawForward::run(const RenderContextPointer& renderContext, const Inputs& i
 
         // Set the light
         deferredLightingEffect->setupKeyLightBatch(args, batch);
-        if (lightingModel->isLocalLightingEnabled()) {
-            deferredLightingEffect->setupLocalLightsBatch(batch, lightClusters);
-        }
+        deferredLightingEffect->setupLocalLightsBatch(batch, lightClusters);
 
         // Setup haze if current zone has haze
         if (haze) {

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -196,7 +196,7 @@ void RenderForwardTask::build(JobModel& task, const render::Varying& input, rend
 gpu::FramebufferPointer PreparePrimaryFramebufferMSAA::createFramebuffer(const char* name, const glm::uvec2& frameSize, int numSamples) {
     gpu::FramebufferPointer framebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create(name));
 
-    auto defaultSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR);
+    auto defaultSampler = Sampler(Sampler::FILTER_MIN_MAG_LINEAR);
 
     auto colorFormat = gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::R11G11B10);
     auto colorTexture =

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -305,8 +305,7 @@ void DrawForward::run(const RenderContextPointer& renderContext, const Inputs& i
 
         // Set the light
         deferredLightingEffect->setupKeyLightBatch(args, batch);
-
-        if (lightingModel->isLocalLightingEnabled()) {
+        if (lightClusters) {
             deferredLightingEffect->setupLocalLightsBatch(batch, lightClusters);
         }
 

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -305,7 +305,10 @@ void DrawForward::run(const RenderContextPointer& renderContext, const Inputs& i
 
         // Set the light
         deferredLightingEffect->setupKeyLightBatch(args, batch);
-        deferredLightingEffect->setupLocalLightsBatch(batch, lightClusters);
+
+        if (lightingModel->isLocalLightingEnabled()) {
+            deferredLightingEffect->setupLocalLightsBatch(batch, lightClusters);
+        }
 
         // Setup haze if current zone has haze
         if (haze) {

--- a/libraries/render-utils/src/RenderForwardTask.h
+++ b/libraries/render-utils/src/RenderForwardTask.h
@@ -16,6 +16,8 @@
 #include <gpu/Pipeline.h>
 #include <render/RenderFetchCullSortTask.h>
 #include "AssembleLightingStageTask.h"
+#include "DeferredFrameTransform.h"
+#include "LightClusters.h"
 #include "LightingModel.h"
 
 class RenderForwardTaskConfig : public render::Task::Config {
@@ -91,7 +93,7 @@ private:
 
 class DrawForward{
 public:
-    using Inputs = render::VaryingSet3<render::ItemBounds, LightingModelPointer, HazeStage::FramePointer>;
+    using Inputs = render::VaryingSet5<render::ItemBounds, LightingModelPointer, HazeStage::FramePointer, LightClustersPointer, DeferredFrameTransformPointer>;
     using JobModel = render::Job::ModelI<DrawForward, Inputs>;
 
     DrawForward(const render::ShapePlumberPointer& shapePlumber, bool opaquePass, uint transformSlot) :

--- a/libraries/render-utils/src/RenderPipelinesInit.cpp.in
+++ b/libraries/render-utils/src/RenderPipelinesInit.cpp.in
@@ -202,7 +202,9 @@ void lightBatchSetter(const ShapePipeline& pipeline, Batch& batch, RenderArgs* a
 
     // Set the light
     if (pipeline.locations->keyLightBufferUnit) {
-        DependencyManager::get<DeferredLightingEffect>()->setupKeyLightBatch(args, batch);
+        auto deferredLightingEffect = DependencyManager::get<DeferredLightingEffect>();
+        deferredLightingEffect->setupKeyLightBatch(args, batch);
+        deferredLightingEffect->setupLocalLightsBatch(batch);
     }
 }
 

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -466,7 +466,6 @@ void main(void) {
         parametricRimFresnelPower, parametricRimLift, rimTex, rimLightingMix, matKeys[0]), opacity);
 
     <@if HIFI_USE_FORWARD@>
-        // TODO: toony local lights, maybe move this to the technique used in #1934?
         vec3 fragPositionWS = _positionWS.xyz;
         vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
         vec3 fragToEyeDirWS = normalize(fragToEyeWS);

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -92,13 +92,9 @@
         <@include GlobalLight.slh@>
         <@if HIFI_USE_LIGHTMAP@>
             <$declareEvalLightmappedColor()$>
-        <@elif HIFI_USE_TRANSLUCENT@>
-            <@if not HIFI_USE_FORWARD@>
-                <@include LightLocal.slh@>
-            <@endif@>
-            <$declareEvalGlobalLightingAlphaBlended()$>
         <@else@>
-            <$declareEvalSkyboxGlobalColor(_SCRIBE_NULL, 1)$>
+            <@include LightLocal.slh@>
+            <$declareEvalGlobalLightingAlphaBlended()$>
         <@endif@>
         <@include gpu/Transform.slh@>
         <$declareStandardCameraTransform()$>
@@ -676,55 +672,45 @@ void main(void) {
     <@if HIFI_USE_FORWARD@>
         TransformCamera cam = getTransformCamera();
         vec3 fresnel = getFresnelF0(metallic, albedo);
-        <@if not HIFI_USE_TRANSLUCENT@>
-            <@if not HIFI_USE_LIGHTMAP@>
-                vec4 color = vec4(evalSkyboxGlobalColor(
-                    cam._viewInverse,
-                    1.0,
-                    occlusion,
-                    _positionES.xyz,
-                    fragNormalWS,
-                    albedo,
-                    fresnel,
-                    metallic,
-                    roughness),
-                    opacity);
-                color.rgb += emissive * isEmissiveEnabled();
-                _fragColor0 = color;
-            <@else@>
-                _fragColor0 = vec4(evalLightmappedColor(
-                    cam._viewInverse,
-                    1.0,
-                    DEFAULT_OCCLUSION,
-                    fragNormalWS,
-                    albedo,
-                    lightmap),
-                    opacity);
-            <@endif@>
-        <@else@>
-            <@if not HIFI_USE_LIGHTMAP@>
-                _fragColor0 =  vec4(evalGlobalLightingAlphaBlended(
-                    cam._viewInverse,
-                    1.0,
-                    occlusion,
-                    _positionES.xyz,
-                    fragNormalWS,
-                    albedo,
-                    fresnel,
-                    metallic,
-                    emissive,
-                    roughness, opacity),
-                    opacity);
-            <@else@>
-                _fragColor0 = vec4(evalLightmappedColor(
+        <@if not HIFI_USE_LIGHTMAP@>
+            vec3 fragPositionWS = _positionWS.xyz;
+            vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
+            vec3 fragToEyeDirWS = normalize(fragToEyeWS);
+            SurfaceData surfaceWS = initSurfaceData(roughness, fragNormalWS, fragToEyeDirWS);
+
+            vec4 localLighting = vec4(0.0);
+            <$fetchClusterInfo(_positionWS)$>
+            if (hasLocalLights(numLights, clusterPos, dims)) {
+                localLighting = evalLocalLighting(cluster, numLights, fragPositionWS, surfaceWS,
+                                                  metallic, fresnel, albedo, 0.0,
+                                                  vec4(0), vec4(0), opacity);
+            }
+
+            _fragColor0 = vec4(evalGlobalLightingAlphaBlended(
                 cam._viewInverse,
                 1.0,
-                DEFAULT_OCCLUSION,
+                occlusion,
+                _positionES.xyz,
                 fragNormalWS,
                 albedo,
-                lightmap),
-                opacity);
+                fresnel,
+                metallic,
+                emissive
+            <@if HIFI_USE_FADE@>
+                    + fadeEmissive
             <@endif@>
+                ,
+                surfaceWS, opacity, localLighting.rgb),
+                opacity);
+        <@else@>
+            _fragColor0 = vec4(evalLightmappedColor(
+            cam._viewInverse,
+            1.0,
+            DEFAULT_OCCLUSION,
+            fragNormalWS,
+            albedo,
+            lightmap),
+            opacity);
         <@endif@>
     <@else@>
         <@if not HIFI_USE_TRANSLUCENT@>

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -88,11 +88,8 @@
         <@include gpu/Transform.slh@>
         <$declareStandardCameraTransform()$>
 
-        // Scribe workaround
-        <@if not HIFI_USE_LIGHTMAP@>
         <@if HIFI_USE_FORWARD@>
             <@include LightLocal.slh@>
-        <@endif@>
         <@endif@>
     <@elif HIFI_USE_FORWARD or HIFI_USE_TRANSLUCENT@>
         <@include DefaultMaterials.slh@>
@@ -470,22 +467,20 @@ void main(void) {
 
     <@if HIFI_USE_FORWARD@>
         // TODO: toony local lights, maybe move this to the technique used in #1934?
-        <@if not HIFI_USE_LIGHTMAP@>
-            vec3 fragPositionWS = _positionWS.xyz;
-            vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
-            vec3 fragToEyeDirWS = normalize(fragToEyeWS);
-            SurfaceData surfaceWS = initSurfaceData(DEFAULT_ROUGHNESS, fragNormalWS, fragToEyeDirWS);
+        vec3 fragPositionWS = _positionWS.xyz;
+        vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
+        vec3 fragToEyeDirWS = normalize(fragToEyeWS);
+        SurfaceData surfaceWS = initSurfaceData(DEFAULT_ROUGHNESS, fragNormalWS, fragToEyeDirWS);
 
-            vec4 localLighting = vec4(0.0);
-            <$fetchClusterInfo(_positionWS)$>
-            if (hasLocalLights(numLights, clusterPos, dims)) {
-                localLighting = evalLocalLighting(cluster, numLights, fragPositionWS, surfaceWS,
-                                                  metallic, fresnel, albedo, 0.0,
-                                                  vec4(0), vec4(0), opacity);
-            }
+        vec4 localLighting = vec4(0.0);
+        <$fetchClusterInfo(_positionWS)$>
+        if (hasLocalLights(numLights, clusterPos, dims)) {
+            localLighting = evalLocalLighting(cluster, numLights, fragPositionWS, surfaceWS,
+                                              metallic, fresnel, albedo, 0.0,
+                                              vec4(0), vec4(0), opacity);
+        }
 
-            color.rgb += localLighting.rgb;
-        <@endif@>
+        color.rgb += localLighting.rgb;
 
         _fragColor0 = isUnlitEnabled() * vec4(color.rgb
         <@if HIFI_USE_FADE@>

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -87,6 +87,13 @@
 
         <@include gpu/Transform.slh@>
         <$declareStandardCameraTransform()$>
+
+        // Scribe workaround
+        <@if not HIFI_USE_LIGHTMAP@>
+        <@if HIFI_USE_FORWARD@>
+            <@include LightLocal.slh@>
+        <@endif@>
+        <@endif@>
     <@elif HIFI_USE_FORWARD or HIFI_USE_TRANSLUCENT@>
         <@include DefaultMaterials.slh@>
         <@include GlobalLight.slh@>
@@ -462,6 +469,24 @@ void main(void) {
         parametricRimFresnelPower, parametricRimLift, rimTex, rimLightingMix, matKeys[0]), opacity);
 
     <@if HIFI_USE_FORWARD@>
+        // TODO: toony local lights, maybe move this to the technique used in #1934?
+        <@if not HIFI_USE_LIGHTMAP@>
+            vec3 fragPositionWS = _positionWS.xyz;
+            vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
+            vec3 fragToEyeDirWS = normalize(fragToEyeWS);
+            SurfaceData surfaceWS = initSurfaceData(DEFAULT_ROUGHNESS, fragNormalWS, fragToEyeDirWS);
+
+            vec4 localLighting = vec4(0.0);
+            <$fetchClusterInfo(_positionWS)$>
+            if (hasLocalLights(numLights, clusterPos, dims)) {
+                localLighting = evalLocalLighting(cluster, numLights, fragPositionWS, surfaceWS,
+                                                  metallic, fresnel, albedo, 0.0,
+                                                  vec4(0), vec4(0), opacity);
+            }
+
+            color.rgb += localLighting.rgb;
+        <@endif@>
+
         _fragColor0 = isUnlitEnabled() * vec4(color.rgb
         <@if HIFI_USE_FADE@>
                 + fadeEmissive

--- a/libraries/render-utils/src/sdf_text3D.slf
+++ b/libraries/render-utils/src/sdf_text3D.slf
@@ -16,14 +16,14 @@
     <@include DefaultMaterials.slh@>
 
     <@include GlobalLight.slh@>
-    <@if HIFI_USE_TRANSLUCENT@>
-        <$declareEvalGlobalLightingAlphaBlended()$>
-    <@else@>
-        <$declareEvalSkyboxGlobalColor(_SCRIBE_NULL, 1)$>
-    <@endif@>
+    <@include LightLocal.slh@>
+    <$declareEvalGlobalLightingAlphaBlended()$>
 
     <@include gpu/Transform.slh@>
     <$declareStandardCameraTransform()$>
+
+    <@include CullFace.slh@>
+    layout(location=RENDER_UTILS_ATTR_POSITION_WS) in vec4 _positionWS;
 <@endif@>
 
 <@if HIFI_USE_FORWARD@>
@@ -115,36 +115,38 @@ void main() {
     <@endif@>
 <@else@>
     <@if HIFI_USE_TRANSLUCENT or HIFI_USE_FORWARD@>
+        float metallic = DEFAULT_METALLIC;
+        vec3 fresnel = getFresnelF0(metallic, color.rgb);
+
         TransformCamera cam = getTransformCamera();
         vec3 fragPosition = _positionES.xyz;
 
-        vec4 outColor;
-        <@if HIFI_USE_TRANSLUCENT@>
-            outColor = vec4(evalGlobalLightingAlphaBlended(
-                cam._viewInverse,
-                1.0,
-                DEFAULT_OCCLUSION,
-                fragPosition,
-                normal,
-                color.rgb,
-                DEFAULT_FRESNEL,
-                DEFAULT_METALLIC,
-                DEFAULT_EMISSIVE,
-                DEFAULT_ROUGHNESS, color.a),
-                color.a);
-        <@else@>
-            outColor = vec4(evalSkyboxGlobalColor(
-                cam._viewInverse,
-                1.0,
-                DEFAULT_OCCLUSION,
-                fragPosition,
-                normal,
-                color.rgb,
-                DEFAULT_FRESNEL,
-                DEFAULT_METALLIC,
-                DEFAULT_ROUGHNESS),
-                color.a);
-        <@endif@>
+        vec3 fragNormalWS = evalFrontOrBackFaceNormal(normalize(_normalWS));
+        vec3 fragPositionWS = _positionWS.xyz;
+        vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
+        vec3 fragToEyeDirWS = normalize(fragToEyeWS);
+        SurfaceData surfaceWS = initSurfaceData(DEFAULT_ROUGHNESS, fragNormalWS, fragToEyeDirWS);
+
+        vec4 localLighting = vec4(0.0);
+        <$fetchClusterInfo(_positionWS)$>
+        if (hasLocalLights(numLights, clusterPos, dims)) {
+            localLighting = evalLocalLighting(cluster, numLights, fragPositionWS, surfaceWS,
+                                              metallic, fresnel, color.rgb, 0.0,
+                                              vec4(0), vec4(0), color.a);
+        }
+
+        vec4 outColor = vec4(evalGlobalLightingAlphaBlended(
+            cam._viewInverse,
+            1.0,
+            DEFAULT_OCCLUSION,
+            _positionES.xyz,
+            fragNormalWS,
+            color.rgb,
+            fresnel,
+            metallic,
+            DEFAULT_EMISSIVE,
+            surfaceWS, color.a, localLighting.rgb),
+            color.a);
 
         <@if HIFI_USE_FORWARD@>
             _fragColor0 = outColor;

--- a/libraries/render-utils/src/sdf_text3D.slf
+++ b/libraries/render-utils/src/sdf_text3D.slf
@@ -23,7 +23,6 @@
     <$declareStandardCameraTransform()$>
 
     <@include CullFace.slh@>
-    layout(location=RENDER_UTILS_ATTR_POSITION_WS) in vec4 _positionWS;
 <@endif@>
 
 <@if HIFI_USE_FORWARD@>
@@ -48,6 +47,10 @@ INPUT(RENDER_UTILS_ATTR_POSITION_MS, vec2, _positionMS);
 <@endif@>
 <@if HIFI_USE_TRANSLUCENT or HIFI_USE_FORWARD@>
     INPUT(RENDER_UTILS_ATTR_POSITION_ES, vec4, _positionES);
+    // workaround for scribe only supporting (A or B) and not (A or B or C)
+    <@if not HIFI_USE_FADE@>
+        NPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
+    <@endif@>
 <@endif@>
 <@if not HIFI_USE_FORWARD@>
     INPUT(RENDER_UTILS_ATTR_PREV_POSITION_CS, vec4, _prevPositionCS);

--- a/libraries/render-utils/src/sdf_text3D.slf
+++ b/libraries/render-utils/src/sdf_text3D.slf
@@ -47,9 +47,9 @@ INPUT(RENDER_UTILS_ATTR_POSITION_MS, vec2, _positionMS);
 <@endif@>
 <@if HIFI_USE_TRANSLUCENT or HIFI_USE_FORWARD@>
     INPUT(RENDER_UTILS_ATTR_POSITION_ES, vec4, _positionES);
-    // workaround for scribe only supporting (A or B) and not (A or B or C)
     <@if not HIFI_USE_FADE@>
-        NPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
+        // workaround for scribe only supporting (A or B) and not (A or B or C)
+        INPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
     <@endif@>
 <@endif@>
 <@if not HIFI_USE_FORWARD@>

--- a/libraries/render-utils/src/sdf_text3D.slv
+++ b/libraries/render-utils/src/sdf_text3D.slv
@@ -29,6 +29,7 @@ OUTPUT(RENDER_UTILS_ATTR_POSITION_MS, vec2, _positionMS);
 <@endif@>
 <@if HIFI_USE_TRANSLUCENT or HIFI_USE_FORWARD@>
     OUTPUT(RENDER_UTILS_ATTR_POSITION_ES, vec4, _positionES);
+    OUTPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
 <@endif@>
 <@if not HIFI_USE_FORWARD@>
     OUTPUT(RENDER_UTILS_ATTR_PREV_POSITION_CS, vec4, _prevPositionCS);
@@ -66,6 +67,10 @@ void main() {
     <$transformModelToEyeClipPosAndPrevClipPos(cam, obj, position, _positionES, gl_Position, _prevPositionCS)$>
 <@else@>
     <$transformModelToClipPosAndPrevClipPos(cam, obj, position, gl_Position, _prevPositionCS)$>
+<@endif@>
+
+<@if HIFI_USE_FORWARD or HIFI_USE_TRANSLUCENT@>
+    <$transformModelToWorldPos(obj, inPosition, _positionWS)$>
 <@endif@>
 
     const vec3 normal = vec3(0, 0, 1);

--- a/libraries/render-utils/src/sdf_text3D.slv
+++ b/libraries/render-utils/src/sdf_text3D.slv
@@ -29,7 +29,10 @@ OUTPUT(RENDER_UTILS_ATTR_POSITION_MS, vec2, _positionMS);
 <@endif@>
 <@if HIFI_USE_TRANSLUCENT or HIFI_USE_FORWARD@>
     OUTPUT(RENDER_UTILS_ATTR_POSITION_ES, vec4, _positionES);
-    OUTPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
+    <@if not HIFI_USE_FADE@>
+        // workaround for scribe only supporting (A or B) and not (A or B or C)
+        OUTPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
+    <@endif@>
 <@endif@>
 <@if not HIFI_USE_FORWARD@>
     OUTPUT(RENDER_UTILS_ATTR_PREV_POSITION_CS, vec4, _prevPositionCS);

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -47,6 +47,7 @@
         INPUT(RENDER_UTILS_ATTR_POSITION_ES, vec4, _positionES);
     <@endif@>
 
+    // workaround for scribe only supporting (A or B) and not (A or B or C)
     <@if not HIFI_USE_FADE@>
         layout(location=RENDER_UTILS_ATTR_POSITION_WS) in vec4 _positionWS;
     <@endif@>

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -33,11 +33,8 @@
 
 <@if not HIFI_USE_UNLIT@>
     <@include GlobalLight.slh@>
-    <@if HIFI_USE_TRANSLUCENT@>
-        <$declareEvalGlobalLightingAlphaBlended()$>
-    <@elif HIFI_USE_FORWARD@>
-        <$declareEvalSkyboxGlobalColor(_SCRIBE_NULL, 1)$>
-    <@endif@>
+    <@include LightLocal.slh@>
+    <$declareEvalGlobalLightingAlphaBlended()$>
 <@endif@>
 
 <@if HIFI_USE_FADE@>
@@ -48,6 +45,10 @@
 <@if HIFI_USE_FORWARD or HIFI_USE_TRANSLUCENT@>
     <@if not HIFI_USE_UNLIT@>
         INPUT(RENDER_UTILS_ATTR_POSITION_ES, vec4, _positionES);
+    <@endif@>
+
+    <@if not HIFI_USE_FADE@>
+        layout(location=RENDER_UTILS_ATTR_POSITION_WS) in vec4 _positionWS;
     <@endif@>
 <@endif@>
 <@if not HIFI_USE_FORWARD@>
@@ -78,24 +79,32 @@ void main(void) {
 <@endif@>
 
 <@if not HIFI_USE_UNLIT@>
-    <@if HIFI_USE_FORWARD or HIFI_USE_TRANSLUCENT@>
+    <@if HIFI_USE_TRANSLUCENT or HIFI_USE_FORWARD@>
         float metallic = DEFAULT_METALLIC;
         vec3 fresnel = getFresnelF0(metallic, texel.rgb);
 
         TransformCamera cam = getTransformCamera();
-        vec3 fragPosition = _positionES.xyz;
-    <@endif@>
-<@endif@>
 
-<@if not HIFI_USE_UNLIT@>
-    <@if HIFI_USE_TRANSLUCENT@>
-        vec3 normal = evalFrontOrBackFaceNormal(normalize(_normalWS));
+        vec3 fragNormalWS = evalFrontOrBackFaceNormal(normalize(_normalWS));
+        vec3 fragPositionWS = _positionWS.xyz;
+        vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;
+        vec3 fragToEyeDirWS = normalize(fragToEyeWS);
+        SurfaceData surfaceWS = initSurfaceData(DEFAULT_ROUGHNESS, fragNormalWS, fragToEyeDirWS);
+
+        vec4 localLighting = vec4(0.0);
+        <$fetchClusterInfo(_positionWS)$>
+        if (hasLocalLights(numLights, clusterPos, dims)) {
+            localLighting = evalLocalLighting(cluster, numLights, fragPositionWS, surfaceWS,
+                                              metallic, fresnel, texel.rgb, 0.0,
+                                              vec4(0), vec4(0), texel.a);
+        }
+
         vec4 color = vec4(evalGlobalLightingAlphaBlended(
             cam._viewInverse,
             1.0,
             DEFAULT_OCCLUSION,
-            fragPosition,
-            normal,
+            _positionES.xyz,
+            fragNormalWS,
             texel.rgb,
             fresnel,
             metallic,
@@ -104,26 +113,14 @@ void main(void) {
                 + fadeEmissive
         <@endif@>
             ,
-            DEFAULT_ROUGHNESS, texel.a),
+            surfaceWS, texel.a, localLighting.rgb),
             texel.a);
 
         <@if HIFI_USE_FORWARD@>
             _fragColor0 = color;
         <@else@>
-            packDeferredFragmentTranslucent(_prevPositionCS, normal, color.a, color.rgb, DEFAULT_ROUGHNESS);
+            packDeferredFragmentTranslucent(_prevPositionCS, fragNormalWS, color.a, color.rgb, DEFAULT_ROUGHNESS);
         <@endif@>
-    <@elif HIFI_USE_FORWARD@>
-        _fragColor0 = vec4(evalSkyboxGlobalColor(
-            cam._viewInverse,
-            1.0,
-            DEFAULT_OCCLUSION,
-            fragPosition,
-            evalFrontOrBackFaceNormal(normalize(_normalWS)),
-            texel.rgb,
-            fresnel,
-            metallic,
-            DEFAULT_ROUGHNESS),
-            texel.a);
     <@else@>
         packDeferredFragment(
             _prevPositionCS,

--- a/libraries/render-utils/src/simple.slv
+++ b/libraries/render-utils/src/simple.slv
@@ -23,6 +23,8 @@
     <$declareFadeVertexInstanced()$>
 
     OUTPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
+<@elif HIFI_USE_FORWARD or HIFI_USE_TRANSLUCENT@>
+    OUTPUT(RENDER_UTILS_ATTR_POSITION_WS, vec4, _positionWS);
 <@endif@>
 
 <@if HIFI_USE_FORWARD or HIFI_USE_TRANSLUCENT@>
@@ -57,6 +59,8 @@ void main(void) {
 <@if HIFI_USE_FADE@>
     <$transformModelToWorldPos(obj, inPosition, _positionWS)$>
     <$passThroughFadeObjectParams()$>
+<@elif HIFI_USE_FORWARD or HIFI_USE_TRANSLUCENT@>
+    <$transformModelToWorldPos(obj, inPosition, _positionWS)$>
 <@endif@>
     <$transformModelToWorldDir(obj, inNormal.xyz, _normalWS)$>
 }

--- a/scripts/system/settings/qml/pages/GraphicsSettings.qml
+++ b/scripts/system/settings/qml/pages/GraphicsSettings.qml
@@ -91,8 +91,6 @@ Flickable {
         }
 
         SettingBoolean {
-            visible: Render.renderMethod === 1
-
             settingText: "Local Lights";
             settingEnabledCondition: () => { return Render.localLightingEnabled }
 

--- a/scripts/system/settings/qml/pages/GraphicsSettings.qml
+++ b/scripts/system/settings/qml/pages/GraphicsSettings.qml
@@ -90,6 +90,17 @@ Flickable {
             }
         }
 
+        SettingBoolean {
+            visible: Render.renderMethod === 1
+
+            settingText: "Local Lights";
+            settingEnabledCondition: () => { return Render.localLightingEnabled }
+
+            onSettingEnabledChanged: {
+                Render.localLightingEnabled = settingEnabled;
+            }
+        }
+
         // Rendering Effects sub options
         AdvancedOptions {
             id: renderingEffectsAdvancedOptions;
@@ -103,21 +114,6 @@ Flickable {
                     Render.shadowsEnabled = settingEnabled;
                 }
             } 
-
-            SettingBoolean {
-                settingText: "Local Lights";
-                settingEnabledCondition: () => { return Render.renderMethod === 0 }
-            }
-
-            // NOTE: Once local lights have a proper toggle, the SettingBoolean above can be replaced with this one below.
-            // SettingBoolean {
-            //     settingText: "Local Lights";
-            //     settingEnabledCondition: () => { return Render.localLightsEnabled }
-
-            //     onSettingEnabledChanged: {
-            //         Render.localLightsEnabled = settingEnabled;
-            //     }
-            // }
 
             SettingBoolean {
                 settingText: "Ambient Occlusion";


### PR DESCRIPTION
The biggest missing feature from the forward renderer, missing no more

Shaders to be modified:
- [x] `model`
- [x] `sdf_text3D`
- [x] `simple` - Opaque shape entities are unlit because the light buffers aren't set up during the instanced shape step
- [ ] ~~`simple_procedural` (maybe not necessary?)~~
- [x] `polyvox`

CPP stuff todo:
- [x] Local lights toggle for both renderers
- [x] Lighting on opaque shapes (the lighting buffers aren't set up for instanced drawing)

Fixes #1485
Fixes #1792

<img width="1280" height="960" alt="overte-snap-by-ada-tv-on-2025-09-02_10-16-17" src="https://github.com/user-attachments/assets/0dca694c-96d4-468e-bfac-7ee263003a13" />