### PR TITLE
Disable fading on UI entities, disable grabbing loading avatar/equip indicator balls

### DIFF
--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -85,6 +85,9 @@ void OtherAvatar::createOrb() {
         properties.getPulse().setMax(1.0f);
         properties.getPulse().setColorMode(PulseMode::IN_PHASE);
         properties.setIgnorePickIntersection(true);
+        properties.getGrab().setGrabbable(false);
+        properties.setFadeInMode(COMPONENT_MODE_DISABLED);
+        properties.setFadeOutMode(COMPONENT_MODE_DISABLED);
 
         properties.setPosition(getHead()->getPosition());
         properties.setRotation(glm::quat(0.0f, 0.0f, 0.0f, 1.0));

--- a/interface/src/ui/Keyboard.cpp
+++ b/interface/src/ui/Keyboard.cpp
@@ -876,6 +876,8 @@ void Keyboard::loadKeyboardFile(const QString& keyboardFile) {
             properties.setParentID(myAvatar->getSelfID());
             properties.setParentJointIndex(SENSOR_TO_WORLD_MATRIX_INDEX);
             properties.setUnlit(true);
+            properties.setFadeInMode(COMPONENT_MODE_DISABLED);
+            properties.setFadeOutMode(COMPONENT_MODE_DISABLED);
 
             Anchor anchor;
             anchor.entityID = entityScriptingInterface->addEntityInternal(properties, entity::HostType::LOCAL);

--- a/scripts/communityScripts/chatBubbles/chatBubbles.js
+++ b/scripts/communityScripts/chatBubbles/chatBubbles.js
@@ -162,6 +162,8 @@ function ChatBubbles_SpawnBubble(data, senderID) {
             billboardMode: "yaw",
             grab: {grabbable: false},
             renderLayer: "front",
+            fadeInMode: "disabled",
+            fadeOutMode: "disabled",
         }, "local");
     } else {
         height *= scale;
@@ -188,6 +190,8 @@ function ChatBubbles_SpawnBubble(data, senderID) {
             topMargin: -0.004 * scale, // center isn't exactly centered?
             grab: {grabbable: false},
             renderLayer: "front",
+            fadeInMode: "disabled",
+            fadeOutMode: "disabled",
             script: (link === undefined && !linkIsImage) ? undefined :
 `(function() {
     this.mousePressOnEntity = function(entity, event) {
@@ -290,6 +294,8 @@ function ChatBubbles_ShowTypingIndicator(senderID) {
         grab: {grabbable: false},
         ignorePickIntersection: true,
         renderLayer: "front",
+        fadeInMode: "disabled",
+        fadeOutMode: "disabled",
     }, "local");
 
     const indicatorInterval = Script.setInterval(() => ChatBubbles_IndicatorTick(senderID), 1000 / BUBBLE_ANIM_FPS);

--- a/scripts/communityScripts/contextMenu.js
+++ b/scripts/communityScripts/contextMenu.js
@@ -584,6 +584,8 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 		a.canCastShadow = false;
 		a.isVisibleInSecondaryCamera = false;
 		a.renderLayer = "front";
+		a.fadeInMode = "disabled";
+		a.fadeOutMode = "disabled";
 
 		if (sensorScaleHack) {
 			a.dimensions[0] /= MyAvatar.sensorToWorldScale;

--- a/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/defaultLocalEntityProps.js
+++ b/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/defaultLocalEntityProps.js
@@ -21,7 +21,9 @@ var localEntityProps = {
     billboardMode: "full",
     lifetime: 3,
     canCastShadow: true,
-    unlit: true
+    unlit: true,
+    fadeInMode: "disabled",
+    fadeOutMode: "disabled",
 };
 
 module.exports = localEntityProps;

--- a/scripts/system/controllers/controllerModules/equipEntity.js
+++ b/scripts/system/controllers/controllerModules/equipEntity.js
@@ -91,7 +91,8 @@ EquipHotspotBuddy.prototype.updateHotspot = function(hotspot, timestamp) {
                 "w": 1
             },
             "dimensions": dimensions,
-            "ignorePickIntersection": true
+            "ignorePickIntersection": true,
+            "grab": { "grabbable": false },
         }, "local"));
         overlayInfoSet.type = "model";
         this.map[hotspot.key] = overlayInfoSet;

--- a/scripts/system/create/editModes/editVoxels.js
+++ b/scripts/system/create/editModes/editVoxels.js
@@ -511,7 +511,9 @@ EditVoxels = function() {
             alpha: 0.5,
             dimensions: sphereDimensions,
             collisionless: true,
-        },"world");
+            ignorePickIntersection: true,
+            grab: { grabbable: false },
+        }, "domain");
     }
 
     function stopSphereResizing() {

--- a/scripts/system/create/entitySelectionTool/entitySelectionTool.js
+++ b/scripts/system/create/entitySelectionTool/entitySelectionTool.js
@@ -981,6 +981,7 @@ SelectionDisplay = (function() {
         primitiveMode: "solid",
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front",
         unlit: true
     };
@@ -991,6 +992,7 @@ SelectionDisplay = (function() {
         primitiveMode: "solid",
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front",
         unlit: true
     };
@@ -1024,6 +1026,7 @@ SelectionDisplay = (function() {
         primitiveMode: "solid",
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front"
     };
 
@@ -1082,6 +1085,7 @@ SelectionDisplay = (function() {
         primitiveMode: "solid",
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front"
     }, "local");
     toolEntityMaterial.push(addUnlitMaterialOnToolEntity(handleRotateCurrentRing));
@@ -1097,6 +1101,7 @@ SelectionDisplay = (function() {
         billboardMode: "full",
         renderLayer: "front",
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         dimensions: { x: 0, y: 0, z: 0.01 },
         lineHeight: 0.0,
         topMargin: 0,
@@ -1112,6 +1117,7 @@ SelectionDisplay = (function() {
         primitiveMode: "solid",
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front",
         unlit: true
     };
@@ -1130,6 +1136,7 @@ SelectionDisplay = (function() {
         alpha: 0.5,
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front",
         unlit: true
     };
@@ -1148,6 +1155,7 @@ SelectionDisplay = (function() {
         color: COLOR_SCALE_CUBE,
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front",
         unlit: true
     }, "local");
@@ -1160,6 +1168,7 @@ SelectionDisplay = (function() {
         color: COLOR_BOUNDING_EDGE,
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front",
         unlit: true
     }, "local");
@@ -1173,6 +1182,7 @@ SelectionDisplay = (function() {
         color: COLOR_DUPLICATOR,
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front",
         unlit: true
     }, "local");
@@ -1188,6 +1198,7 @@ SelectionDisplay = (function() {
         alpha: 0,
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         unlit: true
     }, "local");
 
@@ -1202,6 +1213,7 @@ SelectionDisplay = (function() {
         alpha: 0,
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         unlit: true
     }, "local");
 
@@ -1214,7 +1226,8 @@ SelectionDisplay = (function() {
             green: 0,
             blue: 0
         },
-        ignorePickIntersection: true // always ignore this
+        ignorePickIntersection: true, // always ignore this
+        grab: { grabbable: false },
     }, "local");
     var yRailToolEntity = Entities.addEntity({
         type: "PolyLine",        
@@ -1225,7 +1238,8 @@ SelectionDisplay = (function() {
             green: 255,
             blue: 0
         },
-        ignorePickIntersection: true // always ignore this
+        ignorePickIntersection: true, // always ignore this
+        grab: { grabbable: false },
     }, "local");
     var zRailToolEntity = Entities.addEntity({
         type: "PolyLine",        
@@ -1236,7 +1250,8 @@ SelectionDisplay = (function() {
             green: 0,
             blue: 255
         },
-        ignorePickIntersection: true // always ignore this
+        ignorePickIntersection: true, // always ignore this
+        grab: { grabbable: false },
     }, "local");
 
     var allToolEntities = [
@@ -1314,6 +1329,7 @@ SelectionDisplay = (function() {
         primitiveMode: "solid",
         visible: false,
         ignorePickIntersection: true,
+        grab: { grabbable: false },
         renderLayer: "front"
     }, "local");
     var debugPickPlaneHits = [];
@@ -2446,6 +2462,7 @@ SelectionDisplay = (function() {
             primitiveMode: "solid",
             visible: true,
             ignorePickIntersection: true,
+            grab: { grabbable: false },
             renderLayer: "front",
             color: COLOR_DEBUG_PICK_PLANE_HIT,
             position: pickHitPosition,

--- a/scripts/system/create/modules/entityShapeVisualizer.js
+++ b/scripts/system/create/modules/entityShapeVisualizer.js
@@ -144,7 +144,8 @@ EntityShape.prototype = {
             priority: 1,
             materialMappingMode: PROJECTED_MATERIALS ? "projected" : "uv",
             materialURL: Script.resolvePath("../../assets/images/materials/GridPattern.json"),
-            ignorePickIntersection: true
+            ignorePickIntersection: true,
+            grab: { grabbable: false },
         }, "local");
     },
     update: function() {

--- a/scripts/system/libraries/entityIconOverlayManager.js
+++ b/scripts/system/libraries/entityIconOverlayManager.js
@@ -90,8 +90,11 @@ EntityIconOverlayManager = function(entityTypes, getOverlayPropertiesFunc) {
         if (unusedOverlays.length === 0) {
             overlay = Entities.addEntity({
                 type: "Image", 
+                emissive: true,
                 billboardMode: "full", 
-                emissive: true
+                fadeInMode: "disabled",
+                fadeOutMode: "disabled",
+                grab: { grabbable: false },
             }, "local");
             allOverlays.push(overlay);
         } else {
@@ -119,9 +122,12 @@ EntityIconOverlayManager = function(entityTypes, getOverlayPropertiesFunc) {
                 rotation: Quat.fromPitchYawRollDegrees(0, 0, 270),
                 visible: visible,
                 ignorePickIntersection: !visible,
+                grab: { grabbable: false },
                 alpha: 0.9,
                 dimensions: { x: 0.5, y: 0.5, z: 0.01 },
                 renderLayer: "front",
+                fadeInMode: "disabled",
+                fadeOutMode: "disabled",
                 color: {
                     red: 255,
                     green: 255,

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -262,6 +262,8 @@
                                                "visible": true,
                                                "ignorePickIntersection": true,
                                                "renderLayer": "world",
+                                               "fadeInMode": "disabled",
+                                               "fadeOutMode": "disabled",
                                                "lifetime": 3
                                        }, "local");
                     Script.setTimeout(function() {


### PR DESCRIPTION
Disables fading on UI entities like chat bubbles, typing indicators, the context menu, the tablet, and the keyboard.

Also makes the loading avatar ball and equip indicator ball non-grabbable, since they're currently near-grabbable in VR.