### PR TITLE
apidocs: Update image entity example to use default_image texture

### DIFF
--- a/libraries/entities/src/EntityItemPropertiesDocs.cpp
+++ b/libraries/entities/src/EntityItemPropertiesDocs.cpp
@@ -998,8 +998,8 @@
  * var image = Entities.addEntity({
  *     type: "Image",
  *     position: Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 0, z: -2 })),
- *     dimensions: { x: 1.0, y: 0.26, z: 0.01 },
- *     imageURL: "https://apidocs.overte.org/images/brand-logo-512.png",
+ *     dimensions: { x: 1.0, y: 0.5, z: 0.01 },
+ *     imageURL: "https://content.overte.org/Bazaar/Assets/Textures/Defaults/Interface/default_image.jpg",
  *     billboardMode: "yaw",
  *     lifetime: 300  // Delete after 5 minutes.
  * });


### PR DESCRIPTION
* Current example uses an URL which is 404
* New url points to a domain controlled by Overte
* I also moved the new image a little closer to the user, to make it easier to see/find.