### PR TITLE
Fix building against system Quazip

### DIFF
--- a/cmake/macros/TargetQuazip.cmake
+++ b/cmake/macros/TargetQuazip.cmake
@@ -1,11 +1,19 @@
-# 
+#
 #  Copyright 2015 High Fidelity, Inc.
+#  Copyright 2025 Overte e.V.
 #  Created by Leonardo Murillo on 2015/11/20
 #
 #  Distributed under the Apache License, Version 2.0.
 #  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-# 
+#
 macro(TARGET_QUAZIP)
-  find_package(QuaZip-Qt6 REQUIRED)
-  target_link_libraries(${TARGET_NAME} QuaZip::QuaZip)
+    # System QuaZip sets `IMPORTED_GLOBAL` for itself when finding it using find_package().
+    # Running find_package() a second time shouldn't do anything, since the package was already found,
+    # yet it fails with:
+    # `Attempt to promote imported target "QuaZip::QuaZip" to global scope (by setting IMPORTED_GLOBAL) which is not built in this directory.`
+    # We avoid this error by guarding against running find_package() multiple times.
+    if(NOT TARGET QuaZip::QuaZip)  # if target doesn't exist.
+        find_package(QuaZip-Qt6 REQUIRED)
+    endif()
+    target_link_libraries(${TARGET_NAME} QuaZip::QuaZip)
 endmacro()


### PR DESCRIPTION
This guards against looking for QuaZip multiple times, to avoid the following error:
```
CMake Error at /usr/lib/x86_64-linux-gnu/cmake/QuaZip-Qt6-1.5/QuaZip-Qt6Config.cmake:61 (set_target_properties):
  Attempt to promote imported target "QuaZip::QuaZip" to global scope (by
  setting IMPORTED_GLOBAL) which is not built in this directory.
```
Since CMake has already found and set up the QuaZip::QuaZip target, there is no reason to search for it again.

I tested this both with system QuaZip and Conan QuaZip.

Supersedes: https://github.com/overte-org/overte/pull/1852