### PR TITLE
Add missing `jq` to GitHub Actions Image

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -35,13 +35,13 @@ jobs:
           #  build_type: full
           #  qt_source: source
           - os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2025-10-24-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
+            image: docker.io/overte/overte-full-build:2026-01-01-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
             runner: ubuntu-latest
             arch: amd64
             build_type: full
             qt_source: system
           - os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2025-10-24-ubuntu-22.04-aarch64
+            image: docker.io/overte/overte-full-build:2026-01-01-ubuntu-22.04-aarch64
             runner: ubuntu-24.04-arm
             arch: aarch64
             build_type: full

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -40,7 +40,7 @@ jobs:
             #  build_type: full
             #  qt_source: aqt
             - os: Ubuntu 22.04
-              image: docker.io/overte/overte-full-build:2025-10-24-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
+              image: docker.io/overte/overte-full-build:2026-01-01-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
               runner: ubuntu-latest
               arch: amd64
               build_type: full
@@ -51,7 +51,7 @@ jobs:
             #  apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 python3-github python3-distro
             # Do not change the names of self-hosted runners without knowing what you are doing, as they correspond to labels that have to be set on the runner.
             - os: Ubuntu 22.04
-              image: docker.io/overte/overte-full-build:2025-10-24-ubuntu-22.04-aarch64
+              image: docker.io/overte/overte-full-build:2026-01-01-ubuntu-22.04-aarch64
               runner: ubuntu-24.04-arm
               arch: aarch64
               build_type: full

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -34,13 +34,13 @@ jobs:
             build_type: full
             qt_source: source  # Which Qt Conan package to use. `system`, `source`, or `aqt`.
           - os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2025-10-24-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
+            image: docker.io/overte/overte-full-build:2026-01-01-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
             runner: ubuntu-latest
             arch: amd64
             build_type: full
             qt_source: system
           - os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2025-10-24-ubuntu-22.04-aarch64
+            image: docker.io/overte/overte-full-build:2026-01-01-ubuntu-22.04-aarch64
             runner: ubuntu-24.04-arm
             arch: aarch64
             build_type: full

--- a/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.4
 
-# Copyright 2022-2025 Overte e.V.
+# Copyright 2022-2026 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte
-# Example build: docker build --no-cache --progress=plain -t overte/overte-full-build:2025-10-24-ubuntu-22.04-amd64 -f Dockerfile_build_ubuntu-22.04 .
+# Example build: docker build --no-cache --progress=plain -t overte/overte-full-build:2026-01-01-ubuntu-22.04-amd64 -f Dockerfile_build_ubuntu-22.04 .
 FROM ubuntu:22.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for full Overte builds"
@@ -72,6 +72,7 @@ dh-make
 python3-boto3
 python3-github
 zip
+jq
 PACKAGES
 
 apt-get -y install $(grep -o '^[^#]*' packages.txt)  # Install packages while ignoring comments.


### PR DESCRIPTION
Adds `jq`, used for JSON string operations in our GitHub Actions Workflow, to Docker images.
This fixes Linux Conan binary cache not being uploaded. (I have no idea why GitHub Actions shows the Action as passing even when `jq` is missing. Bash is correctly returning a non-0 returncode.)