### PR TITLE
Add simple dialog for picking display plugin on startup

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -224,6 +224,7 @@ Application::Application(
     _useDiscordPresence("useDiscordPresence", true),
     _firstRun(Settings::firstRun, true),
     _previousScriptLocation("LastScriptLocation", DESKTOP_LOCATION),
+    _previousPreferredDisplayMode("previousPreferredDisplayMode", 0),
     // UI
     _hmdTabletScale("hmdTabletScale", DEFAULT_HMD_TABLET_SCALE_PERCENT),
     _desktopTabletScale("desktopTabletScale", DEFAULT_DESKTOP_TABLET_SCALE_PERCENT),

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -760,6 +760,7 @@ private:
 
     Setting::Handle<bool> _firstRun;
     Setting::Handle<QString> _previousScriptLocation;
+    Setting::Handle<int> _previousPreferredDisplayMode;
 
 
     // UI

--- a/interface/src/Application_Plugins.cpp
+++ b/interface/src/Application_Plugins.cpp
@@ -60,7 +60,7 @@ void Application::initializePluginManager(const QCommandLineParser& parser) {
     // QApplication must exist, or it can't find the plugin path, as QCoreApplication:applicationDirPath
     // won't work yet.
 
-    auto anyPluginSpecified = false;
+    auto displayPluginSpecified = false;
     auto openxrPreferred = false;
     auto desktopPreferred = false;
 
@@ -68,7 +68,7 @@ void Application::initializePluginManager(const QCommandLineParser& parser) {
         auto preferredDisplays = parser.value("display").split(',', Qt::SkipEmptyParts);
         qInfo() << "Setting prefered display plugins:" << preferredDisplays;
         PluginManager::getInstance()->setPreferredDisplayPlugins(preferredDisplays);
-        anyPluginSpecified = true;
+        displayPluginSpecified = true;
 
         if (preferredDisplays.startsWith(DESKTOP_DISPLAY_PLUGIN_NAME)) {
             desktopPreferred = true;
@@ -81,14 +81,13 @@ void Application::initializePluginManager(const QCommandLineParser& parser) {
         auto disabledDisplays = parser.value("disableDisplayPlugins").split(',', Qt::SkipEmptyParts);
         qInfo() << "Disabling following display plugins:"  << disabledDisplays;
         PluginManager::getInstance()->disableDisplays(disabledDisplays);
-        anyPluginSpecified = true;
+        displayPluginSpecified = true;
     }
 
     if (parser.isSet("disableInputPlugins")) {
         auto disabledInputs = parser.value("disableInputPlugins").split(',', Qt::SkipEmptyParts);
         qInfo() << "Disabling following input plugins:" << disabledInputs;
         PluginManager::getInstance()->disableInputs(disabledInputs);
-        anyPluginSpecified = true;
     }
 
     QStringList disabledLaunchPlugins = {};
@@ -103,7 +102,7 @@ void Application::initializePluginManager(const QCommandLineParser& parser) {
         disabledLaunchPlugins.push_back(OPENVR_PLUGIN_NAME);
         disabledLaunchPlugins.push_back(OPENXR_PLUGIN_NAME);
         _previousPreferredDisplayMode.set(0);
-    } else if (!anyPluginSpecified) {
+    } else if (!displayPluginSpecified) {
         const QStringList choices = {
             tr("Desktop"),
             tr("OpenXR (experimental)"),

--- a/interface/src/Application_Plugins.cpp
+++ b/interface/src/Application_Plugins.cpp
@@ -101,7 +101,7 @@ void Application::initializePluginManager(const QCommandLineParser& parser) {
     } else {
         const QStringList choices = {
             tr("Desktop"),
-            tr("OpenXR"),
+            tr("OpenXR (experimental)"),
             tr("OpenVR (compatibility)"),
         };
 

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -300,7 +300,7 @@ int main(int argc, const char* argv[]) {
     );
     QCommandLineOption useExperimentalXROption(
         "useExperimentalXR",
-        "Enables the experimental OpenXR plugin and disables the OpenVR plugin. Some features available in OpenVR aren't yet available in OpenXR."
+        "Legacy alias of --preferredDisplay=openxr"
     );
     QCommandLineOption xrNoHandTrackingOption(
         "xrNoHandTracking",
@@ -313,6 +313,12 @@ int main(int argc, const char* argv[]) {
     QCommandLineOption xrNoPalmPoseOption(
         "xrNoPalmPose",
         "Debug option. Disables use of the OpenXR palm pose, even if it's supported. Falls back to the controller's grip pose."
+    );
+
+    QCommandLineOption preferredDisplay(
+        "preferredDisplay",
+        "If set, this will override the startup dialog asking for the preferred display mode. Can be \"desktop\", \"openvr\", or \"openxr\".",
+        "displayMode"
     );
 
     // "--qmljsdebugger", which appears in output from "--help-all".
@@ -366,6 +372,7 @@ int main(int argc, const char* argv[]) {
     parser.addOption(useExperimentalXROption);
     parser.addOption(xrNoHandTrackingOption);
     parser.addOption(xrNoPalmPoseOption);
+    parser.addOption(preferredDisplay);
 
 
     QString applicationPath;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -153,17 +153,17 @@ int main(int argc, const char* argv[]) {
     );
     QCommandLineOption displaysOption(
         "display",
-        "Preferred display.",
+        "Preferred display plugin. Valid options include \"Desktop\", \"OpenXR\", and \"OpenVR (Vive)\"",
         "displays"
     );
     QCommandLineOption disableDisplaysOption(
         "disableDisplayPlugins",
-        "Displays to disable. Valid options include \"OpenVR (Vive)\" and \"Oculus Rift\"",
+        "Display plugins to disable, separated by commas. Valid options include \"OpenXR\" and \"OpenVR (Vive)\"",
         "string"
     );
     QCommandLineOption disableInputsOption(
         "disableInputPlugins",
-        "Inputs to disable. Valid options include \"OpenVR (Vive)\" and \"Oculus Rift\"",
+        "Input plugins to disable, separated by commas. Valid options include \"SDL2\" (used only for gamepads), \"OpenXR\", and \"OpenVR (Vive)\"",
         "string"
     );
     QCommandLineOption suppressSettingsResetOption(

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -153,17 +153,17 @@ int main(int argc, const char* argv[]) {
     );
     QCommandLineOption displaysOption(
         "display",
-        "Preferred display plugin. Valid options include \"Desktop\", \"OpenXR\", and \"OpenVR (Vive)\"",
+        "Preferred display plugin. Valid options include \"Desktop\", \"OpenXR\", and \"OpenVR (Vive)\". If \"Desktop\" is specified, all VR plugins are disabled.",
         "displays"
     );
     QCommandLineOption disableDisplaysOption(
         "disableDisplayPlugins",
-        "Display plugins to disable, separated by commas. Valid options include \"OpenXR\" and \"OpenVR (Vive)\"",
+        "Display plugins to disable, separated by commas. Valid options include \"OpenXR\" and \"OpenVR (Vive)\".",
         "string"
     );
     QCommandLineOption disableInputsOption(
         "disableInputPlugins",
-        "Input plugins to disable, separated by commas. Valid options include \"SDL2\" (used only for gamepads), \"OpenXR\", and \"OpenVR (Vive)\"",
+        "Input plugins to disable, separated by commas. Valid options include \"SDL2\" (used only for gamepads), \"OpenXR\", and \"OpenVR (Vive)\".",
         "string"
     );
     QCommandLineOption suppressSettingsResetOption(
@@ -300,7 +300,7 @@ int main(int argc, const char* argv[]) {
     );
     QCommandLineOption useExperimentalXROption(
         "useExperimentalXR",
-        "Legacy alias of --display=OpenXR"
+        "Legacy alias of \"--display=OpenXR\"."
     );
     QCommandLineOption xrNoHandTrackingOption(
         "xrNoHandTracking",

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -300,7 +300,7 @@ int main(int argc, const char* argv[]) {
     );
     QCommandLineOption useExperimentalXROption(
         "useExperimentalXR",
-        "Legacy alias of --preferredDisplay=openxr"
+        "Legacy alias of --display=OpenXR"
     );
     QCommandLineOption xrNoHandTrackingOption(
         "xrNoHandTracking",
@@ -313,12 +313,6 @@ int main(int argc, const char* argv[]) {
     QCommandLineOption xrNoPalmPoseOption(
         "xrNoPalmPose",
         "Debug option. Disables use of the OpenXR palm pose, even if it's supported. Falls back to the controller's grip pose."
-    );
-
-    QCommandLineOption preferredDisplay(
-        "preferredDisplay",
-        "If set, this will override the startup dialog asking for the preferred display mode. Can be \"desktop\", \"openvr\", or \"openxr\".",
-        "displayMode"
     );
 
     // "--qmljsdebugger", which appears in output from "--help-all".
@@ -372,7 +366,6 @@ int main(int argc, const char* argv[]) {
     parser.addOption(useExperimentalXROption);
     parser.addOption(xrNoHandTrackingOption);
     parser.addOption(xrNoPalmPoseOption);
-    parser.addOption(preferredDisplay);
 
 
     QString applicationPath;


### PR DESCRIPTION
Makes it a lot easier for non-technical users to use OpenXR or launch in desktop-only mode without the game trying to launch SteamVR in the background.

If/when we have a Steam build, we can use their built-in startup mode picker and bypass this one.

<img width="220" height="134" alt="image" src="https://github.com/user-attachments/assets/4ae7a150-1c31-435d-b385-9c053ab8ac81" />

You can bypass the dialog with the `--display={Desktop,OpenXR,OpenVR (Vive)}` launch flag.

`--useExperimentalXR` is no longer necessary, and behaves the same as `--display=OpenXR`.