### PR TITLE
Disable QML subpixel antialiasing by default, better icon scaling on app buttons and create entity buttons

### DIFF
--- a/interface/resources/qml/hifi/toolbars/ToolbarButton.qml
+++ b/interface/resources/qml/hifi/toolbars/ToolbarButton.qml
@@ -97,7 +97,9 @@ StateImage {
         anchors.bottom: caption.top
         anchors.bottomMargin: 0
         anchors.horizontalCenter: parent.horizontalCenter
-        fillMode: Image.Stretch
+        fillMode: Image.PreserveAspectFit
+        sourceSize.width: width
+        sourceSize.height: height
         source: urlHelper(button.isActive ? (button.isEntered ? button.activeHoverIcon : button.activeIcon) : (button.isEntered ? button.hoverIcon : button.icon))
     }
 

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -70,6 +70,18 @@ int main(int argc, const char* argv[]) {
     }
 #endif
 
+    // Force-disable subpixel antialiasing on QML distance-field text.
+    // An existing override for QSG_DISTANCEFIELD_ANTIALIASING will be respected, and this
+    // variable will change nothing if QML_DISABLE_DISTANCEFIELD is set.
+    // Qt doesn't seem to have any public API for changing this besides the environment variable.
+    // See qtdeclarative/src/quick/scenegraph/qsgdefaultcontext.cpp
+    if (
+        auto aa = qgetenv("QSG_DISTANCEFIELD_ANTIALIASING");
+        aa.isNull() || aa.isEmpty()
+    ) {
+        qputenv("QSG_DISTANCEFIELD_ANTIALIASING", "gray");
+    }
+
     // Setup QCoreApplication settings, install log message handler
     setupHifiApplication(BuildInfo::INTERFACE_NAME);
 

--- a/scripts/system/create/qml/NewEntityButton.qml
+++ b/scripts/system/create/qml/NewEntityButton.qml
@@ -87,7 +87,9 @@ Item {
         anchors.bottom: text.top
         anchors.bottomMargin: 5
         anchors.horizontalCenter: parent.horizontalCenter
-        fillMode: Image.Stretch
+        fillMode: Image.PreserveAspectFit
+        sourceSize.width: width
+        sourceSize.height: height
         source: newEntityButton.icon
     }
 


### PR DESCRIPTION
* Subpixel AA only works properly on desktop LCD screens, not OLED screens or 3D surfaces. This PR disables Qt's default subpixel AA on QML.
* App icons and entity type icons were being rendered at their native resolution and then being scaled as bitmaps afterwards. This PR fixes this by setting the `Image` `sourceSize` property, which renders the SVG at the actual pixel size it's occupying.

If you want to re-enable subpixel AA for yourself, you can either use `QML_DISABLE_DISTANCEFIELD=1` to force QML to use your system font renderer, or `QSG_DISTANCEFIELD_ANTIALIASING=subpixel` to re-enable subpixel AA in Qt's own text renderer. Beware that these settings apply to *all* QML. There's no way of setting these to only trigger in VR or desktop.

## Before (2025.10.1.1 AppImage)
<img width="662" height="84" alt="before-appbar" src="https://github.com/user-attachments/assets/bc85a974-6d0d-45b7-abc1-e968eb7b0837" />
<img width="559" height="442" alt="before-create" src="https://github.com/user-attachments/assets/07d9591b-f99b-453b-b4da-0611fa4c5deb" />
<img width="948" height="286" alt="image" src="https://github.com/user-attachments/assets/566d8e30-547c-4343-ae27-105a8b7a0102" />

For some reason Qt picks a different default font family when it's in an AppImage on my system, ignore that.

## After
<img width="833" height="80" alt="after-appbar" src="https://github.com/user-attachments/assets/6b54a6e8-98cc-4112-99f2-13eeb2ca9b55" />
<img width="562" height="440" alt="after-create" src="https://github.com/user-attachments/assets/809b3117-e12a-4483-b532-fab3a411d3c3" />
<img width="811" height="256" alt="image" src="https://github.com/user-attachments/assets/738da04e-1af3-4b36-9227-d6e1da8b3c46" />

---
The difference is hard to see on the app bar because most of the icons are already at their native size, the settings cog icon is noticably smoother now though.
<img width="214" height="211" alt="image" src="https://github.com/user-attachments/assets/7f3b6705-845c-4440-b8d5-49e9be0919c1" /><img width="206" height="205" alt="image" src="https://github.com/user-attachments/assets/76583ebe-3d5c-4847-9aa8-1702820fefe1" />

---
QML example for testing. Save this as a `.qml` file and put its filepath as a Web entity's source URL.
```qml
import QtQuick 2.15

Text {
	anchors.fill: parent
	font.pixelSize: 32
	text: "Web entity QML"
	color: "white"
	horizontalAlignment: Text.AlignHCenter
	verticalAlignment: Text.AlignVCenter
}
```