### PR TITLE
Improve OpenVR body tracking reliability

### DIFF
--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -2,6 +2,7 @@
 //  Created by Dante Ruiz on 6/1/17.
 //  Copyright 2017 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors.
+//  Copyright 2025 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -27,7 +28,6 @@ Item {
     width: parent.width
 
     property string title: "Controls"
-    property var openVRDevices: ["HTC Vive", "Valve Index", "Valve HMD", "Valve", "WindowsMR", "Oculus"]
 
     HifiConstants { id: hifi }
 
@@ -244,16 +244,6 @@ Item {
                     anchors.fill: parent
                     source: InputConfiguration.configurationLayout(box.textAt(box.currentIndex));
                     onLoaded: {
-                        if (loader.item.hasOwnProperty("pluginName")) {
-                            if (openVRDevices.indexOf(box.textAt(box.currentIndex)) !== -1) {
-                                loader.item.pluginName = "OpenVR";
-                            } else if (box.currentIndex.startsWith("OpenXR")) {
-                                loader.item.pluginName = "OpenXR";
-                            } else {
-                                loader.item.pluginName = box.textAt(box.currentIndex);
-                            }
-                        }
-
                         if (loader.item.hasOwnProperty("displayInformation")) {
                             loader.item.displayConfiguration();
                         }
@@ -301,7 +291,7 @@ Item {
                 loader.source = "";
                 var selectedDevice = box.textAt(box.currentIndex);
                 var source = "";
-                if (openVRDevices.indexOf(selectedDevice) !== -1) {
+                if (selectedDevice.startsWith("OpenVR")) {
                     source = InputConfiguration.configurationLayout("OpenVR");
                 } else if (selectedDevice.startsWith("OpenXR")) {
                     source = InputConfiguration.configurationLayout("OpenXR");

--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -166,7 +166,7 @@ Item {
                     anchors.leftMargin: 40
                     spacing: 10
                     HifiControls.ComboBox {
-                        id: box
+                        id: comboBox
                         width: 160
                         z: 999
                         editable: true
@@ -185,7 +185,7 @@ Item {
                         text: "Show all input devices"
 
                         onClicked: {
-                            box.model = inputPlugins();
+                            comboBox.model = inputPlugins();
                             changeSource();
                         }
                     }
@@ -242,7 +242,7 @@ Item {
                     id: loader
                     asynchronous: false
                     anchors.fill: parent
-                    source: InputConfiguration.configurationLayout(box.textAt(box.currentIndex));
+                    source: InputConfiguration.configurationLayout(comboBox.textAt(comboBox.currentIndex));
                     onLoaded: {
                         if (loader.item.hasOwnProperty("displayInformation")) {
                             loader.item.displayConfiguration();
@@ -289,7 +289,7 @@ Item {
 
             function changeSource() {
                 loader.source = "";
-                var selectedDevice = box.textAt(box.currentIndex);
+                var selectedDevice = comboBox.textAt(comboBox.currentIndex);
                 var source = "";
                 if (selectedDevice.startsWith("OpenVR")) {
                     source = InputConfiguration.configurationLayout("OpenVR");
@@ -301,9 +301,9 @@ Item {
 
                 loader.source = source;
                 if (source === "") {
-                    box.label = "(not configurable)";
+                    comboBox.label = "(not configurable)";
                 } else {
-                    box.label = "";
+                    comboBox.label = "";
                 }
 
                 stack.selectedPlugin = selectedDevice;

--- a/libraries/plugins/src/plugins/InputConfiguration.cpp
+++ b/libraries/plugins/src/plugins/InputConfiguration.cpp
@@ -31,12 +31,7 @@ QStringList InputConfiguration::inputPlugins() {
     QStringList inputPlugins;
     for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         QString pluginName = plugin->getName();
-        if (pluginName == QString("OpenVR")) {
-            QString headsetName = plugin->getDeviceName();
-            inputPlugins << headsetName;
-        } else {
-            inputPlugins << pluginName;
-        }
+        inputPlugins << pluginName;
     }
     return inputPlugins;
 }
@@ -54,12 +49,7 @@ QStringList InputConfiguration::activeInputPlugins() {
     for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         if (plugin->configurable()) {
             QString pluginName = plugin->getName();
-            if (pluginName == QString("OpenVR")) {
-                QString headsetName = plugin->getDeviceName();
-                activePlugins << headsetName;
-            } else {
-                activePlugins << pluginName;
-            }
+            activePlugins << pluginName;
         }
     }
     return activePlugins;

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -2,6 +2,7 @@
 //  Created by Bradley Austin Davis on 2015/05/12
 //  Copyright 2015 High Fidelity, Inc.
 //  Copyright 2020 Vircadia contributors.
+//  Copyright 2025 Overte e.V.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -409,8 +410,8 @@ void OpenVrDisplayPlugin::init() {
 }
 
 const QString OpenVrDisplayPlugin::getName() const {
-    std::string headsetName = getOpenVrDeviceName();
-    if (headsetName == "HTC") {
+    std::string headsetName = "OpenVR: " + getOpenVrDeviceName();
+    if (getOpenVrDeviceName() == "HTC") {
         headsetName += " Vive";
     }
 


### PR DESCRIPTION
Use OpenVR body tracking for everything OpenVR instead of a hardcoded list of HMDs.

This also renames the OpenVR display option by appending "OpenVR: ". So the Valve Index display option is now called "OpenVR: Valve" instead of just "Valve".