### PR TITLE
simplify non-pickable entity logic

### DIFF
--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -197,6 +197,13 @@ EntityItemID EntityTreeElement::evalDetailedRayIntersection(const glm::vec3& ori
     // only called if we do intersect our bounding cube, but find if we actually intersect with entities...
     EntityItemID entityID;
     forEachEntity([&](EntityItemPointer entity) {
+        EntityTypes::EntityType type = entity->getType();
+        if (type == EntityTypes::ParticleEffect || type == EntityTypes::ProceduralParticleEffect || type == EntityTypes::Line ||
+            type == EntityTypes::PolyLine || type == EntityTypes::Sound || type == EntityTypes::Script || type == EntityTypes::Empty ||
+            (type == EntityTypes::Material && !entity->getParentID().isNull())) {
+            return;
+        }
+
         if (entity->getIgnorePickIntersection() && !searchFilter.bypassIgnore()) {
             return;
         }
@@ -257,9 +264,7 @@ EntityItemID EntityTreeElement::evalDetailedRayIntersection(const glm::vec3& ori
                     }
                 } else {
                     // if the entity type doesn't support a detailed intersection, then just return the non-AABox results
-                    // Never intersect with particle or sound entities
-                    if (localDistance < distance && (entity->getType() != EntityTypes::ParticleEffect && entity->getType() != EntityTypes::ProceduralParticleEffect &&
-                         entity->getType() != EntityTypes::Sound && entity->getType() != EntityTypes::Script)) {
+                    if (localDistance < distance) {
                         distance = localDistance;
                         face = localFace;
                         surfaceNormal = glm::vec3(rotation * glm::vec4(localSurfaceNormal, 0.0f));
@@ -344,6 +349,13 @@ EntityItemID EntityTreeElement::evalDetailedParabolaIntersection(const glm::vec3
     // only called if we do intersect our bounding cube, but find if we actually intersect with entities...
     EntityItemID entityID;
     forEachEntity([&](EntityItemPointer entity) {
+        EntityTypes::EntityType type = entity->getType();
+        if (type == EntityTypes::ParticleEffect || type == EntityTypes::ProceduralParticleEffect || type == EntityTypes::Line ||
+            type == EntityTypes::PolyLine || type == EntityTypes::Sound || type == EntityTypes::Script ||
+            type == EntityTypes::Empty || (type == EntityTypes::Material && !entity->getParentID().isNull())) {
+            return;
+        }
+
         if (entity->getIgnorePickIntersection() && !searchFilter.bypassIgnore()) {
             return;
         }
@@ -410,9 +422,7 @@ EntityItemID EntityTreeElement::evalDetailedParabolaIntersection(const glm::vec3
                     }
                 } else {
                     // if the entity type doesn't support a detailed intersection, then just return the non-AABox results
-                    // Never intersect with particle or sound entities
-                    if (localDistance < parabolicDistance && (entity->getType() != EntityTypes::ParticleEffect && entity->getType() != EntityTypes::ProceduralParticleEffect &&
-                         entity->getType() != EntityTypes::Sound && entity->getType() != EntityTypes::Script)) {
+                    if (localDistance < parabolicDistance) {
                         parabolicDistance = localDistance;
                         face = localFace;
                         surfaceNormal = glm::vec3(rotation * glm::vec4(localSurfaceNormal, 0.0f));

--- a/libraries/entities/src/LineEntityItem.h.in
+++ b/libraries/entities/src/LineEntityItem.h.in
@@ -25,19 +25,6 @@ class LineEntityItem : public EntityItem {
 
     bool appendPoint(const glm::vec3& point);
 
-    // never have a ray intersection pick a LineEntityItem.
-    virtual bool supportsDetailedIntersection() const override { return true; }
-    virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
-                                             const glm::vec3& viewFrustumPos, OctreeElementPointer& element, float& distance,
-                                             BoxFace& face, glm::vec3& surfaceNormal,
-                                             QVariantMap& extraInfo,
-                                             bool precisionPicking) const override { return false; }
-    virtual bool findDetailedParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity,
-                                                  const glm::vec3& acceleration, const glm::vec3& viewFrustumPos, OctreeElementPointer& element,
-                                                  float& parabolicDistance, BoxFace& face, glm::vec3& surfaceNormal,
-                                                  QVariantMap& extraInfo,
-                                                  bool precisionPicking) const override { return false; }
-
     static const int MAX_POINTS_PER_LINE;
 
     QVector<glm::vec3> getLinePoints() const;

--- a/libraries/entities/src/ParticleEffectEntityItem.h.in
+++ b/libraries/entities/src/ParticleEffectEntityItem.h.in
@@ -217,8 +217,6 @@ public:
 
     void computeAndUpdateDimensions();
 
-    virtual bool supportsDetailedIntersection() const override { return false; }
-
     ShapeType getShapeType() const override;
     void setShapeType(ShapeType type) override;
 

--- a/libraries/entities/src/PolyLineEntityItem.h.in
+++ b/libraries/entities/src/PolyLineEntityItem.h.in
@@ -37,17 +37,6 @@ public:
     void resetTexturesChanged() { _texturesChanged = false; }
     void resetPolyLineChanged() { _colorsChanged = _widthsChanged = _normalsChanged = _pointsChanged = false; }
 
-    // never have a ray intersection pick a PolyLineEntityItem.
-    virtual bool supportsDetailedIntersection() const override { return true; }
-    virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
-                                             const glm::vec3& viewFrustumPos, OctreeElementPointer& element, float& distance,
-                                             BoxFace& face, glm::vec3& surfaceNormal,
-                                             QVariantMap& extraInfo, bool precisionPicking) const override { return false; }
-    virtual bool findDetailedParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity,
-                                                  const glm::vec3& acceleration, const glm::vec3& viewFrustumPos, OctreeElementPointer& element,
-                                                  float& parabolicDistance, BoxFace& face, glm::vec3& surfaceNormal,
-                                                  QVariantMap& extraInfo, bool precisionPicking) const override { return false; }
-
     void computeTightLocalBoundingBox(AABox& box) const;
 private:
     void computeAndUpdateDimensions();

--- a/libraries/entities/src/PolyVoxEntityItem.h.in
+++ b/libraries/entities/src/PolyVoxEntityItem.h.in
@@ -23,17 +23,6 @@ public:
     ALLOW_INSTANTIATION // This class can be instantiated
     ENTITY_PROPERTY_SUBCLASS_METHODS
 
-    // never have a ray intersection pick a PolyVoxEntityItem.
-    virtual bool supportsDetailedIntersection() const override { return true; }
-    virtual bool findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
-                                             const glm::vec3& viewFrustumPos, OctreeElementPointer& element, float& distance,
-                                             BoxFace& face, glm::vec3& surfaceNormal,
-                                             QVariantMap& extraInfo, bool precisionPicking) const override { return false; }
-    virtual bool findDetailedParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity,
-                                                  const glm::vec3& acceleration, const glm::vec3& viewFrustumPos, OctreeElementPointer& element,
-                                                  float& parabolicDistance, BoxFace& face, glm::vec3& surfaceNormal,
-                                                  QVariantMap& extraInfo, bool precisionPicking) const override { return false; }
-
     virtual int getOnCount() const { return 0; }
 
     /*@jsdoc

--- a/libraries/entities/src/ProceduralParticleEffectEntityItem.h.in
+++ b/libraries/entities/src/ProceduralParticleEffectEntityItem.h.in
@@ -36,8 +36,6 @@ public:
 
     bool shouldBePhysical() const override { return false; }
 
-    virtual bool supportsDetailedIntersection() const override { return false; }
-
 protected:
 
 @ProceduralParticleEffect_ENTITY_PROPS@

--- a/libraries/entities/src/ScriptEntityItem.h.in
+++ b/libraries/entities/src/ScriptEntityItem.h.in
@@ -23,8 +23,6 @@ public:
 
     bool shouldBePhysical() const override { return false; }
 
-    virtual bool supportsDetailedIntersection() const override { return false; }
-
     AACube calculateInitialQueryAACube(bool& success) override;
 
     virtual void update(const quint64& now) override;

--- a/libraries/entities/src/SoundEntityItem.h.in
+++ b/libraries/entities/src/SoundEntityItem.h.in
@@ -26,8 +26,6 @@ public:
 
     bool shouldBePhysical() const override { return false; }
 
-    virtual bool supportsDetailedIntersection() const override { return false; }
-
     virtual void update(const quint64& now) override;
     bool needsToCallUpdate() const override { return _updateNeeded; }
 


### PR DESCRIPTION
fixes #1527 

particles (both types), lines (both types), sound, script, empty, and material (when they are parented to something) entities are not supposed to be pickable.  make sure we're enforcing this correctly and simply by early exiting the picking methods and cleaning up the old, more confusing logic