### PR TITLE
Update clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,11 @@
 # https://clang.llvm.org/docs/ClangFormat.html
 #
 # Copyright 2013-2019, High Fidelity, Inc.
-# Copyright 2022 Overte e.V.
+# Copyright 2022-2025 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 Language: Cpp
-Standard: Cpp11
+Standard: c++20
 BasedOnStyle: "Chromium"
 ColumnLimit: 128
 IndentWidth: 4
@@ -29,7 +29,6 @@ BraceWrapping:
 AccessModifierOffset: -4
 AllowShortFunctionsOnASingleLine: InlineOnly
 BreakConstructorInitializers: AfterColon
-BreakConstructorInitializersBeforeComma: false
 IndentCaseLabels: true
 ReflowComments: false
 Cpp11BracedListStyle: false


### PR DESCRIPTION
- Bump to C++20
- Remove BreakConstructorInitializersBeforeComma, which was replaced by BreakConstructorInitializers in Clang 5.0 (see: https://github.com/llvm/llvm-project/commit/a6b6d51ba471a2f645e63bee46e896e7f350b0b5 and https://reviews.llvm.org/D32479).

Unfortunately, clang-format cannot really do what I want, which is to allow some loose formatting. (For example we probably don't care if people put two or one space between code and an inline comment.)