### PR TITLE
Expose more OpenXR inputs

### DIFF
--- a/interface/resources/controllers/openxr.json
+++ b/interface/resources/controllers/openxr.json
@@ -1,7 +1,7 @@
 {
     "name": "OpenXR to Standard",
     "channels": [
-        { "from": "OpenXR.Head", "to" : "Standard.Head", "when" : [ "Application.InHMD"] },
+        { "from": "OpenXR.Head", "to" : "Standard.Head", "when" : ["Application.InHMD"] },
 
         { "from": "OpenXR.LT", "to": "Standard.LT" },
         { "from": "OpenXR.RT", "to": "Standard.RT" },
@@ -20,10 +20,29 @@
         { "from": "OpenXR.LS", "to": "Standard.LS" },
         { "from": "OpenXR.RS", "to": "Standard.RS" },
 
-        { "from": "OpenXR.LeftPrimaryThumb", "to": "Standard.LeftPrimaryThumb" },
-        { "from": "OpenXR.RightPrimaryThumb", "to": "Standard.RightPrimaryThumb" },
-        { "from": "OpenXR.LeftSecondaryThumb", "to": "Standard.LeftSecondaryThumb" },
-        { "from": "OpenXR.RightSecondaryThumb", "to": "Standard.RightSecondaryThumb" },
+        { "when" : ["!OpenXR.LeftHasThumbstick", "OpenXR.LeftTrackpadClick"], "from": "OpenXR.LeftTrackpadX", "to" : "Standard.LX", "peek": true },
+        { "when" : ["!OpenXR.LeftHasThumbstick", "OpenXR.LeftTrackpadClick"], "from": "OpenXR.LeftTrackpadY", "to" : "Standard.LY", "peek": true },
+        { "when" : ["OpenXR.LeftHasThumbstick", "!OpenXR.LeftHasPrimary"], "from": "OpenXR.LeftTrackpadClick", "to" : "Standard.LeftPrimaryThumb", "peek": true },
+
+        { "when" : ["!OpenXR.RightHasThumbstick", "OpenXR.RightTrackpadClick"], "from": "OpenXR.RightTrackpadX", "to" : "Standard.RX", "peek": true },
+        { "when" : ["!OpenXR.RightHasThumbstick", "OpenXR.RightTrackpadClick"], "from": "OpenXR.RightTrackpadY", "to" : "Standard.RY", "peek": true },
+        { "when" : ["OpenXR.RightHasThumbstick", "!OpenXR.RightHasPrimary"], "from": "OpenXR.RightTrackpadClick", "to" : "Standard.RightPrimaryThumb", "peek": true },
+
+        { "from": "OpenXR.LeftPrimary", "to": "Standard.LeftPrimaryThumb" },
+        { "from": "OpenXR.LeftPrimaryTouch", "to": "Standard.LeftPrimaryThumbTouch" },
+        { "from": "OpenXR.LeftSecondary", "to": "Standard.LeftSecondaryThumb" },
+        { "from": "OpenXR.LeftSecondaryTouch", "to": "Standard.LeftSecondaryThumbTouch" },
+
+        { "from": "OpenXR.RightPrimary", "to": "Standard.RightPrimaryThumb" },
+        { "from": "OpenXR.RightPrimaryTouch", "to": "Standard.RightPrimaryThumbTouch" },
+        { "from": "OpenXR.RightSecondary", "to": "Standard.RightSecondaryThumb" },
+        { "from": "OpenXR.RightSecondaryTouch", "to": "Standard.RightSecondaryThumbTouch" },
+
+        { "from": "OpenXR.LeftIndexPoint", "to" : "Standard.LeftIndexPoint" },
+        { "from": "OpenXR.LeftThumbUp", "to" : "Standard.LeftThumbUp" },
+
+        { "from": "OpenXR.RightIndexPoint", "to" : "Standard.RightIndexPoint" },
+        { "from": "OpenXR.RightThumbUp", "to" : "Standard.RightThumbUp" },
 
         { "from": "OpenXR.LeftHand", "to": "Standard.LeftHand" },
         { "from": "OpenXR.LeftHandThumb1", "to": "Standard.LeftHandThumb1"},

--- a/interface/resources/controllers/openxr.json
+++ b/interface/resources/controllers/openxr.json
@@ -5,8 +5,8 @@
 
         { "from": "OpenXR.LT", "to": "Standard.LT" },
         { "from": "OpenXR.RT", "to": "Standard.RT" },
-        { "from": "OpenXR.LTClick", "to": "Standard.LTClick" },
-        { "from": "OpenXR.RTClick", "to": "Standard.RTClick" },
+        { "from": "OpenXR.LTVirtualClick", "to": "Standard.LTClick" },
+        { "from": "OpenXR.RTVirtualClick", "to": "Standard.RTClick" },
 
         { "from": "OpenXR.LeftGrip", "to": "Standard.LeftGrip" },
         { "from": "OpenXR.RightGrip", "to": "Standard.RightGrip" },

--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -572,10 +572,7 @@ bool OpenXrContext::pollEvents() {
                     if (!xrCheck(_instance, res, "Failed to get interaction profile"))
                         continue;
 
-                    _stickEmulation = false;
-                    if (_viveControllerPath != XR_NULL_PATH && state.interactionProfile == _viveControllerPath) {
-                        _stickEmulation = true;
-                    }
+                    _vivePoseHack[i] = _viveControllerPath != XR_NULL_PATH && state.interactionProfile == _viveControllerPath;
 
                     uint32_t bufferCountOutput;
                     char profilePath[XR_MAX_PATH_LENGTH];

--- a/plugins/openxr/src/OpenXrContext.h
+++ b/plugins/openxr/src/OpenXrContext.h
@@ -74,8 +74,7 @@ public:
     QString _systemName;
     bool _isSessionRunning = false;
 
-    // hack for vive controllers
-    bool _stickEmulation = false;
+    std::array<bool, HAND_COUNT> _vivePoseHack = { false, false };
 
     // only supported by a few runtimes, but lets us
     // emulate OpenVR's headset proximity sensor system

--- a/plugins/openxr/src/OpenXrInputPlugin.cpp
+++ b/plugins/openxr/src/OpenXrInputPlugin.cpp
@@ -27,16 +27,21 @@ enum ExtraButtonChannel {
     LEFT_HAS_TRACKPAD,
     LEFT_HAS_THUMBSTICK,
     LEFT_HAS_CAPACITIVE_TOUCH,
+    LEFT_HAS_TRIGGER_CLICK,
 
     RIGHT_HAS_PRIMARY,
     RIGHT_HAS_TRACKPAD,
     RIGHT_HAS_THUMBSTICK,
     RIGHT_HAS_CAPACITIVE_TOUCH,
+    RIGHT_HAS_TRIGGER_CLICK,
 
     LEFT_TRACKPAD_TOUCH,
     RIGHT_TRACKPAD_TOUCH,
+
     LT_TOUCH,
+    LT_VIRTUAL_CLICK,
     RT_TOUCH,
+    RT_VIRTUAL_CLICK,
 };
 
 enum ExtraAxisChannel {
@@ -572,6 +577,7 @@ controller::Input::NamedVector OpenXrInputPlugin::InputDevice::getAvailableInput
         makePair(LY, "LY"),
         makePair(LT, "LT"),
         makePair(LT_CLICK, "LTClick"),
+        makePair((StandardButtonChannel)LT_VIRTUAL_CLICK, "LTVirtualClick"),
         makePair((StandardButtonChannel)LT_TOUCH, "LTTouch"),
         makePair(LEFT_GRIP, "LeftGrip"),
         makePair(LEFT_PRIMARY_THUMB, "LeftPrimary"),
@@ -592,6 +598,7 @@ controller::Input::NamedVector OpenXrInputPlugin::InputDevice::getAvailableInput
         makePair(RY, "RY"),
         makePair(RT, "RT"),
         makePair(RT_CLICK, "RTClick"),
+        makePair((StandardButtonChannel)RT_VIRTUAL_CLICK, "RTVirtualClick"),
         makePair((StandardButtonChannel)RT_TOUCH, "RTTouch"),
         makePair(RIGHT_GRIP, "RightGrip"),
         makePair(RIGHT_PRIMARY_THUMB, "RightPrimary"),
@@ -687,6 +694,7 @@ bool OpenXrInputPlugin::InputDevice::initActions() {
         {"left_secondary_touch",   {"Left Secondary Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
         {"left_squeeze_value",     {"Left Squeeze", XR_ACTION_TYPE_FLOAT_INPUT}},
         {"left_trigger_value",     {"Left Trigger", XR_ACTION_TYPE_FLOAT_INPUT}},
+        {"left_trigger_click",     {"Left Trigger Click", XR_ACTION_TYPE_BOOLEAN_INPUT}},
         {"left_trigger_touch",     {"Left Trigger Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
         {"left_thumbstick",        {"Left Thumbstick", XR_ACTION_TYPE_VECTOR2F_INPUT}},
         {"left_thumbstick_click",  {"Left Thumbstick Click", XR_ACTION_TYPE_BOOLEAN_INPUT}},
@@ -704,6 +712,7 @@ bool OpenXrInputPlugin::InputDevice::initActions() {
         {"right_secondary_touch",  {"Right Secondary Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
         {"right_squeeze_value",    {"Right Squeeze", XR_ACTION_TYPE_FLOAT_INPUT}},
         {"right_trigger_value",    {"Right Trigger", XR_ACTION_TYPE_FLOAT_INPUT}},
+        {"right_trigger_click",    {"Right Trigger Click", XR_ACTION_TYPE_BOOLEAN_INPUT}},
         {"right_trigger_touch",    {"Right Trigger Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
         {"right_thumbstick",       {"Right Thumbstick", XR_ACTION_TYPE_VECTOR2F_INPUT}},
         {"right_thumbstick_click", {"Right Thumbstick Click", XR_ACTION_TYPE_BOOLEAN_INPUT}},
@@ -743,6 +752,7 @@ bool OpenXrInputPlugin::InputDevice::initActions() {
             {"left_secondary_click",   hand_left  + "/menu/click"},
             {"left_squeeze_value",     hand_left  + "/squeeze/click"},
             {"left_trigger_value",     hand_left  + "/trigger/value"},
+            {"left_trigger_click",     hand_left  + "/trigger/click"},
             {"left_trackpad",          hand_left  + "/trackpad"},
             {"left_trackpad_click",    hand_left  + "/trackpad/click"},
             {"left_trackpad_touch",    hand_left  + "/trackpad/touch"},
@@ -753,6 +763,7 @@ bool OpenXrInputPlugin::InputDevice::initActions() {
             {"right_secondary_click",  hand_right + "/menu/click"},
             {"right_squeeze_value",    hand_right + "/squeeze/click"},
             {"right_trigger_value",    hand_right + "/trigger/value"},
+            {"right_trigger_click",    hand_right + "/trigger/click"},
             {"right_trackpad",         hand_right + "/trackpad"},
             {"right_trackpad_click",   hand_right + "/trackpad/click"},
             {"right_trackpad_touch",   hand_right + "/trackpad/touch"},
@@ -846,6 +857,7 @@ bool OpenXrInputPlugin::InputDevice::initActions() {
             {"left_secondary_touch",   hand_left  + "/b/touch"},
             {"left_squeeze_value",     hand_left  + "/squeeze/force"},
             {"left_trigger_value",     hand_left  + "/trigger/value"},
+            {"left_trigger_click",     hand_left  + "/trigger/click"},
             {"left_trigger_touch",     hand_left  + "/trigger/touch"},
             {"left_thumbstick",        hand_left  + "/thumbstick"},
             {"left_thumbstick_click",  hand_left  + "/thumbstick/click"},
@@ -862,6 +874,7 @@ bool OpenXrInputPlugin::InputDevice::initActions() {
             {"right_secondary_click",  hand_right + "/b/click"},
             {"right_secondary_touch",  hand_right + "/b/touch"},
             {"right_squeeze_value",    hand_right + "/squeeze/force"},
+            {"right_trigger_click",    hand_right + "/trigger/click"},
             {"right_trigger_value",    hand_right + "/trigger/value"},
             {"right_trigger_touch",    hand_right + "/trigger/touch"},
             {"right_thumbstick",       hand_right + "/thumbstick"},
@@ -1117,11 +1130,11 @@ void OpenXrInputPlugin::InputDevice::update(float deltaTime, const controller::I
 
         // TODO: Customisable click threshold?
         if (left_trigger.isActive && left_trigger.currentState >= 0.95f) {
-            _buttonPressedMap.insert(LT_CLICK);
+            _buttonPressedMap.insert(LT_VIRTUAL_CLICK);
         }
 
         if (right_trigger.isActive && right_trigger.currentState >= 0.95f) {
-            _buttonPressedMap.insert(RT_CLICK);
+            _buttonPressedMap.insert(RT_VIRTUAL_CLICK);
         }
     }
 
@@ -1141,6 +1154,7 @@ void OpenXrInputPlugin::InputDevice::update(float deltaTime, const controller::I
     }
 
     std::vector<std::pair<std::string, StandardButtonChannel>> buttonsToUpdate = {
+        {"left_trigger_click", LT_CLICK},
         {"left_primary_click", LEFT_PRIMARY_THUMB},
         {"left_primary_touch", LEFT_PRIMARY_THUMB_TOUCH},
         {"left_secondary_click", LEFT_SECONDARY_THUMB},
@@ -1150,6 +1164,7 @@ void OpenXrInputPlugin::InputDevice::update(float deltaTime, const controller::I
         {"left_trigger_touch", (StandardButtonChannel)LT_TOUCH},
         {"left_trackpad_touch", (StandardButtonChannel)LEFT_TRACKPAD_TOUCH},
 
+        {"right_trigger_click", RT_CLICK},
         {"right_primary_click", RIGHT_PRIMARY_THUMB},
         {"right_primary_touch", RIGHT_PRIMARY_THUMB_TOUCH},
         {"right_secondary_click", RIGHT_SECONDARY_THUMB},
@@ -1192,11 +1207,13 @@ void OpenXrInputPlugin::InputDevice::setupControllerFlags() {
     auto left_primary_touch = _actions.at("left_primary_touch")->getBool();
     auto left_thumbstick = _actions.at("left_thumbstick")->getVector2f();
     auto left_trackpad = _actions.at("left_trackpad")->getVector2f();
+    auto left_trigger_click = _actions.at("left_trigger_click")->getVector2f();
 
     auto right_primary = _actions.at("right_primary_click")->getBool();
     auto right_primary_touch = _actions.at("right_primary_touch")->getBool();
     auto right_thumbstick = _actions.at("right_thumbstick")->getVector2f();
     auto right_trackpad = _actions.at("right_trackpad")->getVector2f();
+    auto right_trigger_click = _actions.at("right_trigger_click")->getVector2f();
 
     if (left_primary.isActive) { _buttonPressedMap.insert(LEFT_HAS_PRIMARY); }
     if (left_trackpad.isActive) { _buttonPressedMap.insert(LEFT_HAS_TRACKPAD); }
@@ -1206,11 +1223,13 @@ void OpenXrInputPlugin::InputDevice::setupControllerFlags() {
     // /input/a/touch also has /input/trigger/touch,
     // so we can safely use that for hand pose simulation
     if (left_primary_touch.isActive) { _buttonPressedMap.insert(LEFT_HAS_CAPACITIVE_TOUCH); }
+    if (left_trigger_click.isActive) { _buttonPressedMap.insert(LEFT_HAS_TRIGGER_CLICK); }
 
     if (right_primary.isActive) { _buttonPressedMap.insert(RIGHT_HAS_PRIMARY); }
     if (right_trackpad.isActive) { _buttonPressedMap.insert(RIGHT_HAS_TRACKPAD); }
     if (right_thumbstick.isActive) { _buttonPressedMap.insert(RIGHT_HAS_THUMBSTICK); }
     if (right_primary_touch.isActive) { _buttonPressedMap.insert(RIGHT_HAS_CAPACITIVE_TOUCH); }
+    if (right_trigger_click.isActive) { _buttonPressedMap.insert(RIGHT_HAS_TRIGGER_CLICK); }
 }
 
 void OpenXrInputPlugin::InputDevice::getHandTrackingInputs(int i, const mat4& sensorToAvatar) {

--- a/plugins/openxr/src/OpenXrInputPlugin.cpp
+++ b/plugins/openxr/src/OpenXrInputPlugin.cpp
@@ -688,46 +688,46 @@ bool OpenXrInputPlugin::InputDevice::initActions() {
         return false;
 
     std::map<std::string, std::pair<std::string, XrActionType>> actionTypes = {
-        {"left_primary_click",     {"Left Primary", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_primary_touch",     {"Left Primary Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_secondary_click",   {"Left Secondary", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_secondary_touch",   {"Left Secondary Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_squeeze_value",     {"Left Squeeze", XR_ACTION_TYPE_FLOAT_INPUT}},
-        {"left_trigger_value",     {"Left Trigger", XR_ACTION_TYPE_FLOAT_INPUT}},
-        {"left_trigger_click",     {"Left Trigger Click", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_trigger_touch",     {"Left Trigger Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_thumbstick",        {"Left Thumbstick", XR_ACTION_TYPE_VECTOR2F_INPUT}},
-        {"left_thumbstick_click",  {"Left Thumbstick Click", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_thumbstick_touch",  {"Left Thumbstick Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_trackpad",          {"Left Trackpad", XR_ACTION_TYPE_VECTOR2F_INPUT}},
-        {"left_trackpad_touch",    {"Left Trackpad Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"left_trackpad_click",    {"Left Trackpad Click", XR_ACTION_TYPE_FLOAT_INPUT}},
-        {"left_grip_pose",         {"Left Grip Pose", XR_ACTION_TYPE_POSE_INPUT}},
-        {"left_palm_pose",         {"Left Palm Pose", XR_ACTION_TYPE_POSE_INPUT}},
-        {"left_haptic",            {"Left Hand Haptic", XR_ACTION_TYPE_VIBRATION_OUTPUT}},
+        {"left_primary_click",     {"Left Primary",           XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_primary_touch",     {"Left Primary Touch",     XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_secondary_click",   {"Left Secondary",         XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_secondary_touch",   {"Left Secondary Touch",   XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_squeeze_value",     {"Left Squeeze",           XR_ACTION_TYPE_FLOAT_INPUT}},
+        {"left_trigger_value",     {"Left Trigger",           XR_ACTION_TYPE_FLOAT_INPUT}},
+        {"left_trigger_click",     {"Left Trigger Click",     XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_trigger_touch",     {"Left Trigger Touch",     XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_thumbstick",        {"Left Thumbstick",        XR_ACTION_TYPE_VECTOR2F_INPUT}},
+        {"left_thumbstick_click",  {"Left Thumbstick Click",  XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_thumbstick_touch",  {"Left Thumbstick Touch",  XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_trackpad",          {"Left Trackpad",          XR_ACTION_TYPE_VECTOR2F_INPUT}},
+        {"left_trackpad_touch",    {"Left Trackpad Touch",    XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"left_trackpad_click",    {"Left Trackpad Click",    XR_ACTION_TYPE_FLOAT_INPUT}},
+        {"left_grip_pose",         {"Left Grip Pose",         XR_ACTION_TYPE_POSE_INPUT}},
+        {"left_palm_pose",         {"Left Palm Pose",         XR_ACTION_TYPE_POSE_INPUT}},
+        {"left_haptic",            {"Left Hand Haptic",       XR_ACTION_TYPE_VIBRATION_OUTPUT}},
 
-        {"right_primary_click",    {"Right Primary", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"right_primary_touch",    {"Right Primary Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"right_secondary_click",  {"Right Secondary", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"right_secondary_touch",  {"Right Secondary Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"right_squeeze_value",    {"Right Squeeze", XR_ACTION_TYPE_FLOAT_INPUT}},
-        {"right_trigger_value",    {"Right Trigger", XR_ACTION_TYPE_FLOAT_INPUT}},
-        {"right_trigger_click",    {"Right Trigger Click", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"right_trigger_touch",    {"Right Trigger Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"right_thumbstick",       {"Right Thumbstick", XR_ACTION_TYPE_VECTOR2F_INPUT}},
+        {"right_primary_click",    {"Right Primary",          XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"right_primary_touch",    {"Right Primary Touch",    XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"right_secondary_click",  {"Right Secondary",        XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"right_secondary_touch",  {"Right Secondary Touch",  XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"right_squeeze_value",    {"Right Squeeze",          XR_ACTION_TYPE_FLOAT_INPUT}},
+        {"right_trigger_value",    {"Right Trigger",          XR_ACTION_TYPE_FLOAT_INPUT}},
+        {"right_trigger_click",    {"Right Trigger Click",    XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"right_trigger_touch",    {"Right Trigger Touch",    XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"right_thumbstick",       {"Right Thumbstick",       XR_ACTION_TYPE_VECTOR2F_INPUT}},
         {"right_thumbstick_click", {"Right Thumbstick Click", XR_ACTION_TYPE_BOOLEAN_INPUT}},
         {"right_thumbstick_touch", {"Right Thumbstick Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"right_trackpad",         {"Right Trackpad", XR_ACTION_TYPE_VECTOR2F_INPUT}},
-        {"right_trackpad_touch",   {"Right Trackpad Touch", XR_ACTION_TYPE_BOOLEAN_INPUT}},
-        {"right_trackpad_click",   {"Right Trackpad Click", XR_ACTION_TYPE_FLOAT_INPUT}},
-        {"right_grip_pose",        {"Right Grip Pose", XR_ACTION_TYPE_POSE_INPUT}},
-        {"right_palm_pose",        {"Right Palm Pose", XR_ACTION_TYPE_POSE_INPUT}},
-        {"right_haptic",           {"Right Hand Haptic", XR_ACTION_TYPE_VIBRATION_OUTPUT}},
+        {"right_trackpad",         {"Right Trackpad",         XR_ACTION_TYPE_VECTOR2F_INPUT}},
+        {"right_trackpad_touch",   {"Right Trackpad Touch",   XR_ACTION_TYPE_BOOLEAN_INPUT}},
+        {"right_trackpad_click",   {"Right Trackpad Click",   XR_ACTION_TYPE_FLOAT_INPUT}},
+        {"right_grip_pose",        {"Right Grip Pose",        XR_ACTION_TYPE_POSE_INPUT}},
+        {"right_palm_pose",        {"Right Palm Pose",        XR_ACTION_TYPE_POSE_INPUT}},
+        {"right_haptic",           {"Right Hand Haptic",      XR_ACTION_TYPE_VIBRATION_OUTPUT}},
 
-        {"hips_pose",              {"Hips Pose", XR_ACTION_TYPE_POSE_INPUT}},
-        {"chest_pose",             {"Chest Pose", XR_ACTION_TYPE_POSE_INPUT}},
-        {"left_foot_pose",         {"Left Foot Pose", XR_ACTION_TYPE_POSE_INPUT}},
-        {"right_foot_pose",        {"Right Foot Pose", XR_ACTION_TYPE_POSE_INPUT}},
+        {"hips_pose",              {"Hips Pose",              XR_ACTION_TYPE_POSE_INPUT}},
+        {"chest_pose",             {"Chest Pose",             XR_ACTION_TYPE_POSE_INPUT}},
+        {"left_foot_pose",         {"Left Foot Pose",         XR_ACTION_TYPE_POSE_INPUT}},
+        {"right_foot_pose",        {"Right Foot Pose",        XR_ACTION_TYPE_POSE_INPUT}},
     };
 
     std::string hand_left = "/user/hand/left/input";
@@ -1207,13 +1207,13 @@ void OpenXrInputPlugin::InputDevice::setupControllerFlags() {
     auto left_primary_touch = _actions.at("left_primary_touch")->getBool();
     auto left_thumbstick = _actions.at("left_thumbstick")->getVector2f();
     auto left_trackpad = _actions.at("left_trackpad")->getVector2f();
-    auto left_trigger_click = _actions.at("left_trigger_click")->getVector2f();
+    auto left_trigger_click = _actions.at("left_trigger_click")->getBool();
 
     auto right_primary = _actions.at("right_primary_click")->getBool();
     auto right_primary_touch = _actions.at("right_primary_touch")->getBool();
     auto right_thumbstick = _actions.at("right_thumbstick")->getVector2f();
     auto right_trackpad = _actions.at("right_trackpad")->getVector2f();
-    auto right_trigger_click = _actions.at("right_trigger_click")->getVector2f();
+    auto right_trigger_click = _actions.at("right_trigger_click")->getBool();
 
     if (left_primary.isActive) { _buttonPressedMap.insert(LEFT_HAS_PRIMARY); }
     if (left_trackpad.isActive) { _buttonPressedMap.insert(LEFT_HAS_TRACKPAD); }
@@ -1236,7 +1236,7 @@ void OpenXrInputPlugin::InputDevice::getHandTrackingInputs(int i, const mat4& se
     using namespace controller;
 
     // simple index/thumb/rest tracking from button inputs
-    if (_buttonPressedMap.contains(LEFT_HAS_CAPACITIVE_TOUCH)) {
+    if (_buttonPressedMap.contains(LEFT_HAS_CAPACITIVE_TOUCH) || _buttonPressedMap.contains(LEFT_HAS_TRACKPAD)) {
         auto left_trigger_touch = _actions.at("left_trigger_touch")->getBool().currentState;
 
         if (!left_trigger_touch) { _buttonPressedMap.insert(LEFT_INDEX_POINT); }
@@ -1256,7 +1256,7 @@ void OpenXrInputPlugin::InputDevice::getHandTrackingInputs(int i, const mat4& se
         }
     }
 
-    if (_buttonPressedMap.contains(RIGHT_HAS_CAPACITIVE_TOUCH)) {
+    if (_buttonPressedMap.contains(RIGHT_HAS_CAPACITIVE_TOUCH) || _buttonPressedMap.contains(RIGHT_HAS_TRACKPAD)) {
         auto right_trigger_touch = _actions.at("right_trigger_touch")->getBool().currentState;
 
         if (!right_trigger_touch) { _buttonPressedMap.insert(RIGHT_INDEX_POINT); }
@@ -1278,7 +1278,7 @@ void OpenXrInputPlugin::InputDevice::getHandTrackingInputs(int i, const mat4& se
 
     // if real hand tracking isn't available,
     // don't do any more than the capacitive touch tracking
-    if (_context->_handTrackingSupported) {
+    if (!_context->_handTrackingSupported) {
         return;
     }
 

--- a/plugins/openxr/src/OpenXrInputPlugin.cpp
+++ b/plugins/openxr/src/OpenXrInputPlugin.cpp
@@ -1228,6 +1228,7 @@ void OpenXrInputPlugin::InputDevice::setupControllerFlags() {
     if (right_primary.isActive) { _buttonPressedMap.insert(RIGHT_HAS_PRIMARY); }
     if (right_trackpad.isActive) { _buttonPressedMap.insert(RIGHT_HAS_TRACKPAD); }
     if (right_thumbstick.isActive) { _buttonPressedMap.insert(RIGHT_HAS_THUMBSTICK); }
+
     if (right_primary_touch.isActive) { _buttonPressedMap.insert(RIGHT_HAS_CAPACITIVE_TOUCH); }
     if (right_trigger_click.isActive) { _buttonPressedMap.insert(RIGHT_HAS_TRIGGER_CLICK); }
 }
@@ -1238,8 +1239,11 @@ void OpenXrInputPlugin::InputDevice::getHandTrackingInputs(int i, const mat4& se
     // simple index/thumb/rest tracking from button inputs
     if (_buttonPressedMap.contains(LEFT_HAS_CAPACITIVE_TOUCH) || _buttonPressedMap.contains(LEFT_HAS_TRACKPAD)) {
         auto left_trigger_touch = _actions.at("left_trigger_touch")->getBool().currentState;
+        auto left_trigger = _actions.at("left_trigger_value")->getFloat().currentState;
 
-        if (!left_trigger_touch) { _buttonPressedMap.insert(LEFT_INDEX_POINT); }
+        if (!(left_trigger_touch || left_trigger > 0.2f)) {
+            _buttonPressedMap.insert(LEFT_INDEX_POINT);
+        }
 
         auto left_primary_touch = _actions.at("left_primary_touch")->getBool().currentState;
         auto left_secondary_touch = _actions.at("left_secondary_touch")->getBool().currentState;
@@ -1258,8 +1262,11 @@ void OpenXrInputPlugin::InputDevice::getHandTrackingInputs(int i, const mat4& se
 
     if (_buttonPressedMap.contains(RIGHT_HAS_CAPACITIVE_TOUCH) || _buttonPressedMap.contains(RIGHT_HAS_TRACKPAD)) {
         auto right_trigger_touch = _actions.at("right_trigger_touch")->getBool().currentState;
+        auto right_trigger = _actions.at("right_trigger_value")->getFloat().currentState;
 
-        if (!right_trigger_touch) { _buttonPressedMap.insert(RIGHT_INDEX_POINT); }
+        if (!(right_trigger_touch || right_trigger > 0.2f)) {
+            _buttonPressedMap.insert(RIGHT_INDEX_POINT);
+        }
 
         auto right_primary_touch = _actions.at("right_primary_touch")->getBool().currentState;
         auto right_secondary_touch = _actions.at("right_secondary_touch")->getBool().currentState;

--- a/plugins/openxr/src/OpenXrInputPlugin.h
+++ b/plugins/openxr/src/OpenXrInputPlugin.h
@@ -95,7 +95,7 @@ private:
         void focusOutEvent() override;
         bool triggerHapticPulse(float strength, float duration, uint16_t index) override;
 
-        void emulateStickFromTrackpad();
+        void setupControllerFlags();
         void getHandTrackingInputs(int index, const mat4& sensorToAvatar);
 
         void updateBodyFromViveTrackers(const mat4& sensorToAvatar);

--- a/scripts/developer/debugging/openxrControllerInputs.js
+++ b/scripts/developer/debugging/openxrControllerInputs.js
@@ -1,0 +1,104 @@
+// extra-inputs.js
+// Created by Ada <ada@thingvellir.net> on 2025-12-16
+// SPDX-License-Identifier: Apache-2.0
+"use strict";
+
+if (!Controller.Hardware.OpenXR) { throw new Error("Not in OpenXR mode!"); }
+
+const CAMERA_RELATIVE_CONTROLLER_RIGHTHAND_INDEX = -5;
+const CAMERA_RELATIVE_CONTROLLER_LEFTHAND_INDEX = -6;
+
+const XR = Controller.Hardware.OpenXR;
+
+// TODO: Expose *all* inputs later?
+const inputHandles = {
+	left: {
+		triggerTouch: XR.LTTouch,
+		triggerClick: XR.LTClick,
+		thumbstickTouch: XR.LSTouch,
+		primaryTouch: XR.LeftPrimaryTouch,
+		secondaryTouch: XR.LeftSecondaryTouch,
+
+		trackpadX: XR.LeftTrackpadX,
+		trackpadY: XR.LeftTrackpadY,
+		trackpadTouch: XR.LeftTrackpadTouch,
+		trackpadClick: XR.LeftTrackpadClick,
+	},
+	right: {
+		triggerTouch: XR.RTTouch,
+		triggerClick: XR.RTClick,
+		thumbstickTouch: XR.RSTouch,
+		primaryTouch: XR.RightPrimaryTouch,
+		secondaryTouch: XR.RightSecondaryTouch,
+
+		trackpadX: XR.RightTrackpadX,
+		trackpadY: XR.RightTrackpadY,
+		trackpadTouch: XR.RightTrackpadTouch,
+		trackpadClick: XR.RightTrackpadClick,
+	},
+};
+
+function fetchInputs() {
+	let tmp = {
+		left: {},
+		right: {},
+	};
+
+	for (const [key, path] of Object.entries(inputHandles.left)) {
+		tmp.left[key] = Controller.getValue(path);
+	}
+
+	for (const [key, path] of Object.entries(inputHandles.right)) {
+		tmp.right[key] = Controller.getValue(path);
+	}
+
+	return tmp;
+}
+
+const defaultProps = {
+	parentID: MyAvatar.sessionUUID,
+	type: "Text",
+	lineHeight: 0.015,
+	dimensions: [0.2, 0.2, 0.1],
+	localPosition: [0.0, 0.3, 0.0],
+	backgroundAlpha: 0.8,
+	unlit: true,
+	ignorePickIntersection: true,
+	renderLayer: "front",
+};
+
+const leftEntity = Entities.addEntity({
+	parentJointIndex: CAMERA_RELATIVE_CONTROLLER_LEFTHAND_INDEX,
+	localRotation: Quat.fromPitchYawRollDegrees(45, -90, 0),
+	text: "Left display",
+	...defaultProps
+}, "local");
+
+const rightEntity= Entities.addEntity({
+	parentJointIndex: CAMERA_RELATIVE_CONTROLLER_RIGHTHAND_INDEX,
+	localRotation: Quat.fromPitchYawRollDegrees(45, 90, 0),
+	text: "Right display",
+	...defaultProps
+}, "local");
+
+Script.update.connect(() => {
+	const inputs = fetchInputs();
+
+	let leftText = [], rightText = [];
+
+	for (const [key, value] of Object.entries(inputs.left)) {
+		leftText.push(`${key}: ${value.toFixed(2)}`);
+	}
+
+	for (const [key, value] of Object.entries(inputs.right)) {
+		rightText.push(`${key}: ${value.toFixed(2)}`);
+	}
+
+	Entities.editEntity(leftEntity, { text: leftText.join("\n") });
+	Entities.editEntity(rightEntity, { text: rightText.join("\n") });
+});
+
+Script.scriptEnding.connect(() => {
+	Entities.deleteEntity(leftEntity);
+	Entities.deleteEntity(rightEntity);
+});


### PR DESCRIPTION
Exposes capacitive button touches and trackpad inputs on controllers that have them, as well as virtual "buttons" marking what hardware a controller has so scripts can adapt to them.

Also moves the simulated primary button from the thumbstick click to a trackpad click on WMR controllers. Vive controllers don't have any way of activating the primary button or the thumbstick click, since it only has a single face button and no thumbstick to click. Later we might be able to support long or double presses for those.

~~Also includes a workaround for [monado!2659](https://gitlab.freedesktop.org/monado/monado/-/merge_requests/2659) which enforces non-null states on `glxFBConfig` and `visualid` (which is the behavior the spec expects), even though they're not used by Monado or SteamVR.~~ Split out into #1950

[Testing script that puts displays of the new controller state on your controllers](https://github.com/ada-tv/overte-scripts/raw/refs/heads/main/tests/extra-inputs.js)