### PR TITLE
Workaround for monado!2659

### DIFF
--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -389,9 +389,20 @@ bool OpenXrContext::initSession() {
     // blah blah...
     // info.next = &wlBinding;
     // } else
+
+    auto* xDisplay = XOpenDisplay(nullptr);
+    int fbConfigCount = 0;
+    auto* fbConfigs = glXGetFBConfigs(xDisplay, 0, &fbConfigCount);
+
     XrGraphicsBindingOpenGLXlibKHR xlibBinding = {
         .type = XR_TYPE_GRAPHICS_BINDING_OPENGL_XLIB_KHR,
-        .xDisplay = XOpenDisplay(nullptr),
+        .xDisplay = xDisplay,
+
+        // not actually used anywhere but monado now
+        // requires these to be non-null (in-line with the spec)
+        .visualid = 1,
+        .glxFBConfig = fbConfigs[0],
+
         .glxDrawable = glXGetCurrentDrawable(),
         .glxContext = glXGetCurrentContext(),
     };


### PR DESCRIPTION
Workaround for https://gitlab.freedesktop.org/monado/monado/-/merge_requests/2659 which enforces non-null states on glxFBConfig and visualid (which is the behavior the spec expects), even though they're not used by Monado or SteamVR.

Cherry-picked from https://github.com/overte-org/overte/pull/1948