### PR TITLE
Move GCC 15 workaround to the default Conan profile on Linux CI

### DIFF
--- a/.github/actions/conan-install/action.yml
+++ b/.github/actions/conan-install/action.yml
@@ -23,5 +23,5 @@ runs:
     run: |
       # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
       for counter in {1..2}; do
-        conan install . -c tools.build:cxxflags="['-include', 'cstdint']" -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o 'Overte/*:qt_source='${{ inputs.qt_source }} -b missing -pr=${{ inputs.conan_profile }} -of build --format=json > build.json
+        conan install . -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o 'Overte/*:qt_source='${{ inputs.qt_source }} -b missing -pr=${{ inputs.conan_profile }} -of build --format=json > build.json
       done

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -75,9 +75,9 @@ runs:
 
       # FIXME: Remove once we have full GCC 15 compatibility.
       if [[ "${{ matrix.os }}" = "Ubuntu"* ]]; then
-        cat >> ${CONAN_HOME}/profiles/default <<EOF
-        [conf]
-        tools.build:cxxflags=['-include', 'cstdint']
-        EOF
-        echo "Printing Conan default profile…" && cat ${CONAN_HOME}/profiles/default
+      cat >> ${CONAN_HOME}/profiles/default <<EOF
+      [conf]
+      tools.build:cxxflags=['-include', 'cstdint']
+      EOF
+      echo "Printing Conan default profile…" && cat ${CONAN_HOME}/profiles/default
       fi

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -72,3 +72,12 @@ runs:
       !cmake/*: cmake/[>=3 <4]
       EOF
       echo "Printing Conan default profile…" && cat ${CONAN_HOME}/profiles/default
+
+      # FIXME: Remove once we have full GCC 15 compatibility.
+      if [[ "${{ matrix.os }}" = "Ubuntu"* ]]; then
+        cat >> ${CONAN_HOME}/profiles/default <<EOF
+        [conf]
+        tools.build:cxxflags=['-include', 'cstdint']
+        EOF
+        echo "Printing Conan default profile…" && cat ${CONAN_HOME}/profiles/default
+      fi


### PR DESCRIPTION
Move GCC 15 workaround to the default Conan profile on Linux, to avoid passing to MSVC on Windows and causing issues.