### PR TITLE
Remove Interface cache on uninstall

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -1564,7 +1564,7 @@ Section "Uninstall"
     StrCmp "$MUI_TEMP" "$SMPROGRAMS" startMenuDeleteLoopDone startMenuDeleteLoop
   startMenuDeleteLoopDone:
 
-  ; If the user changed the shortcut, then untinstall may not work. This should
+  ; If the user changed the shortcut, then uninstall may not work. This should
   ; try to fix it.
   StrCpy $MUI_TEMP "$START_MENU"
   Delete "$SMPROGRAMS\$MUI_TEMP\Uninstall.lnk"

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -1539,6 +1539,11 @@ Section "Uninstall"
   Delete "$SMSTARTUP\@CONSOLE_HF_SHORTCUT_NAME@.lnk"
   Delete "$SMSTARTUP\@SANDBOX_HF_SHORTCUT_NAME@.lnk"
   SetShellVarContext all
+  
+  ; Remove all Interface caches of the current user when uninstalling.
+  SetShellVarContext current
+  RMDir /r "$LOCALAPPDATA\@BUILD_ORGANIZATION@\Interface"
+  SetShellVarContext all
 
 @CPACK_NSIS_DELETE_ICONS@
 @CPACK_NSIS_DELETE_ICONS_EXTRA@


### PR DESCRIPTION
Fixes: https://github.com/overte-org/overte/issues/952

This only removes the caches and logs. It does not remove user data, like the settings. It also doesn't remove any server data, since it is unclear to me what is a cache and what is user data there.

I tested both uninstalling with the relevant files being present, and uninstalling with no Interface directory being present.