### PR TITLE
More reasonable walk speed in VR, remove old movement modes and MyAvatar.energy

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -808,16 +808,6 @@ void MyAvatar::update(float deltaTime) {
 
     simulate(deltaTime, true);
 
-    currentEnergy += energyChargeRate;
-    currentEnergy -= getAccelerationEnergy();
-    currentEnergy -= getAudioEnergy();
-
-    if(didTeleport()) {
-        currentEnergy = 0.0f;
-    }
-    currentEnergy = max(0.0f, min(currentEnergy,1.0f));
-    emit energyChanged(currentEnergy);
-
     updateEyeContactTarget(deltaTime);
 }
 
@@ -5555,27 +5545,6 @@ bool MyAvatar::FollowHelper::getForceActivateHorizontal() const {
 
 void MyAvatar::FollowHelper::setForceActivateHorizontal(bool val) {
     _forceActivateHorizontal = val;
-}
-
-float MyAvatar::getAccelerationEnergy() {
-    glm::vec3 velocity = getWorldVelocity();
-    int changeInVelocity = abs(velocity.length() - priorVelocity.length());
-    float changeInEnergy = priorVelocity.length() * changeInVelocity * AVATAR_MOVEMENT_ENERGY_CONSTANT;
-    priorVelocity = velocity;
-
-    return changeInEnergy;
-}
-
-float MyAvatar::getEnergy() {
-    return currentEnergy;
-}
-
-void MyAvatar::setEnergy(float value) {
-    currentEnergy = value;
-}
-
-float MyAvatar::getAudioEnergy() {
-    return getAudioLoudness() * AUDIO_ENERGY_CONSTANT;
 }
 
 bool MyAvatar::didTeleport() {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3592,7 +3592,6 @@ void MyAvatar::updateOrientation(float deltaTime) {
 }
 
 glm::vec3 MyAvatar::scaleMotorSpeed(const glm::vec3 forward, const glm::vec3 right) {
-    float stickFullOn = 0.85f;
     auto zSpeed = getDriveKey(TRANSLATE_Z);
     auto xSpeed = !_characterController.getSeated() ? getDriveKey(TRANSLATE_X) : 0.0f;
     glm::vec3 direction;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -243,11 +243,6 @@ MyAvatar::MyAvatar(QThread* thread) :
     _flyingHMDSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "flyingHMD", _flyingPrefHMD),
     _movementReferenceSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "movementReference", _movementReference),
     _avatarEntityCountSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "avatarEntityData" << "size", 0),
-    _driveGear1Setting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "driveGear1", _driveGear1),
-    _driveGear2Setting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "driveGear2", _driveGear2),
-    _driveGear3Setting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "driveGear3", _driveGear3),
-    _driveGear4Setting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "driveGear4", _driveGear4),
-    _driveGear5Setting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "driveGear5", _driveGear5),
     _analogWalkSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "analogWalkSpeed", _analogWalkSpeed.get()),
     _analogPlusWalkSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "analogPlusWalkSpeed", _analogPlusWalkSpeed.get()),
     _controlSchemeIndexSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "controlSchemeIndex", _controlSchemeIndex),
@@ -1350,11 +1345,6 @@ void MyAvatar::saveData() {
     _userHeightSetting.set(getUserHeight());
     _flyingHMDSetting.set(getFlyingHMDPref());
     _movementReferenceSetting.set(getMovementReference());
-    _driveGear1Setting.set(getDriveGear1());
-    _driveGear2Setting.set(getDriveGear2());
-    _driveGear3Setting.set(getDriveGear3());
-    _driveGear4Setting.set(getDriveGear4());
-    _driveGear5Setting.set(getDriveGear5());
     _analogWalkSpeedSetting.set(getAnalogWalkSpeed());
     _analogPlusWalkSpeedSetting.set(getAnalogPlusWalkSpeed());
     _controlSchemeIndexSetting.set(getControlSchemeIndex());
@@ -2104,11 +2094,6 @@ void MyAvatar::loadData() {
     Setting::Handle<bool> firstRunVal { Settings::firstRun, true };
     setFlyingHMDPref(firstRunVal.get() ? true : _flyingHMDSetting.get());
     setMovementReference(firstRunVal.get() ? false : _movementReferenceSetting.get());
-    setDriveGear1(firstRunVal.get() ? DEFAULT_GEAR_1 : _driveGear1Setting.get());
-    setDriveGear2(firstRunVal.get() ? DEFAULT_GEAR_2 : _driveGear2Setting.get());
-    setDriveGear3(firstRunVal.get() ? DEFAULT_GEAR_3 : _driveGear3Setting.get());
-    setDriveGear4(firstRunVal.get() ? DEFAULT_GEAR_4 : _driveGear4Setting.get());
-    setDriveGear5(firstRunVal.get() ? DEFAULT_GEAR_5 : _driveGear5Setting.get());
     setControlSchemeIndex(firstRunVal.get() ? LocomotionControlsMode::CONTROLS_ANALOG : _controlSchemeIndexSetting.get());
     setAnalogWalkSpeed(firstRunVal.get() ? ANALOG_AVATAR_MAX_WALKING_SPEED : _analogWalkSpeedSetting.get());
     setAnalogPlusWalkSpeed(firstRunVal.get() ? ANALOG_PLUS_AVATAR_MAX_WALKING_SPEED : _analogPlusWalkSpeedSetting.get());
@@ -4362,111 +4347,6 @@ void MyAvatar::setControlSchemeIndex(int index){
 
 int MyAvatar::getControlSchemeIndex() {
     return _controlSchemeIndex;
-}
-
-void MyAvatar::setDriveGear1(float shiftPoint) {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setDriveGear1", Q_ARG(float, shiftPoint));
-        return;
-    }
-    if (shiftPoint > 1.0f || shiftPoint < 0.0f) return;
-    _driveGear1 = (shiftPoint < _driveGear2) ? shiftPoint : _driveGear1;
-}
-
-float MyAvatar::getDriveGear1() {
-    switch (_controlSchemeIndex) {
-        case LocomotionControlsMode::CONTROLS_ANALOG:
-            return ANALOG_AVATAR_GEAR_1;
-        case LocomotionControlsMode::CONTROLS_ANALOG_PLUS:
-            return _driveGear1;
-        case LocomotionControlsMode::CONTROLS_DEFAULT:
-        default:
-            return 1.0f;
-    }
-}
-
-void MyAvatar::setDriveGear2(float shiftPoint) {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setDriveGear2", Q_ARG(float, shiftPoint));
-        return;
-    }
-    if (shiftPoint > 1.0f || shiftPoint < 0.0f) return;
-    _driveGear2 = (shiftPoint < _driveGear3 && shiftPoint >= _driveGear1) ? shiftPoint : _driveGear2;
-}
-
-float MyAvatar::getDriveGear2() {
-    switch (_controlSchemeIndex) {
-        case LocomotionControlsMode::CONTROLS_ANALOG:
-            return ANALOG_AVATAR_GEAR_2;
-        case LocomotionControlsMode::CONTROLS_ANALOG_PLUS:
-            return _driveGear2;
-        case LocomotionControlsMode::CONTROLS_DEFAULT:
-        default:
-            return 1.0f;
-    }
-}
-
-void MyAvatar::setDriveGear3(float shiftPoint) {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setDriveGear3", Q_ARG(float, shiftPoint));
-        return;
-    }
-    if (shiftPoint > 1.0f || shiftPoint < 0.0f) return;
-    _driveGear3 = (shiftPoint < _driveGear4 && shiftPoint >= _driveGear2) ? shiftPoint : _driveGear3;
-}
-
-float MyAvatar::getDriveGear3() {
-    switch (_controlSchemeIndex) {
-        case LocomotionControlsMode::CONTROLS_ANALOG:
-            return ANALOG_AVATAR_GEAR_3;
-        case LocomotionControlsMode::CONTROLS_ANALOG_PLUS:
-            return _driveGear3;
-        case LocomotionControlsMode::CONTROLS_DEFAULT:
-        default:
-            return 1.0f;
-    }
-}
-
-void MyAvatar::setDriveGear4(float shiftPoint) {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setDriveGear4", Q_ARG(float, shiftPoint));
-        return;
-    }
-    if (shiftPoint > 1.0f || shiftPoint < 0.0f) return;
-    _driveGear4 = (shiftPoint < _driveGear5 && shiftPoint >= _driveGear3) ? shiftPoint : _driveGear4;
-}
-
-float MyAvatar::getDriveGear4() {
-    switch (_controlSchemeIndex) {
-        case LocomotionControlsMode::CONTROLS_ANALOG:
-            return ANALOG_AVATAR_GEAR_4;
-        case LocomotionControlsMode::CONTROLS_ANALOG_PLUS:
-            return _driveGear4;
-        case LocomotionControlsMode::CONTROLS_DEFAULT:
-        default:
-            return 1.0f;
-    }
-}
-
-void MyAvatar::setDriveGear5(float shiftPoint) {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setDriveGear5", Q_ARG(float, shiftPoint));
-        return;
-    }
-    if (shiftPoint > 1.0f || shiftPoint < 0.0f) return;
-    _driveGear5 = (shiftPoint > _driveGear4) ? shiftPoint : _driveGear5;
-}
-
-float MyAvatar::getDriveGear5() {
-    switch (_controlSchemeIndex) {
-        case LocomotionControlsMode::CONTROLS_ANALOG:
-            return ANALOG_AVATAR_GEAR_5;
-        case LocomotionControlsMode::CONTROLS_ANALOG_PLUS:
-            return _driveGear5;
-        case LocomotionControlsMode::CONTROLS_DEFAULT:
-        default:
-            return 1.0f;
-    }
 }
 
 bool MyAvatar::getFlyingHMDPref() {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3591,29 +3591,6 @@ void MyAvatar::updateOrientation(float deltaTime) {
     }
 }
 
-float MyAvatar::calculateGearedSpeed(const float driveKey) {
-    float absDriveKey = abs(driveKey);
-    float sign = (driveKey < 0.0f) ? -1.0f : 1.0f;
-    if (absDriveKey > getDriveGear5()) {
-        return sign * 1.0f;
-    }
-    else if (absDriveKey > getDriveGear4()) {
-        return sign * 0.8f;
-    }
-    else if (absDriveKey > getDriveGear3()) {
-        return sign * 0.6f;
-    }
-    else if (absDriveKey > getDriveGear2()) {
-        return sign * 0.4f;
-    }
-    else if (absDriveKey > getDriveGear1()) {
-        return sign * 0.2f;
-    }
-    else {
-        return sign * 0.0f;
-    }
-}
-
 glm::vec3 MyAvatar::scaleMotorSpeed(const glm::vec3 forward, const glm::vec3 right) {
     float stickFullOn = 0.85f;
     auto zSpeed = getDriveKey(TRANSLATE_Z);
@@ -3641,8 +3618,8 @@ glm::vec3 MyAvatar::scaleMotorSpeed(const glm::vec3 forward, const glm::vec3 rig
             case LocomotionControlsMode::CONTROLS_ANALOG:
             case LocomotionControlsMode::CONTROLS_ANALOG_PLUS:
                 if (zSpeed || xSpeed) {
-                    glm::vec3 scaledForward = calculateGearedSpeed(zSpeed) * _walkSpeedScalar * ((zSpeed >= stickFullOn) ? getSprintSpeed() : getWalkSpeed()) * forward;
-                    glm::vec3 scaledRight = calculateGearedSpeed(xSpeed) * _walkSpeedScalar * ((xSpeed > stickFullOn) ? getSprintSpeed() : getWalkSpeed()) * right;
+                    glm::vec3 scaledForward = zSpeed * _walkSpeedScalar * getWalkSpeed() * forward;
+                    glm::vec3 scaledRight = xSpeed * _walkSpeedScalar * getWalkSpeed() * right;
                     direction = scaledForward + scaledRight;
                     return direction;
                 } else {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2730,7 +2730,7 @@ private:
     float _driveGear3 { DEFAULT_GEAR_3 };
     float _driveGear4 { DEFAULT_GEAR_4 };
     float _driveGear5 { DEFAULT_GEAR_5 };
-    int _controlSchemeIndex { CONTROLS_ANALOG };
+    int _controlSchemeIndex { CONTROLS_ANALOG_PLUS };
     int _movementReference{ 0 };
 
     glm::vec3 _thrust { 0.0f };  // impulse accumulator for outside sources

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -214,7 +214,6 @@ class MyAvatar : public Avatar {
      * @property {Pose} rightHandTipPose - The right hand's pose as determined by the hand controllers, relative to the avatar,
      *     with the position adjusted by 0.3m along the direction of the palm. <em>Read-only.</em>
      *
-     * @property {number} energy - <span class="important">Deprecated: This property will be removed.</span>
      * @property {boolean} isAway - <code>true</code> if your avatar is away (i.e., inactive), <code>false</code> if it is
      *     active.
      *
@@ -355,7 +354,6 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(controller::Pose leftHandTipPose READ getLeftHandTipPose)
     Q_PROPERTY(controller::Pose rightHandTipPose READ getRightHandTipPose)
 
-    Q_PROPERTY(float energy READ getEnergy WRITE setEnergy)
     Q_PROPERTY(bool isAway READ getIsAway WRITE setAway)
 
     Q_PROPERTY(bool centerOfGravityModelEnabled READ getCenterOfGravityModelEnabled WRITE setCenterOfGravityModelEnabled)
@@ -2360,14 +2358,6 @@ signals:
     void animGraphUrlChanged(const QUrl& url);
 
     /*@jsdoc
-     * @function MyAvatar.energyChanged
-     * @param {number} energy - Avatar energy.
-     * @returns {Signal}
-     * @deprecated This signal is deprecated and will be removed.
-     */
-    void energyChanged(float newEnergy);
-
-    /*@jsdoc
      * Triggered when the avatar has been moved to a new position by one of the MyAvatar "goTo" functions.
      * @function MyAvatar.positionGoneTo
      * @returns {Signal}
@@ -2787,17 +2777,9 @@ private:
     std::mutex _holdActionsMutex;
     std::vector<AvatarActionHold*> _holdActions;
 
-    float AVATAR_MOVEMENT_ENERGY_CONSTANT { 0.001f };
-    float AUDIO_ENERGY_CONSTANT { 0.000001f };
     float MAX_AVATAR_MOVEMENT_PER_FRAME { 30.0f };
-    float currentEnergy { 0.0f };
-    float energyChargeRate { 0.003f };
     glm::vec3 priorVelocity;
     glm::vec3 lastPosition;
-    float getAudioEnergy();
-    float getAccelerationEnergy();
-    float getEnergy();
-    void setEnergy(float value);
     bool didTeleport();
     bool getIsAway() const { return _isAway; }
     void setAway(bool value);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1541,76 +1541,6 @@ public:
     */
     Q_INVOKABLE int getMovementReference();
 
-    /*@jsdoc
-     * Set the first 'shifting point' for acceleration step function.
-     * @function MyAvatar.setDriveGear1
-     * @param {number} shiftPoint - Set the first shift point for analog movement acceleration step function, between [0.0, 1.0]. Must be less than or equal to Gear 2.
-    */
-    Q_INVOKABLE void setDriveGear1(float shiftPoint);
-
-    /*@jsdoc
-     * Get the first 'shifting point' for acceleration step function.
-     * @function MyAvatar.getDriveGear1
-     * @returns {number} Value between [0.0, 1.0].
-    */
-    Q_INVOKABLE float getDriveGear1();
-
-    /*@jsdoc
-    * Set the second 'shifting point' for acceleration step function.
-    * @function MyAvatar.setDriveGear2
-    * @param {number} shiftPoint - Defines the second shift point for analog movement acceleration step function, between [0, 1]. Must be greater than or equal to Gear 1 and less than or equal to Gear 2.
-    */
-    Q_INVOKABLE void setDriveGear2(float shiftPoint);
-
-    /*@jsdoc
-    * Get the second 'shifting point' for acceleration step function.
-    * @function MyAvatar.getDriveGear2
-    * @returns {number} Value between [0.0, 1.0].
-    */
-    Q_INVOKABLE float getDriveGear2();
-
-    /*@jsdoc
-    * Set the third 'shifting point' for acceleration step function.
-    * @function MyAvatar.setDriveGear3
-    * @param {number} shiftPoint - Defines the third shift point for analog movement acceleration step function, between [0, 1]. Must be greater than or equal to Gear 2 and less than or equal to Gear 4.
-    */
-    Q_INVOKABLE void setDriveGear3(float shiftPoint);
-
-    /*@jsdoc
-    * Get the third 'shifting point' for acceleration step function.
-    * @function MyAvatar.getDriveGear3
-    * @returns {number} Value between [0.0, 1.0].
-    */
-    Q_INVOKABLE float getDriveGear3();
-
-    /*@jsdoc
-    * Set the fourth 'shifting point' for acceleration step function.
-    * @function MyAvatar.setDriveGear4
-    * @param {number} shiftPoint - Defines the fourth shift point for analog movement acceleration step function, between [0, 1]. Must be greater than Gear 3 and less than Gear 5.
-    */
-    Q_INVOKABLE void setDriveGear4(float shiftPoint);
-
-    /*@jsdoc
-    * Get the fourth 'shifting point' for acceleration step function.
-    * @function MyAvatar.getDriveGear4
-    * @returns {number} Value between [0.0, 1.0].
-    */
-    Q_INVOKABLE float getDriveGear4();
-
-    /*@jsdoc
-    * Set the fifth 'shifting point' for acceleration step function.
-    * @function MyAvatar.setDriveGear5
-    * @param {number} shiftPoint - Defines the fifth shift point for analog movement acceleration step function, between [0, 1]. Must be greater than or equal to Gear 4.
-    */
-    Q_INVOKABLE void setDriveGear5(float shiftPoint);
-
-    /*@jsdoc
-    * Get the fifth 'shifting point' for acceleration step function.
-    * @function MyAvatar.getDriveGear5
-    * @returns {number} Value between [0.0, 1.0].
-    */
-    Q_INVOKABLE float getDriveGear5();
-
     void setControlSchemeIndex(int index);
 
     int getControlSchemeIndex();
@@ -2725,11 +2655,6 @@ private:
     float _yawSpeed; // degrees/sec
     float _hmdYawSpeed; // degrees/sec
     float _pitchSpeed; // degrees/sec
-    float _driveGear1 { DEFAULT_GEAR_1 };
-    float _driveGear2 { DEFAULT_GEAR_2 };
-    float _driveGear3 { DEFAULT_GEAR_3 };
-    float _driveGear4 { DEFAULT_GEAR_4 };
-    float _driveGear5 { DEFAULT_GEAR_5 };
     int _controlSchemeIndex { CONTROLS_ANALOG_PLUS };
     int _movementReference{ 0 };
 
@@ -3023,11 +2948,6 @@ private:
     Setting::Handle<int> _movementReferenceSetting;
     Setting::Handle<int> _avatarEntityCountSetting;
     Setting::Handle<bool> _allowTeleportingSetting { "allowTeleporting", true };
-    Setting::Handle<float> _driveGear1Setting;
-    Setting::Handle<float> _driveGear2Setting;
-    Setting::Handle<float> _driveGear3Setting;
-    Setting::Handle<float> _driveGear4Setting;
-    Setting::Handle<float> _driveGear5Setting;
     Setting::Handle<float> _analogWalkSpeedSetting;
     Setting::Handle<float> _analogPlusWalkSpeedSetting;
     Setting::Handle<int> _controlSchemeIndexSetting;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2790,7 +2790,6 @@ private:
     // private methods
     void updateOrientation(float deltaTime);
     glm::vec3 calculateScaledDirection();
-    float calculateGearedSpeed(const float driveKey);
     glm::vec3 scaleMotorSpeed(const glm::vec3 forward, const glm::vec3 right);
     void updateActionMotor(float deltaTime);
     void updatePosition(float deltaTime);

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -468,26 +468,6 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
     {
-        auto getter = [myAvatar]()->int { return myAvatar->getControlScheme(); };
-        auto setter = [myAvatar](int index) { myAvatar->setControlScheme(index); };
-        auto preference = new RadioButtonsPreference(VR_MOVEMENT, "Control Scheme", getter, setter);
-        QStringList items;
-        items << "Default" << "Analog" << "Analog++";
-        preference->setHeading("Control Scheme Selection");
-        preference->setItems(items);
-        preferences->addPreference(preference);
-    }
-    {
-        auto getter = [myAvatar]()->float { return myAvatar->getAnalogPlusWalkSpeed(); };
-        auto setter = [myAvatar](float value) { myAvatar->setAnalogPlusWalkSpeed(value); };
-        auto preference = new SpinnerSliderPreference(VR_MOVEMENT, "Analog++ Walk Speed", getter, setter);
-        preference->setMin(6.0f);
-        preference->setMax(30.0f);
-        preference->setStep(1);
-        preference->setDecimals(0);
-        preferences->addPreference(preference);
-    }
-    {
         auto getter = []()->bool {
             return qApp->getVisionSqueeze().getVisionSqueezeEnabled();
         };

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -468,8 +468,8 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
     {
-        auto getter = [myAvatar]()->float { return myAvatar->getAnalogPlusWalkSpeed(); };
-        auto setter = [myAvatar](float value) { myAvatar->setAnalogPlusWalkSpeed(value); };
+        auto getter = [myAvatar]()->float { return myAvatar->getVrWalkSpeed(); };
+        auto setter = [myAvatar](float value) { myAvatar->setVrWalkSpeed(value); };
         auto preference = new SpinnerSliderPreference(VR_MOVEMENT, "VR Walk Speed", getter, setter);
         preference->setMin(1.5f);
         preference->setMax(9.0f);

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -468,6 +468,16 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
     {
+        auto getter = [myAvatar]()->float { return myAvatar->getAnalogPlusWalkSpeed(); };
+        auto setter = [myAvatar](float value) { myAvatar->setAnalogPlusWalkSpeed(value); };
+        auto preference = new SpinnerSliderPreference(VR_MOVEMENT, "VR Walk Speed", getter, setter);
+        preference->setMin(1.5f);
+        preference->setMax(9.0f);
+        preference->setStep(0.1f);
+        preference->setDecimals(1);
+        preferences->addPreference(preference);
+    }
+    {
         auto getter = []()->bool {
             return qApp->getVisionSqueeze().getVisionSqueezeEnabled();
         };

--- a/libraries/shared/src/AvatarConstants.h
+++ b/libraries/shared/src/AvatarConstants.h
@@ -74,8 +74,8 @@ const float DEFAULT_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
 const float DEFAULT_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
 const float DEFAULT_AVATAR_WALK_SPEED_THRESHOLD = 0.15f; // meters / second
 
-const float ANALOG_AVATAR_MAX_WALKING_SPEED = 2.6f; // meters / second
-const float ANALOG_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.6f; // meters / second
+const float ANALOG_AVATAR_MAX_WALKING_SPEED = 3.4f; // meters / second
+const float ANALOG_AVATAR_MAX_WALKING_BACKWARD_SPEED = 3.4f; // meters / second
 const float ANALOG_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
 const float ANALOG_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
 const float ANALOG_AVATAR_GEAR_1 = 0.2f;    // meters / second
@@ -84,10 +84,10 @@ const float ANALOG_AVATAR_GEAR_3 = 0.6f;    // meters / second
 const float ANALOG_AVATAR_GEAR_4 = 0.8f;    // meters / second
 const float ANALOG_AVATAR_GEAR_5 = 1.0f;    // meters / second
 
-const float ANALOG_PLUS_AVATAR_MAX_WALKING_SPEED = 2.6f; // meters / second
-const float ANALOG_PLUS_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.6f; // meters / second
+const float ANALOG_PLUS_AVATAR_MAX_WALKING_SPEED = 3.7f; // meters / second
+const float ANALOG_PLUS_AVATAR_MAX_WALKING_BACKWARD_SPEED = 3.7f; // meters / second
 const float ANALOG_PLUS_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
-const float ANALOG_PLUS_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
+const float ANALOG_PLUS_AVATAR_MAX_SPRINT_SPEED = 3.7f; // meters / second
 
 const float DEFAULT_AVATAR_GRAVITY = -9.8f; // meters / second^2 (world) (originally -5.0f)
 const float DEFAULT_AVATAR_JUMP_SPEED = 5.0f; // meters / second (sensor) (originally 3.5f)

--- a/libraries/shared/src/AvatarConstants.h
+++ b/libraries/shared/src/AvatarConstants.h
@@ -68,21 +68,11 @@ const glm::quat DEFAULT_AVATAR_LEFTFOOT_ROT { -0.40167322754859924f, 0.915459036
 const glm::vec3 DEFAULT_AVATAR_RIGHTFOOT_POS { 0.08f, -0.96f, 0.029f };
 const glm::quat DEFAULT_AVATAR_RIGHTFOOT_ROT { -0.4016716778278351f, 0.9154615998268127f, 0.0053307069465518f, 0.023696165531873703f };
 
-const float DEFAULT_AVATAR_MAX_WALKING_SPEED = 2.6f; // meters / second
-const float DEFAULT_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.6f; // meters / second
-const float DEFAULT_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
-const float DEFAULT_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
 const float DEFAULT_AVATAR_WALK_SPEED_THRESHOLD = 0.15f; // meters / second
-
-const float ANALOG_AVATAR_MAX_WALKING_SPEED = 3.4f; // meters / second
-const float ANALOG_AVATAR_MAX_WALKING_BACKWARD_SPEED = 3.4f; // meters / second
-const float ANALOG_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
-const float ANALOG_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
-
-const float ANALOG_PLUS_AVATAR_MAX_WALKING_SPEED = 3.7f; // meters / second
-const float ANALOG_PLUS_AVATAR_MAX_WALKING_BACKWARD_SPEED = 3.7f; // meters / second
-const float ANALOG_PLUS_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
-const float ANALOG_PLUS_AVATAR_MAX_SPRINT_SPEED = 3.7f; // meters / second
+const float DEFAULT_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
+const float DESKTOP_AVATAR_DEFAULT_WALKING_SPEED = 2.6f; // meters / second
+const float DESKTOP_AVATAR_DEFAULT_SPRINT_SPEED = 3.4f; // meters / second
+const float VR_AVATAR_DEFAULT_WALKING_SPEED = 3.7f; // meters / second
 
 const float DEFAULT_AVATAR_GRAVITY = -9.8f; // meters / second^2 (world) (originally -5.0f)
 const float DEFAULT_AVATAR_JUMP_SPEED = 5.0f; // meters / second (sensor) (originally 3.5f)

--- a/libraries/shared/src/AvatarConstants.h
+++ b/libraries/shared/src/AvatarConstants.h
@@ -72,7 +72,7 @@ const float DEFAULT_AVATAR_WALK_SPEED_THRESHOLD = 0.15f; // meters / second
 const float DEFAULT_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
 const float DESKTOP_AVATAR_DEFAULT_WALKING_SPEED = 2.6f; // meters / second
 const float DESKTOP_AVATAR_DEFAULT_SPRINT_SPEED = 3.4f; // meters / second
-const float VR_AVATAR_DEFAULT_WALKING_SPEED = 3.7f; // meters / second
+const float VR_AVATAR_DEFAULT_WALKING_SPEED = 4.0f; // meters / second
 
 const float DEFAULT_AVATAR_GRAVITY = -9.8f; // meters / second^2 (world) (originally -5.0f)
 const float DEFAULT_AVATAR_JUMP_SPEED = 5.0f; // meters / second (sensor) (originally 3.5f)

--- a/libraries/shared/src/AvatarConstants.h
+++ b/libraries/shared/src/AvatarConstants.h
@@ -78,11 +78,6 @@ const float ANALOG_AVATAR_MAX_WALKING_SPEED = 3.4f; // meters / second
 const float ANALOG_AVATAR_MAX_WALKING_BACKWARD_SPEED = 3.4f; // meters / second
 const float ANALOG_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
 const float ANALOG_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
-const float ANALOG_AVATAR_GEAR_1 = 0.2f;    // meters / second
-const float ANALOG_AVATAR_GEAR_2 = 0.4f;    // meters / second
-const float ANALOG_AVATAR_GEAR_3 = 0.6f;    // meters / second
-const float ANALOG_AVATAR_GEAR_4 = 0.8f;    // meters / second
-const float ANALOG_AVATAR_GEAR_5 = 1.0f;    // meters / second
 
 const float ANALOG_PLUS_AVATAR_MAX_WALKING_SPEED = 3.7f; // meters / second
 const float ANALOG_PLUS_AVATAR_MAX_WALKING_BACKWARD_SPEED = 3.7f; // meters / second

--- a/libraries/shared/src/AvatarConstants.h
+++ b/libraries/shared/src/AvatarConstants.h
@@ -69,25 +69,25 @@ const glm::vec3 DEFAULT_AVATAR_RIGHTFOOT_POS { 0.08f, -0.96f, 0.029f };
 const glm::quat DEFAULT_AVATAR_RIGHTFOOT_ROT { -0.4016716778278351f, 0.9154615998268127f, 0.0053307069465518f, 0.023696165531873703f };
 
 const float DEFAULT_AVATAR_MAX_WALKING_SPEED = 2.6f; // meters / second
-const float DEFAULT_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.2f; // meters / second
+const float DEFAULT_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.6f; // meters / second
 const float DEFAULT_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
 const float DEFAULT_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
 const float DEFAULT_AVATAR_WALK_SPEED_THRESHOLD = 0.15f; // meters / second
 
-const float ANALOG_AVATAR_MAX_WALKING_SPEED = 6.0f; // meters / second
-const float ANALOG_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.2f; // meters / second
+const float ANALOG_AVATAR_MAX_WALKING_SPEED = 2.6f; // meters / second
+const float ANALOG_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.6f; // meters / second
 const float ANALOG_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
-const float ANALOG_AVATAR_MAX_SPRINT_SPEED = 8.0f; // meters / second
+const float ANALOG_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
 const float ANALOG_AVATAR_GEAR_1 = 0.2f;    // meters / second
 const float ANALOG_AVATAR_GEAR_2 = 0.4f;    // meters / second
 const float ANALOG_AVATAR_GEAR_3 = 0.6f;    // meters / second
 const float ANALOG_AVATAR_GEAR_4 = 0.8f;    // meters / second
 const float ANALOG_AVATAR_GEAR_5 = 1.0f;    // meters / second
 
-const float ANALOG_PLUS_AVATAR_MAX_WALKING_SPEED = 10.0f; // meters / second
-const float ANALOG_PLUS_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.42f; // meters / second
+const float ANALOG_PLUS_AVATAR_MAX_WALKING_SPEED = 2.6f; // meters / second
+const float ANALOG_PLUS_AVATAR_MAX_WALKING_BACKWARD_SPEED = 2.6f; // meters / second
 const float ANALOG_PLUS_AVATAR_MAX_FLYING_SPEED = 30.0f; // meters / second
-const float ANALOG_PLUS_AVATAR_MAX_SPRINT_SPEED = 20.0f; // meters / second
+const float ANALOG_PLUS_AVATAR_MAX_SPRINT_SPEED = 3.4f; // meters / second
 
 const float DEFAULT_AVATAR_GRAVITY = -9.8f; // meters / second^2 (world) (originally -5.0f)
 const float DEFAULT_AVATAR_JUMP_SPEED = 5.0f; // meters / second (sensor) (originally 3.5f)


### PR DESCRIPTION
*Note: This won't override the movement mode or walk speed already in your config file. You'll need to remove those config keys for this PR to take effect.*