### PR TITLE
fix material/script entity queryAACube not containing parent

### DIFF
--- a/libraries/entities/src/MaterialEntityItem.cpp.in
+++ b/libraries/entities/src/MaterialEntityItem.cpp.in
@@ -100,6 +100,7 @@ void MaterialEntityItem::setParentID(const QUuid& parentID) {
     if (parentID != getParentID()) {
         EntityItem::setParentID(parentID);
         _hasVertexShader = false;
+        _queryAACubeSet = false; // Force queryAACube update
     }
 }
 

--- a/libraries/entities/src/ScriptEntityItem.cpp.in
+++ b/libraries/entities/src/ScriptEntityItem.cpp.in
@@ -132,6 +132,7 @@ void ScriptEntityItem::setParentID(const QUuid& parentID) {
     if (parentID != getParentID()) {
         EntityItem::setParentID(parentID);
         updateScript();
+        _queryAACubeSet = false; // Force queryAACube update
     }
 }
 


### PR DESCRIPTION
fixes #668

I created a large cube (1000 x 1000 x 1, white) and attached a material entity to it (red).  I opened the domain's model.json and found that the queryAACube of the material was still small, which meant it wasn't updated when the parent changed.  so this ended up being a much simpler fix than I've thought all this time (...5+ years) - we just need to force queryAACube updates on materials/scripts when their parentIDs change.

To test:
- set up the cube + material as above
- move 1000m away
- reload content or restart interface.
- the big cube should be red!