### PR TITLE
Always-on setting for VR lasers

### DIFF
--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -519,6 +519,15 @@ void PickScriptingInterface::setHandLaserDelay(float delay) {
     emit handLaserDelayChanged(delay);
 }
 
+bool PickScriptingInterface::getHandLaserPassive() const {
+    return _handLaserPassiveSetting.get();
+}
+
+void PickScriptingInterface::setHandLaserPassive(bool passive) {
+    _handLaserPassiveSetting.set(passive);
+    emit handLaserPassiveChanged(passive);
+}
+
 void PickScriptingInterface::setParentTransform(std::shared_ptr<PickQuery> pick, const QVariantMap& propMap) {
     QUuid parentUuid;
     int parentJointIndex = 0;

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -74,6 +74,7 @@ class ScriptValue;
  *
  * @property {number} perFrameTimeBudget - The maximum time, in microseconds, to spend per frame updating pick results.
  * @property {number} handLaserDelay - The delay, in seconds, applied to the hand lasers to smooth their movement.
+ * @property {number} handLaserPassive - If <code>true</code>, the hand lasers will always show passively, without needing the trigger to be pulled.
  */
 
 class PickScriptingInterface : public QObject, public Dependency {
@@ -108,6 +109,7 @@ class PickScriptingInterface : public QObject, public Dependency {
     Q_PROPERTY(unsigned int INTERSECTED_HUD READ getIntersectedHud CONSTANT)
     Q_PROPERTY(unsigned int perFrameTimeBudget READ getPerFrameTimeBudget WRITE setPerFrameTimeBudget)
     Q_PROPERTY(float handLaserDelay READ getHandLaserDelay WRITE setHandLaserDelay)
+    Q_PROPERTY(bool handLaserPassive READ getHandLaserPassive WRITE setHandLaserPassive)
     SINGLETON_DEPENDENCY
 
 public:
@@ -310,6 +312,9 @@ public:
     float getHandLaserDelay() const;
     void setHandLaserDelay(float delay);
 
+    bool getHandLaserPassive() const;
+    void setHandLaserPassive(bool passive);
+
 public slots:
 
     static constexpr unsigned int getPickBypassIgnore() { return PickFilter::getBitMask(PickFilter::FlagBit::PICK_BYPASS_IGNORE); }
@@ -478,6 +483,7 @@ public slots:
 
 signals:
     void handLaserDelayChanged(float delay);
+    void handLaserPassiveChanged(bool passive);
 
 protected:
     static std::shared_ptr<PickQuery> buildRayPick(const QVariantMap& properties);
@@ -489,6 +495,7 @@ protected:
 
 private:
     Setting::Handle<float> _handLaserDelaySetting { "handLaserDelay", 0.35f };
+    Setting::Handle<bool> _handLaserPassiveSetting { "handLaserPassive", false };
 };
 
 #endif // hifi_PickScriptingInterface_h

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -240,6 +240,12 @@ void setupPreferences() {
         preferences->addPreference(delaySlider);
     }
 
+    {
+        auto getter = []() -> float { return DependencyManager::get<PickScriptingInterface>()->getHandLaserPassive(); };
+        auto setter = [](bool value) { DependencyManager::get<PickScriptingInterface>()->setHandLaserPassive(value); };
+        preferences->addPreference(new CheckPreference(UI_CATEGORY, "Always Show Lasers", getter, setter));
+    }
+
     static const QString VIEW_CATEGORY { "View" };
     {
         auto getter = [myAvatar]()->float { return myAvatar->getRealWorldFieldOfView(); };

--- a/scripts/system/controllers/controllerDispatcher.js
+++ b/scripts/system/controllers/controllerDispatcher.js
@@ -589,7 +589,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             scaleWithParent: true,
             distanceScaleEnd: true,
             hand: LEFT_HAND,
-            delay: Picks.handLaserDelay
+            delay: Picks.handLaserDelay,
+            allowPassive: true,
         });
         Keyboard.setLeftHandLaser(this.leftPointer);
         this.rightPointer = this.pointerManager.createPointer(false, PickType.Ray, {
@@ -605,7 +606,8 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             scaleWithParent: true,
             distanceScaleEnd: true,
             hand: RIGHT_HAND,
-            delay: Picks.handLaserDelay
+            delay: Picks.handLaserDelay,
+            allowPassive: true,
         });
         Keyboard.setRightHandLaser(this.rightPointer);
         this.leftHudPointer = this.pointerManager.createPointer(true, PickType.Ray, {
@@ -696,6 +698,10 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             Pointers.setDelay(_this.rightHudPointer, delay);
         };
 
+        this.handLaserPassiveChanged = function (passive) {
+            _this.pointerManager.setPassive(passive);
+        };
+
         this.cleanup = function () {
             Controller.disableMapping(MAPPING_NAME);
             _this.pointerManager.removePointers();
@@ -759,6 +765,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
     Messages.messageReceived.connect(controllerDispatcher.handleMessage);
 
     Picks.handLaserDelayChanged.connect(controllerDispatcher.handLaserDelayChanged);
+    Picks.handLaserPassiveChanged.connect(controllerDispatcher.handLaserPassiveChanged);
 
     Script.scriptEnding.connect(function () {
         controllerDispatcher.cleanup();

--- a/scripts/system/libraries/controllerDispatcherUtils.js
+++ b/scripts/system/libraries/controllerDispatcherUtils.js
@@ -102,6 +102,8 @@ var PICK_MAX_DISTANCE = 500; // max length of pick-ray
 var DEFAULT_SEARCH_SPHERE_DISTANCE = 1000; // how far from camera to search intersection?
 var NEAR_GRAB_PICK_RADIUS = 0.25; // radius used for search ray vs object for near grabbing.
 
+var COLORS_GRAB_SEARCHING_PASSIVE = { red: 144, green: 144, blue: 144 };
+var COLORS_GRAB_SEARCHING_PASSIVE_INTERACTIVE = { red: 144, green: 255, blue: 144 };
 var COLORS_GRAB_SEARCHING_HALF_SQUEEZE = { red: 10, green: 10, blue: 255 };
 var COLORS_GRAB_SEARCHING_FULL_SQUEEZE = { red: 250, green: 10, blue: 10 };
 var COLORS_GRAB_DISTANCE_HOLD = { red: 238, green: 75, blue: 214 };


### PR DESCRIPTION
Setting in general next to the laser delay slider

*Note: This only applies to the world lasers. The HUD laser doesn't have the gray passive mode. That's a lot more tricky to handle properly and could potentially break stuff again, so it's been left out of this PR.*

![overte-snap-by-ada-tv-on-2025-09-02_12-00-56](https://github.com/user-attachments/assets/ba752f52-8f66-4345-9988-918730f379c2)

Closes #554

- [ ] Stylus mode broken on the tablet when passive lasers are on