### PR TITLE
Un-premultiply overlay desktop texture

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -407,7 +407,7 @@ void OpenGLDisplayPlugin::customizeContext() {
 
         _SRGBToLinearPipeline = gpu::Pipeline::create(gpu::Shader::createProgram(DrawTextureSRGBToLinear), scissorState);
 
-        _hudPipeline = gpu::Pipeline::create(gpu::Shader::createProgram(DrawTextureSRGBToLinear), blendState);
+        _hudPipeline = gpu::Pipeline::create(gpu::Shader::createProgram(DrawTexturePremultipliedSRGBToLinear), blendState);
 
         _cursorPipeline = gpu::Pipeline::create(gpu::Shader::createProgram(DrawTransformedTexture), blendState);
     }

--- a/libraries/gpu/src/gpu/DrawTexturePremultipliedSRGBToLinear.slf
+++ b/libraries/gpu/src/gpu/DrawTexturePremultipliedSRGBToLinear.slf
@@ -1,0 +1,32 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  DrawTextureSRGBToLinear.frag
+//
+//  Draw texture 0 fetched at texcoord.xy, and apply sRGB to Linear color space conversion
+//
+//  Created by Ada <ada@thingvellir.net> on 2025-11-09
+//  Copyright 2025 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include gpu/Color.slh@>
+
+
+LAYOUT(binding=0) uniform sampler2D colorMap;
+
+layout(location=0) in vec2 varTexCoord0;
+layout(location=0) out vec4 outFragColor;
+
+void main(void) {
+    vec4 color = texture(colorMap, varTexCoord0);
+
+    // Weirdly, Qt gives us a texture with premultiplied alpha.
+    // We have to un-premultiply or there are black halos around transparent parts.
+    color.rgb /= max(0.004 /* 1.0 / 255.0 */, color.a);
+
+    outFragColor = color_sRGBAToLinear(color);
+}

--- a/libraries/gpu/src/gpu/DrawTexturePremultipliedSRGBToLinear.slp
+++ b/libraries/gpu/src/gpu/DrawTexturePremultipliedSRGBToLinear.slp
@@ -1,0 +1,1 @@
+VERTEX DrawUnitQuadTexcoord

--- a/libraries/render-utils/src/hmd_ui.slf
+++ b/libraries/render-utils/src/hmd_ui.slf
@@ -32,6 +32,11 @@ layout(location=0) out vec4 fragColor0;
 
 void main() {
     vec4 color = texture(hudTexture, _texCoord0);
+
+    // Weirdly, Qt gives us a texture with premultiplied alpha.
+    // We have to un-premultiply or there are black halos around transparent parts.
+    color.rgb /= max(0.004 /* 1.0 / 255.0 */, color.a);
+
     color.a *= hud.alpha;
     if (color.a <= 0.0) {
         discard;


### PR DESCRIPTION
Fixes subtly wrong color rendering on transparent parts of the overlay UI. The effects of this PR won't be *nearly* as noticable with the new theme in #1873, but this is the more correct way of rendering anyway.

We kinda *have* to do this, because it's what Qt gives us, and Qt is where the underlying issue is. I'm not sure why they prefer premultiplied alpha for everything but they might be stuck using it for compatibility.

Related to #1599
Closes #1861

## Master
The red QML debug text has visible black smudges and the window border outlines are very faint
<img width="678" height="112" alt="premul-before-toolbar" src="https://github.com/user-attachments/assets/3f74c412-88c1-4a22-8d99-41eb4bb77ccd" />
The title text and buttons have broken antialiasing
<img width="421" height="731" alt="premul-before-window" src="https://github.com/user-attachments/assets/285150d4-4720-4ca4-bbd8-4c8b09f1ef64" />

## This PR
<img width="662" height="91" alt="image" src="https://github.com/user-attachments/assets/a5999f5d-be86-4465-be5e-c08d0439e34b" />
<img width="420" height="730" alt="image" src="https://github.com/user-attachments/assets/2d687c76-c8ca-4d5a-b3a5-99b6cc14f0e9" />