### PR TITLE
Chat app: Fix images not loading

### DIFF
--- a/scripts/communityScripts/armored-chat/qml/ChatMessage.qml
+++ b/scripts/communityScripts/armored-chat/qml/ChatMessage.qml
@@ -35,7 +35,8 @@ Item {
 		}
 
 		// Message body
-		TextEdit { 
+		TextEdit {
+			id: messageText;
 			text: delegateMessage;
 			color: "white";
 			font.pixelSize: 18;
@@ -54,6 +55,30 @@ Item {
 					return;
 				} else {
 					Qt.openUrlExternally(link);
+				}
+			}
+
+			Component.onCompleted: {
+				// Images do not appear when done loading until
+				// the component is redrawn, which it does not do
+				// automatically; so we need to create a hidden
+				// Image object and wait for that to load
+				// before we cause it to redraw by altering the content.
+				var re = /<img[^>]+src="([^"]+)"[^>]+>/gi
+				var m;
+				while ((m = re.exec(text)) !== null) {
+					var loader = Qt.createQmlObject('import QtQuick 2.0; Image {}', messageText);
+					loader.source = m[1];
+					loader.visible = false;
+					loader.onStatusChanged.connect(function () {
+						if (loader.status === Image.Ready) {
+							// Alter the content of messageText
+							// to prompt it to redraw
+							var originalText = messageText.text;
+							messageText.text = "";          // force a change
+							messageText.text = originalText;
+						}
+					});
 				}
 			}
 		}


### PR DESCRIPTION
When images load they are not shown in the chat app as it does not seem to redraw the message automatically.

This PR prompts the TextEdit component to refresh its content once the first image in the message loads.

Known issue: This will not ensure *all* images in a message will show, only the first; if others have loaded by that point then it'll show those too.

I am aware the chat app has a rewrite which will replace it. I'm happy enough to see this replaced, and if the new chat needs this fix too I think we can put a bit more effort in for the new app to show multiple images.