### PR TITLE
Automatic Docker release builds

### DIFF
--- a/.github/workflows/release_docker_server_build.yml
+++ b/.github/workflows/release_docker_server_build.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Build server
       shell: bash
+      # Using the previously checked out Docker files.
       run: docker build --no-cache --build-arg "TAG=${{ github.ref_name }}" --build-arg "REPO=https://github.com/${{ github.repository }}.git" -t domain-server-builder -f ./Dockerfile.build .
 
     - name: Deploy server into runtime image


### PR DESCRIPTION
This PR adds automatic Docker server release builds. This way, I don't have to build them manually every release.
Only the latest tag needs to be updated manually.
They can be seen in action here: https://github.com/JulianGro/overte/actions/runs/19611606837 and here: https://github.com/JulianGro/overte/actions/runs/19613230103
aarch64 builds are failing due to shader compilation issues.
It uses the https://github.com/overte-org/overte-domain-server-docker repository, which has always been used for Docker server release builds.