### PR TITLE
Qt6: QML render target now set up properly, QML web entities rendering

### DIFF
--- a/libraries/qml/src/qml/impl/RenderEventHandler.cpp
+++ b/libraries/qml/src/qml/impl/RenderEventHandler.cpp
@@ -155,10 +155,7 @@ void RenderEventHandler::qmlRender(bool sceneGraphSync) {
             glClear(GL_COLOR_BUFFER_BIT);
         } else {
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            _shared->setRenderTarget(_fbo, _currentSize);
-            // Qt6 TODO: Qt says that it doesn't have a valid render target
-            // on the deferred renderer, and on the forward one it just makes
-            // the screen gray as if the size hasn't been set properly
+            _shared->setRenderTarget(texture, _currentSize);
             _shared->_renderControl->render();
         }
         _shared->_renderControl->endFrame();

--- a/libraries/qml/src/qml/impl/SharedObject.cpp
+++ b/libraries/qml/src/qml/impl/SharedObject.cpp
@@ -320,9 +320,9 @@ void SharedObject::releaseTextureAndFence() {
 #endif
 }
 
-void SharedObject::setRenderTarget(uint32_t fbo, const QSize& size) {
+void SharedObject::setRenderTarget(uint32_t texture, const QSize& size) {
 #ifndef DISABLE_QML
-    _quickWindow->setRenderTarget(QQuickRenderTarget::fromOpenGLTexture(fbo, size));
+    _quickWindow->setRenderTarget(QQuickRenderTarget::fromOpenGLTexture(texture, size));
 #endif
 }
 

--- a/libraries/qml/src/qml/impl/SharedObject.h
+++ b/libraries/qml/src/qml/impl/SharedObject.h
@@ -73,7 +73,9 @@ private:
     // Called by the render event handler, from the render thread
     void initializeRenderControl(QOpenGLContext* context);
     void releaseTextureAndFence();
-    void setRenderTarget(uint32_t fbo, const QSize& size);
+
+    // NOTE: On Qt5 this took an FBO handle, on Qt6 it takes a texture handle
+    void setRenderTarget(uint32_t texture, const QSize& size);
 
     QQmlEngine* acquireEngine(OffscreenSurface* surface);
     void releaseEngine(QQmlEngine* engine);


### PR DESCRIPTION
`Desktop.qml` still doesn't work, but Web entities now render. (Albeit without interactivity, something is still broken there)

Context menu quick chat (an interesting demo of the cursor hit-tests now working, the I-beam cursor is now used on the text field)
<img width="960" height="521" alt="image" src="https://github.com/user-attachments/assets/54da865b-6b63-4ace-be42-de84857e700a" />

```js
Entities.addEntity({type: "Web", alpha: 0.95, sourceUrl: "file:///path/to/transp_test.qml", dimensions: [2, 1, 0], position: MyAvatar.getHeadPosition()})
```
(the same QML test case from #1819)
<img width="611" height="512" alt="image" src="https://github.com/user-attachments/assets/2511b426-2393-4d53-8f29-ba285ff762e0" />

Web pages don't work yet, there's some QML that needs fixing first.

---

Interestingly, the Qt6 upgrade has gotten desktop cursor hit-tests working on plain QML web entities, so they now appropriately change the cursor shape (arrow, link hand, text I-beam). This happens on master too, but (presumably due to a Qt5 bug) it only worked on WebEngine pages.