### PR TITLE
Avoid division by 0 on web shader un-premultiply

### DIFF
--- a/libraries/render-utils/src/web_browser.slf
+++ b/libraries/render-utils/src/web_browser.slf
@@ -48,7 +48,7 @@ void main(void) {
 
     // Weirdly, Qt gives us a texture with premultiplied alpha.
     // We have to un-premultiply or there are black halos around transparent parts.
-    texel.rgb /= texel.a;
+    texel.rgb /= max(0.004 /* 1.0 / 255.0 */, texel.a);
 
     texel = color_sRGBAToLinear(texel);
     texel *= _color;


### PR DESCRIPTION
An oops-patch for #1819 cos I forgot about div by zero and remembered slightly too late

## Before
The bright green pixels are low alphas blowing up the division to brighter than the source color (which still happens slightly, it's just an artifact of this workaround we have to do for Qt's weird premultiplied texture), the black regions (and sharp pixel boundaries) here are infinity/NaN but the background is black anyway so it's not visible here
<img width="490" height="380" alt="image" src="https://github.com/user-attachments/assets/7bdaa1df-d2c1-4b6b-ad52-c9c37dbdd270" />

They don't seem to appear on my driver, but the thin black lines on this screenshot by @JulianGro are from infinities/NaNs caused by the div by zero
<img width="155" height="228" alt="image" src="https://github.com/user-attachments/assets/7c92517b-e75e-4f92-90d6-a9657574db83" />

## After
Minimum alpha of roughly 1 / 255 so it doesn't blow up to infinity
<img width="545" height="395" alt="image" src="https://github.com/user-attachments/assets/f176cde8-8fba-4e86-acf3-424fcfdb6c1a" />