### PR TITLE
Use depth bias instead of physical offset for Text entity text

### DIFF
--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -294,7 +294,7 @@ ShapeKey entities::TextPayload::getShapeKey() const {
         if (renderable) {
             auto textRenderable = std::static_pointer_cast<TextEntityRenderer>(renderable);
 
-            auto builder = render::ShapeKey::Builder().withOwnPipeline();
+            auto builder = render::ShapeKey::Builder().withOwnPipeline().withDepthBias();
             if (textRenderable->isTextTransparent()) {
                 builder.withTranslucent();
             }
@@ -382,7 +382,7 @@ void entities::TextPayload::render(RenderArgs* args) {
     if (fontHeight > 0.0f) {
         scale = textRenderable->_lineHeight / fontHeight;
     }
-    transform.postTranslate(glm::vec3(-0.5, 0.5, 1.0f + EPSILON / dimensions.z));
+    transform.postTranslate(glm::vec3(-0.5f, 0.5f, 0.0f));
     transform.setScale(scale);
     batch.setModelTransform(transform, _prevRenderTransform);
     if (args->_renderMode == Args::RenderMode::DEFAULT_RENDER_MODE || args->_renderMode == Args::RenderMode::MIRROR_RENDER_MODE) {


### PR DESCRIPTION
Improves the look of Text entities, since the physical offset was a global constant, it could make the text stick out pretty far on small Text entities and the slight parallax even on larger ones felt kinda weird to look at

I've tested this with some of my toy scripts and looking at the Text entities around the hub. Everything looks to be working fine with this change.

Closes #2006

### Before
<img width="240" height="346" alt="without-depth-bias" src="https://github.com/user-attachments/assets/0fe5a586-2543-4b7e-be0e-b2bfb62609c4" />

### After
<img width="156" height="320" alt="with-depth-bias" src="https://github.com/user-attachments/assets/81289d4a-975d-416a-9508-bb18331331cb" />