### PR TITLE
Script-driven OSC

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -94,6 +94,7 @@
 #include <scripting/SettingsScriptingInterface.h>
 #include <scripting/TestScriptingInterface.h>
 #include <scripting/WindowScriptingInterface.h>
+#include <scripting/OSCScriptingInterface.h>
 #ifndef Q_OS_ANDROID
 #include <shared/FileLogger.h>
 #endif
@@ -657,6 +658,8 @@ void Application::registerScriptEngineWithApplicationServices(ScriptManagerPoint
     scriptEngine->registerGlobalObject(sgp, "Workload", _gameWorkload._engine->getConfiguration().get());
 
     scriptEngine->registerGlobalObject(sgp, "Graphics", DependencyManager::get<GraphicsScriptingInterface>().data());
+
+    scriptEngine->registerGlobalObject(sgp, "OSCSocket", DependencyManager::get<OSCScriptingInterface>().data());
 
     scriptEngine->registerGlobalObject(sgp, "ScriptDiscoveryService", DependencyManager::get<ScriptEngines>().data());
     scriptEngine->registerGlobalObject(sgp, "Reticle", getApplicationCompositor().getReticleInterface());

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -660,6 +660,7 @@ void Application::registerScriptEngineWithApplicationServices(ScriptManagerPoint
     scriptEngine->registerGlobalObject(sgp, "Graphics", DependencyManager::get<GraphicsScriptingInterface>().data());
 
     scriptEngine->registerGlobalObject(sgp, "OSCSocket", DependencyManager::get<OSCScriptingInterface>().data());
+    scriptEngine->registerFunction(sgp, "OSCSocket", "sendPacket", OSCScriptingInterface::sendPacket, 0);
 
     scriptEngine->registerGlobalObject(sgp, "ScriptDiscoveryService", DependencyManager::get<ScriptEngines>().data());
     scriptEngine->registerGlobalObject(sgp, "Reticle", getApplicationCompositor().getReticleInterface());

--- a/interface/src/Application_Setup.cpp
+++ b/interface/src/Application_Setup.cpp
@@ -97,6 +97,7 @@
 #include <scripting/TestScriptingInterface.h>
 #include <scripting/TTSScriptingInterface.h>
 #include <scripting/WindowScriptingInterface.h>
+#include <scripting/OSCScriptingInterface.h>
 #include <ShapeEntityItem.h>
 #ifndef Q_OS_ANDROID
 #include <shared/FileLogger.h>
@@ -357,6 +358,7 @@ bool setupEssentials(const QCommandLineParser& parser, bool runningMarkerExisted
     DependencyManager::set<DesktopScriptingInterface>();
     DependencyManager::set<EntityScriptingInterface>(true);
     DependencyManager::set<GraphicsScriptingInterface>();
+    DependencyManager::set<OSCScriptingInterface>();
     DependencyManager::registerInheritance<scriptable::ModelProviderFactory, ApplicationMeshProvider>();
     DependencyManager::set<ApplicationMeshProvider>();
     DependencyManager::set<RecordingScriptingInterface>();

--- a/interface/src/scripting/OSCScriptingInterface.cpp
+++ b/interface/src/scripting/OSCScriptingInterface.cpp
@@ -1,0 +1,174 @@
+//
+//  OSCScriptingInterface.cpp
+//  interface/src/scripting
+//
+//  Created by Ada <ada@thingvellir.net> on 2025-12-13
+//  Copyright 2025 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include <QLoggingCategory>
+#include <QRegularExpression>
+#include <QtEndian>
+
+#include "ScriptEngine.h"
+#include "OSCScriptingInterface.h"
+
+
+Q_LOGGING_CATEGORY(osc, "overte.osc")
+
+enum OSCTag: char {
+    Int = 'i',
+    Float = 'f',
+    String = 's',
+    Blob = 'b',
+};
+
+static const QRegularExpression invalidCharacters = QRegularExpression("([ #*,/?\\[\\]{}])");
+static const QMap<QChar, QVariant::Type> typeNameMap = {
+    { OSCTag::Int, QVariant::Int },
+    { OSCTag::Float, QVariant::Double },
+    { OSCTag::String, QVariant::String },
+    { OSCTag::Blob, QVariant::ByteArray },
+};
+
+
+OSCScriptingInterface::OSCScriptingInterface(ScriptManager* parent) :
+    _scriptManager(parent),
+    _receivePort("osc/receivePort", 9000),
+    _receiveHost("osc/receiveHost", "127.0.0.1"),
+    _sendPort("osc/sendPort", 9001),
+    _sendHost("osc/sendHost", "127.0.0.1"),
+    _socket(std::make_shared<QUdpSocket>(this))
+{
+    _socket->bind(QHostAddress(_receiveHost.get()), _receivePort.get());
+
+    connect(_socket.get(), &QUdpSocket::readyRead, this, &OSCScriptingInterface::receivePacket);
+
+    qCInfo(osc) << "Listening on" << _socket->localAddress();
+}
+
+OSCScriptingInterface::~OSCScriptingInterface() {
+    _socket->close();
+    qCInfo(osc) << "Closed listen socket";
+}
+
+void OSCScriptingInterface::receivePacket() {
+    // TODO
+    emit messageReceived("/test", "", QVariantList());
+}
+
+void OSCScriptingInterface::sendMessage(const QString& address, const QString &argumentTypes, const QVariantList& arguments) {
+    Q_ASSERT(_socket);
+
+    auto scriptEngine = _scriptManager->engine();
+
+    if (address.length() < 2 || address[0] != '/') {
+        scriptEngine->raiseException("address must be at least two characters and start with '/'");
+        return;
+    }
+
+    if (auto match = invalidCharacters.match(address); match.hasMatch()) {
+        scriptEngine->raiseException(QString("address contains invalid character '%1'").arg(match.captured()));
+        return;
+    }
+
+    if (argumentTypes.length() != arguments.length()) {
+        scriptEngine->raiseException(QString("argumentTypes.length (%1) does not match arguments.length (%2)").arg(argumentTypes.length()).arg(argumentTypes.length()));
+        return;
+    }
+
+    QByteArray bytes = address.toUtf8();
+
+    // pad to 4-byte boundary with at least one zero for the address string
+    bytes.append((bytes.length() + 1) % 4, 0);
+
+    // comma at the start of the argument list, even if empty
+    bytes.append(',');
+
+    QByteArray bodyBytes;
+
+    for (int i = 0; i < arguments.length(); i++) {
+        auto arg = arguments[i];
+
+        if (!typeNameMap.contains(argumentTypes[i])) {
+            scriptEngine->raiseException(QString("Unknown type tag '%1'").arg(argumentTypes[i]));
+            return;
+        }
+
+        auto expectedType = typeNameMap[argumentTypes[i]];
+        if (expectedType != arg.type()) {
+            scriptEngine->raiseException(QString("Specified argument type '%1' does not match value of type '%2'").arg(QVariant::typeToName(expectedType)).arg(arg.typeName()));
+            return;
+        }
+
+        switch (arg.type()) {
+            case QVariant::Int: {
+                bytes.append(OSCTag::Int);
+
+                auto* ptr = bodyBytes.data() + bodyBytes.length();
+                bodyBytes.append(4, 0);
+
+                qToBigEndian(static_cast<qint32>(arg.toInt()), ptr);
+            } break;
+
+            case QVariant::Double: {
+                bytes.append(OSCTag::Float);
+
+                auto* ptr = bodyBytes.data() + bodyBytes.length();
+                bodyBytes.append(4, 0);
+
+                // FIXME: use std::bit_cast instead of this hack once c++20 is in
+                auto tmp = arg.toFloat();
+                qToBigEndian(*reinterpret_cast<quint32*>(&tmp), ptr);
+            } break;
+
+            case QVariant::String: {
+                bytes.append(OSCTag::String);
+
+                auto stringArg = arg.toString();
+
+                if (stringArg.contains(QChar(0))) {
+                    scriptEngine->raiseException("String contains null (0x00) character");
+                    return;
+                }
+
+                bodyBytes.append(stringArg.toUtf8());
+                // pad to 4-byte boundary with at least one zero for the string
+                bodyBytes.append((bodyBytes.length() + 1) % 4, 0);
+            } break;
+
+            case QVariant::ByteArray: {
+                bytes.append(OSCTag::Blob);
+
+                auto bytesArg = arg.toByteArray();
+
+                // write length prefix
+                auto* ptr = bodyBytes.data() + bodyBytes.length();
+                bodyBytes.append(4, 0);
+                qToBigEndian(bytesArg.length(), ptr);
+
+                // write body
+                bodyBytes.append(bytesArg);
+
+                // pad to 4-byte boundary with at least one zero for the string
+                bodyBytes.append((bodyBytes.length() + 1) % 4, 0);
+            } break;
+
+            // unreachable
+            default:
+                Q_ASSERT(false);
+                break;
+        }
+    }
+
+    // pad to 4-byte boundary with at least one zero for the argument list string
+    bytes.append((bytes.length() + 1) % 4, 0);
+
+    // pack the header + body data together for the datagram
+    bytes.append(bodyBytes);
+
+    _socket->writeDatagram(bytes, QHostAddress(_sendHost.get()), _sendPort.get());
+}

--- a/interface/src/scripting/OSCScriptingInterface.cpp
+++ b/interface/src/scripting/OSCScriptingInterface.cpp
@@ -197,7 +197,7 @@ OSCScriptingInterface::~OSCScriptingInterface() {
 }
 
 void OSCScriptingInterface::rebindSocket() {
-    _socket->bind(QHostAddress(_sendHost.get()), _sendPort.get());
+    _socket->bind(QHostAddress(_receiveHost.get()), _receivePort.get());
     qCInfo(osc_cat) << "Listening on" << _socket->localAddress() << ":" << _socket->localPort();
 }
 

--- a/interface/src/scripting/OSCScriptingInterface.h
+++ b/interface/src/scripting/OSCScriptingInterface.h
@@ -1,0 +1,63 @@
+//
+//  OSCScriptingInterface.h
+//  interface/src/scripting
+//
+//  Created by Ada <ada@thingvellir.net> on 2025-12-13
+//  Copyright 2025 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_OSCScriptingInterface_h
+#define hifi_OSCScriptingInterface_h
+
+#include <QObject>
+#include <QUdpSocket>
+
+#include "SettingHandle.h"
+#include "ScriptManager.h"
+
+class OSCScriptingInterface : public QObject {
+    Q_OBJECT
+
+    void receivePacket();
+public:
+    OSCScriptingInterface(ScriptManager* parent);
+    ~OSCScriptingInterface();
+
+    /*@jsdoc
+     * Sends an encoded OSC message. The target host address and port are visible as the <code>osc/sendHost</code> and <code>osc/sendPort</code> settings.
+     * @function OSCSocket.sendMessage
+     * @param {string} address - The OSC address, starting with <code>/</code>
+     * @param {string} argumentTypes - A string of the data types contained in <code>arguments</code>.
+     * Supports the <code>i</code> (32-bit integer), <code>f</code> (32-bit float),
+     * <code>s</code> (null-terminated string), <code>b</code> (ArrayBuffer), <code>T</code> (boolean true), and <code>F</code> (boolean false) tag types. The string should not be prefixed with a comma. May be left empty for no arguments.
+     * @param {Array.<*>} [arguments] - OSC arguments.
+     */
+    Q_INVOKABLE void sendMessage(const QString& address, const QString& argumentTypes = QString(), const QVariantList& arguments = QVariantList());
+
+signals:
+    /*@jsdoc
+     * Triggered when an OSC datagram is received. The receiving host address and port are visible as the <code>osc/receiveHost</code> and <code>osc/receivePort</code> settings.
+     * @function OSCSocket.messageReceived
+     * @param {string} address - OSC address starting with <code>/</code>
+     * @param {string} argumentTypes - String of OSC data types contained by <code>arguments</code>
+     * @param {Array.<*>} arguments
+     * @returns {Signal}
+     */
+    void messageReceived(const QString& address, const QString& argumentTypes, const QVariantList& arguments);
+
+private:
+    ScriptManager* _scriptManager;
+
+    Setting::Handle<int> _receivePort;
+    Setting::Handle<QString> _receiveHost;
+
+    Setting::Handle<int> _sendPort;
+    Setting::Handle<QString> _sendHost;
+
+    std::shared_ptr<QUdpSocket> _socket;
+};
+
+#endif

--- a/interface/src/scripting/OSCScriptingInterface.h
+++ b/interface/src/scripting/OSCScriptingInterface.h
@@ -44,9 +44,11 @@ class ScriptContext;
 /*@jsdoc
  * The <code>OSCSocket</code> API lets you send and receive Open Sound Control packets.
  * Despite the name, OSC is commonly used with VR applications too. It is used by some
- * tracking and haptic devices that aren't exposed through OpenVR or OpenXR.
+ * tracking and haptic systems that aren't exposed through OpenVR or OpenXR.
  *
  * <p>Overte doesn't have any built-in OSC functionality; OSC is only useful with scripts.</p>
+ *
+ * {@link https://opensoundcontrol.stanford.edu/spec-1_0.html}
  *
  * @namespace OSCSocket
  *

--- a/interface/src/scripting/OSCScriptingInterface.h
+++ b/interface/src/scripting/OSCScriptingInterface.h
@@ -19,10 +19,12 @@
 
 #include "SettingHandle.h"
 
+class ScriptValue;
+class ScriptEngine;
+class ScriptContext;
+
 class OSCScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
-
-    void readPacket();
 public:
     OSCScriptingInterface(QObject* parent = nullptr);
     ~OSCScriptingInterface();
@@ -31,10 +33,10 @@ public:
      * Sends an encoded OSC message. The target host address and port are accessible as the <code>osc/sendHost</code> and <code>osc/sendPort</code> settings. Changes to these settings do not apply until a restart.
      * @function OSCSocket.sendMessage
      * @param {string} address - The OSC address, starting with <code>/</code>
-     * @param {Array.<*>} [arguments] - OSC arguments. May be plain values, or in an object like <code>{ type: "i", value: 123 }</code>.
+     * @param {...*} [arguments] - OSC arguments. May be plain values, or in an object like <code>{ type: "i", value: 123 }</code>.
      * Supported OSC types are <code>i</code> (32-bit int), <code>f</code> (32-bit float), <code>s</code> (UTF-8 string), <code>b</code> (<code>ArrayBuffer</code>), <code>F</code> (boolean false), <code>T</code> (boolean true), and <code>N</code> (<code>null</code>). OSC bundles are not supported.
      */
-    Q_INVOKABLE void sendPacket(const QString& address, const QVariantList& arguments = QVariantList());
+    static ScriptValue sendPacket(ScriptContext* context, ScriptEngine* engine);
 
 signals:
     /*@jsdoc
@@ -47,6 +49,8 @@ signals:
     void packetReceived(const QString& address, const QVariantList& arguments);
 
 private:
+    void readPacket();
+
     Setting::Handle<int> _receivePort;
     Setting::Handle<QString> _receiveHost;
 

--- a/interface/src/scripting/OSCScriptingInterface.h
+++ b/interface/src/scripting/OSCScriptingInterface.h
@@ -15,15 +15,17 @@
 #include <QObject>
 #include <QUdpSocket>
 
+#include <DependencyManager.h>
+
 #include "SettingHandle.h"
 #include "ScriptManager.h"
 
-class OSCScriptingInterface : public QObject {
+class OSCScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
 
     void receivePacket();
 public:
-    OSCScriptingInterface(ScriptManager* parent);
+    OSCScriptingInterface(QObject* parent = nullptr);
     ~OSCScriptingInterface();
 
     /*@jsdoc
@@ -49,8 +51,6 @@ signals:
     void messageReceived(const QString& address, const QString& argumentTypes, const QVariantList& arguments);
 
 private:
-    ScriptManager* _scriptManager;
-
     Setting::Handle<int> _receivePort;
     Setting::Handle<QString> _receiveHost;
 

--- a/interface/src/scripting/OSCScriptingInterface.h
+++ b/interface/src/scripting/OSCScriptingInterface.h
@@ -18,37 +18,33 @@
 #include <DependencyManager.h>
 
 #include "SettingHandle.h"
-#include "ScriptManager.h"
 
 class OSCScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
 
-    void receivePacket();
+    void readPacket();
 public:
     OSCScriptingInterface(QObject* parent = nullptr);
     ~OSCScriptingInterface();
 
     /*@jsdoc
-     * Sends an encoded OSC message. The target host address and port are visible as the <code>osc/sendHost</code> and <code>osc/sendPort</code> settings.
+     * Sends an encoded OSC message. The target host address and port are accessible as the <code>osc/sendHost</code> and <code>osc/sendPort</code> settings. Changes to these settings do not apply until a restart.
      * @function OSCSocket.sendMessage
      * @param {string} address - The OSC address, starting with <code>/</code>
-     * @param {string} argumentTypes - A string of the data types contained in <code>arguments</code>.
-     * Supports the <code>i</code> (32-bit integer), <code>f</code> (32-bit float),
-     * <code>s</code> (null-terminated string), <code>b</code> (ArrayBuffer), <code>T</code> (boolean true), and <code>F</code> (boolean false) tag types. The string should not be prefixed with a comma. May be left empty for no arguments.
-     * @param {Array.<*>} [arguments] - OSC arguments.
+     * @param {Array.<*>} [arguments] - OSC arguments. May be plain values, or in an object like <code>{ type: "i", value: 123 }</code>.
+     * Supported OSC types are <code>i</code> (32-bit int), <code>f</code> (32-bit float), <code>s</code> (UTF-8 string), <code>b</code> (<code>ArrayBuffer</code>), <code>F</code> (boolean false), <code>T</code> (boolean true), and <code>N</code> (<code>null</code>). OSC bundles are not supported.
      */
-    Q_INVOKABLE void sendMessage(const QString& address, const QString& argumentTypes = QString(), const QVariantList& arguments = QVariantList());
+    Q_INVOKABLE void sendPacket(const QString& address, const QVariantList& arguments = QVariantList());
 
 signals:
     /*@jsdoc
-     * Triggered when an OSC datagram is received. The receiving host address and port are visible as the <code>osc/receiveHost</code> and <code>osc/receivePort</code> settings.
+     * Triggered when an OSC packet is received. The receiving host address and port are accessible as the <code>osc/receiveHost</code> and <code>osc/receivePort</code> settings. Changes to these settings do not apply until a restart.
      * @function OSCSocket.messageReceived
      * @param {string} address - OSC address starting with <code>/</code>
-     * @param {string} argumentTypes - String of OSC data types contained by <code>arguments</code>
-     * @param {Array.<*>} arguments
+     * @param {Array.<Object.<string,*>>} arguments
      * @returns {Signal}
      */
-    void messageReceived(const QString& address, const QString& argumentTypes, const QVariantList& arguments);
+    void packetReceived(const QString& address, const QVariantList& arguments);
 
 private:
     Setting::Handle<int> _receivePort;

--- a/interface/src/scripting/OSCScriptingInterface.h
+++ b/interface/src/scripting/OSCScriptingInterface.h
@@ -64,7 +64,7 @@ class ScriptContext;
  * @property {string} sendHost - IP address to send OSC packets to.
  *      <code>127.0.0.1</code> by default, and shouldn't be changed unless
  *      you know what you're doing and need to use something different.
- * @property {number} receivePort - IP port to send OSC packets to.
+ * @property {number} sendPort - IP port to send OSC packets to.
  *      <code>9001</code> by default.
  */
 class OSCScriptingInterface : public QObject, public Dependency {


### PR DESCRIPTION
The `hifiOsc` plugin is disabled by default, and only ever worked with face blendshapes sent from an ancient iPhone app.

This PR adds a new `OSCSocket` API that can be used by scripts to handle any OSC message they want.

```js
OSCSocket.packetReceived.connect((address, args) => {
  // ...
});

OSCSocket.sendPacket("/test/path/1", 1, "hello", { type: "i", value: 2 });
// /test/path/1 ,fsi 1.0 "hello" 2
```

Tested in development with the [`oscd`](https://github.com/karnpapon/oscd) OSC debugging tool.

## TODOs
- [x] Sending OSC packets
- [x] Re-binding the listen socket when `receive{Host,Port}` changes (UDP is connectionless, so `send{Host,Port}` can change transparently without needing reconfiguration)