### PR TITLE
Actually fix libnss related regression this time.

### DIFF
--- a/INSTALLER.md
+++ b/INSTALLER.md
@@ -167,7 +167,7 @@ Overte Interface AppImages are built using [linuxdeploy](https://github.com/linu
 6. Run linuxdeploy (make sure that linuxdeploy-plugin-qt is next to linuxdeploy and that both are executable)
    ```bash
    export "QML_SOURCES_PATHS=interface/resources/qml/"
-   export "LINUXDEPLOY_EXCLUDED_LIBRARIES=libnss3.so,libnssutil3.so"
+   export "LINUXDEPLOY_EXCLUDED_LIBRARIES=libnss3.so;libnssutil3.so"
    ~/temp/linuxdeploy-x86_64.AppImage --appdir build/AppDir --executable build/interface/interface --deploy-deps-only build/AppDir/usr/bin/plugins --output appimage --plugin qt --icon-file interface/icon/interface.svg --desktop-file interface/org.overte.interface.desktop
    ```
 

--- a/cmake/modules/GenerateAppImage.cmake
+++ b/cmake/modules/GenerateAppImage.cmake
@@ -61,7 +61,7 @@ execute_process(
       # https://github.com/overte-org/overte/issues/1835
       # https://github.com/probonopd/linuxdeployqt/issues/35
       # https://github.com/probonopd/linuxdeployqt/issues/35#issuecomment-382994446
-      LINUXDEPLOY_EXCLUDED_LIBRARIES=libnss3.so,libnssutil3.so
+      LINUXDEPLOY_EXCLUDED_LIBRARIES=libnss3.so\;libnssutil3.so
     ${LINUXDEPLOY_EXECUTABLE}
     --appdir=${CPACK_TEMPORARY_DIRECTORY}
     --executable=${CPACK_PACKAGE_DIRECTORY}/interface/interface


### PR DESCRIPTION
Apparently, I didn't test this enough and apparently the AppImage was working for Kresney for some other reason.

Now libnss and libnssutil are *actually* missing from the AppImage.