### PR TITLE
Fix transparent web entity alpha

### DIFF
--- a/libraries/qml/src/qml/impl/SharedObject.cpp
+++ b/libraries/qml/src/qml/impl/SharedObject.cpp
@@ -71,7 +71,7 @@ SharedObject::SharedObject() {
     QQuickWindow::setDefaultAlphaBuffer(true);
     _quickWindow = new QQuickWindow(_renderControl);
     _quickWindow->setFormat(getDefaultOpenGLSurfaceFormat());
-    _quickWindow->setColor(QColor(255, 255, 255, 0));
+    _quickWindow->setColor(Qt::transparent);
     _quickWindow->setClearBeforeRendering(true);
 
 #endif

--- a/libraries/render-utils/src/web_browser.slf
+++ b/libraries/render-utils/src/web_browser.slf
@@ -45,6 +45,11 @@ layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
 
 void main(void) {
     vec4 texel = texture(webTexture, _texCoord0);
+
+    // Weirdly, Qt gives us a texture with premultiplied alpha.
+    // We have to un-premultiply or there are black halos around transparent parts.
+    texel.rgb /= texel.a;
+
     texel = color_sRGBAToLinear(texel);
     texel *= _color;
 


### PR DESCRIPTION
For whatever reason, Qt gives us a texture with premultiplied alpha, which doesn't work well with 3D rendering. This PR changes the background color to transparent black (rather than transparent white), and undoes the alpha premultiply in the Web entity shader. This isn't ideal, but I'm not sure Qt exposes any way of getting an offscreen QML texture with straight alpha instead.

## Before
<img width="758" height="452" alt="image" src="https://github.com/user-attachments/assets/7961e4c0-1bab-4f33-ba3c-f8c08df36308" />

## After
<img width="462" height="252" alt="image" src="https://github.com/user-attachments/assets/fb7d0751-9062-46ab-8a83-55ddf3dd6bb6" />

## QML example for testing
<img width="523" height="357" alt="image" src="https://github.com/user-attachments/assets/5c53f866-176c-4262-8dd1-d72fcd98163e" />

Save this QML as a local file and use it as the source for a Web entity to test.

```qml
import QtQuick 2.15

Item {
	anchors.fill: parent

	Rectangle {
		anchors.top: parent.top
		anchors.left: parent.left
		width: parent.width / 3
		height: parent.height / 3

		color: "red"
		radius: 8
	}

	Rectangle {
		anchors.top: parent.top
		anchors.right: parent.right
		width: parent.width / 3
		height: parent.height / 3

		color: "green"
		radius: 8
	}

	Rectangle {
		anchors.bottom: parent.bottom
		anchors.left: parent.left
		width: parent.width / 3
		height: parent.height / 3

		color: "blue"
		radius: 8
	}

	Rectangle {
		anchors.bottom: parent.bottom
		anchors.right: parent.right
		width: parent.width / 3
		height: parent.height / 3

		color: "#80ffffff"
		radius: 8
	}
}
```