### PR TITLE
move quazip find_package to init.cmake

### DIFF
--- a/cmake/init.cmake
+++ b/cmake/init.cmake
@@ -58,3 +58,7 @@ if (UNIX)
 endif ()
 
 find_package(Python3 REQUIRED)
+
+# QT6TODO: See macros/TargetQuazip.cmake
+find_package(QuaZip-Qt6 REQUIRED)
+

--- a/cmake/macros/TargetQuazip.cmake
+++ b/cmake/macros/TargetQuazip.cmake
@@ -6,6 +6,7 @@
 #  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 # 
 macro(TARGET_QUAZIP)
-  find_package(QuaZip-Qt6 REQUIRED)
+  # QT6TODO: if this is found twice, it throws an error. This will be called in init.cmake
+  #find_package(QuaZip-Qt6 REQUIRED)
   target_link_libraries(${TARGET_NAME} QuaZip::QuaZip)
 endmacro()


### PR DESCRIPTION
this circumvents the "promote imported target to global scope" error.