### PR TITLE
Fix Text entity SNScale handling

### DIFF
--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -53,9 +53,8 @@ void TextEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
     void* key = (void*)this;
     AbstractViewStateInterface::instance()->pushPostUpdateLambda(key, [this, entity] {
         withWriteLock([&] {
-            _dimensions = entity->getScaledDimensions();
+            _dimensions = entity->getUnscaledDimensions();
             _renderTransform = getModelTransform();
-            _renderTransform.postScale(_dimensions);
         });
     });
 }
@@ -161,12 +160,15 @@ void TextEntityRenderer::doRender(RenderArgs* args) {
 
     bool transparent;
     Transform transform;
+    vec3 dimensions;
     withReadLock([&] {
         transparent = isTransparent();
         transform = _renderTransform;
+        dimensions = _dimensions;
     });
 
     bool usePrimaryFrustum = args->_renderMode == RenderArgs::RenderMode::SHADOW_RENDER_MODE || args->_mirrorDepth > 0;
+    transform.setScale(transform.getScale() * dimensions);
     transform.setRotation(BillboardModeHelpers::getBillboardRotation(transform.getTranslation(), transform.getRotation(), _billboardMode,
         usePrimaryFrustum ? BillboardModeHelpers::getPrimaryViewFrustumPosition() : args->getViewFrustum().getPosition()));
     batch.setModelTransform(transform, _prevRenderTransform);
@@ -390,8 +392,8 @@ void entities::TextPayload::render(RenderArgs* args) {
     if (fontHeight > 0.0f) {
         scale = textRenderable->_lineHeight / fontHeight;
     }
-    transform.postTranslate(glm::vec3(-0.5f, 0.5f, 0.0f));
-    transform.setScale(scale);
+    transform.postTranslate(glm::vec3(-dimensions.x / 2.0f, dimensions.y / 2.0f, dimensions.z / 2.0f));
+    transform.setScale(transform.getScale() * scale);
     batch.setModelTransform(transform, _prevRenderTransform);
     if (args->_renderMode == Args::RenderMode::DEFAULT_RENDER_MODE || args->_renderMode == Args::RenderMode::MIRROR_RENDER_MODE) {
         _prevRenderTransform = transform;

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -451,7 +451,7 @@ void WebEntityRenderer::destroyWebSurface() {
 }
 
 glm::vec2 WebEntityRenderer::getWindowSize(const TypedEntityPointer& entity) const {
-    glm::vec2 dims = glm::vec2(entity->getScaledDimensions());
+    glm::vec2 dims = glm::vec2(entity->getUnscaledDimensions());
     dims *= METERS_TO_INCHES * _dpi;
 
     // ensure no side is never larger then MAX_WINDOW_SIZE

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -451,7 +451,9 @@ void WebEntityRenderer::destroyWebSurface() {
 }
 
 glm::vec2 WebEntityRenderer::getWindowSize(const TypedEntityPointer& entity) const {
-    glm::vec2 dims = glm::vec2(entity->getUnscaledDimensions());
+    // TODO: Properly support SNScale (getUnscaledDimensions),
+    // will need modifications to the rayhit-to-2D position code
+    glm::vec2 dims = glm::vec2(entity->getScaledDimensions());
     dims *= METERS_TO_INCHES * _dpi;
 
     // ensure no side is never larger then MAX_WINDOW_SIZE

--- a/libraries/entities/src/TextEntityItem.cpp.in
+++ b/libraries/entities/src/TextEntityItem.cpp.in
@@ -41,6 +41,8 @@ TextEntityItem::TextEntityItem(const EntityItemID& entityItemID) : EntityItem(en
     _type = EntityTypes::Text;
 }
 
+// FIXME: The text renderer supports using dimensions.z as the text depth offset,
+// but this forces it to always be 1cm
 void TextEntityItem::setUnscaledDimensions(const glm::vec3& value) {
     const float TEXT_ENTITY_ITEM_FIXED_DEPTH = 0.01f;
     // NOTE: Text Entities always have a "depth" of 1cm.

--- a/scripts/communityScripts/contextMenu.js
+++ b/scripts/communityScripts/contextMenu.js
@@ -256,11 +256,10 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 	mouseWasCaptured = Camera.captureMouse;
 	Camera.captureMouse = false;
 
-	const scale = MyAvatar.sensorToWorldScale;
+	const scale = 1;
+	// FIXME: lineHeight and margin properties sets don't take SNScale into account
+	const lineScale = scale / MyAvatar.sensorToWorldScale;
 	const myAvatar = MyAvatar.sessionUUID;
-
-	// https://github.com/overte-org/overte/issues/1668
-	const sensorScaleHack = HMD.active;
 
 	const baseActions = registeredActionSets[actionSetName];
 
@@ -388,20 +387,20 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 			type: "Text",
 			position: Vec3.sum(origin, Vec3.multiplyQbyV(angle, [0, yPos, 0])),
 			rotation: angle,
-			dimensions: [0.3 * scale, 0.2 * scale, 0.01 * scale],
+			localDimensions: [0.3 * scale, 0.2 * scale, 0.01 * scale],
 			text: descriptionText,
 			textColor: [255, 255, 255],
 			backgroundColor: [0, 0, 0],
 			backgroundAlpha: 0.9,
 			unlit: true,
-			lineHeight: 0.016 * scale,
+			lineHeight: 0.016 * lineScale,
 			verticalAlignment: "bottom",
 			alignment: "center",
 			triggerable: false,
-			topMargin: 0.005 * scale,
-			bottomMargin: 0.005 * scale,
-			leftMargin: 0.005 * scale,
-			rightMargin: 0.005 * scale,
+			topMargin: 0.005 * lineScale,
+			bottomMargin: 0.005 * lineScale,
+			leftMargin: 0.005 * lineScale,
+			rightMargin: 0.005 * lineScale,
 			textEffect: "outline fill",
 			textEffectColor: [0, 0, 0],
 			textEffectThickness: 0.3,
@@ -416,13 +415,13 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 		type: "Text",
 		position: Vec3.sum(origin, Vec3.multiplyQbyV(angle, [0, yPos, 0])),
 		rotation: angle,
-		dimensions: [0.215 * scale, 0.04 * scale, 0.01 * scale],
+		localDimensions: [0.215 * scale, 0.04 * scale, 0.01 * scale],
 		text: titleText,
 		textColor: [230, 230, 230],
 		backgroundColor: [0, 0, 0],
 		backgroundAlpha: 0.9,
 		unlit: true,
-		lineHeight: 0.018 * scale,
+		lineHeight: 0.018 * lineScale,
 		verticalAlignment: "center",
 		alignment: "center",
 		triggerable: false,
@@ -436,18 +435,18 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 		type: "Text",
 		position: Vec3.sum(origin, Vec3.multiplyQbyV(angle, [-0.13 * scale, yPos, 0])),
 		rotation: angle,
-		dimensions: [0.04 * scale, 0.04 * scale, 0.01 * scale],
+		localDimensions: [0.04 * scale, 0.04 * scale, 0.01 * scale],
 		text: hasPages && page > 0 ? "<" : "",
 		textColor: [230, 230, 230],
 		backgroundColor: [0, 0, 0],
 		backgroundAlpha: 0.9,
 		unlit: true,
-		lineHeight: 0.05 * scale,
+		lineHeight: 0.05 * lineScale,
 		verticalAlignment: "top",
 		alignment: "center",
 		triggerable: false,
-		leftMargin: 0.003 * scale,
-		topMargin: -0.008 * scale,
+		leftMargin: 0.003 * lineScale,
+		topMargin: -0.008 * lineScale,
 		userData: hasPages && page > 0 ? JSON.stringify({nextPage: page - 1, actionSetName: actionSetName}) : undefined,
 		textEffect: "outline fill",
 		textEffectColor: [0, 0, 0],
@@ -459,18 +458,18 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 		type: "Text",
 		position: Vec3.sum(origin, Vec3.multiplyQbyV(angle, [0.13 * scale, yPos, 0])),
 		rotation: angle,
-		dimensions: [0.04 * scale, 0.04 * scale, 0.01 * scale],
+		localDimensions: [0.04 * scale, 0.04 * scale, 0.01 * scale],
 		text: hasPages && page < maxPages ? ">" : "",
 		textColor: [230, 230, 230],
 		backgroundColor: [0, 0, 0],
 		backgroundAlpha: 0.9,
 		unlit: true,
-		lineHeight: 0.05 * scale,
+		lineHeight: 0.05 * lineScale,
 		verticalAlignment: "top",
 		alignment: "center",
 		triggerable: false,
-		leftMargin: -0.002 * scale,
-		topMargin: -0.008 * scale,
+		leftMargin: -0.002 * lineScale,
+		topMargin: -0.008 * lineScale,
 		userData: hasPages && page < maxPages ? JSON.stringify({nextPage: page + 1, actionSetName: actionSetName}) : undefined,
 		textEffect: "outline fill",
 		textEffectColor: [0, 0, 0],
@@ -489,18 +488,18 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 			type: "Text",
 			position: pos,
 			rotation: angle,
-			dimensions: [0.3 * scale, 0.05 * scale, 0.0001 * scale],
+			localDimensions: [0.3 * scale, 0.05 * scale, 0.01 * scale],
 			text: action.text,
 			textColor: action.textColor ?? [255, 255, 255],
 			backgroundColor: action.backgroundColor ?? [0, 0, 0],
 			backgroundAlpha: action.backgroundAlpha ?? 0.8,
 			unlit: true,
-			lineHeight: 0.025 * scale,
+			lineHeight: 0.025 * lineScale,
 			verticalAlignment: "center",
 			alignment: "left",
 			triggerable: true,
-			leftMargin: 0.05 * scale,
-			rightMargin: 0.05 * scale,
+			leftMargin: 0.05 * lineScale,
+			rightMargin: 0.05 * lineScale,
 			userData: JSON.stringify({actionFunc: i}),
 			textEffect: "outline fill",
 			textEffectColor: action.backgroundColor ?? [0, 0, 0],
@@ -513,7 +512,7 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 				type: "Image",
 				position: pos,
 				rotation: angle,
-				dimensions: [0.03 * scale, 0.03 * scale, 0.01 * scale],
+				localDimensions: [0.03 * scale, 0.03 * scale, 0.01 * scale],
 				imageURL: action.iconImage,
 				emissive: true,
 				userData: JSON.stringify({actionFunc: i}),
@@ -555,18 +554,18 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 			type: "Text",
 			position: pos,
 			rotation: angle,
-			dimensions: [0.3 * scale, 0.05 * scale, 0.0001 * scale],
+			localDimensions: [0.3 * scale, 0.05 * scale, 0.01 * scale],
 			text: "(No actions)",
 			textColor: [230, 230, 230],
 			backgroundColor: [64, 64, 64],
 			backgroundAlpha: 0.8,
 			unlit: true,
-			lineHeight: 0.025 * scale,
+			lineHeight: 0.025 * lineScale,
 			verticalAlignment: "center",
 			alignment: "left",
 			triggerable: true,
-			leftMargin: 0.05 * scale,
-			rightMargin: 0.05 * scale,
+			leftMargin: 0.05 * lineScale,
+			rightMargin: 0.05 * lineScale,
 			textEffect: "outline fill",
 			textEffectColor: [0, 0, 0],
 			textEffectThickness: 0.3,
@@ -583,19 +582,8 @@ function ContextMenu_OpenActions(actionSetName, page = 0) {
 		a.font = CONTEXT_MENU_FONT;
 		a.canCastShadow = false;
 		a.isVisibleInSecondaryCamera = false;
-		a.renderLayer = "front";
 		a.fadeInMode = "disabled";
 		a.fadeOutMode = "disabled";
-
-		if (sensorScaleHack) {
-			a.dimensions[0] /= MyAvatar.sensorToWorldScale;
-			a.dimensions[1] /= MyAvatar.sensorToWorldScale;
-
-			if (a.rightMargin === undefined) { a.rightMargin = 0; }
-			if (a.bottomMargin === undefined) { a.bottomMargin = 0; }
-			a.rightMargin += a.dimensions[0] * -(MyAvatar.sensorToWorldScale - 1);
-			a.bottomMargin += a.dimensions[1] * -(MyAvatar.sensorToWorldScale - 1);
-		}
 
 		const e = Entities.addEntity(a, (CONTEXT_MENU_SETTINGS.public ?? false) ? "avatar" : "local");
 		currentMenuEntities.add(e);

--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -106,7 +106,9 @@
                 }                
                 if (isOnHMD) {
                     //use HMD local entities
-                    var sensorScaleFactor = MyAvatar.sensorToWorldScale * HMD_UI_SCALE_FACTOR;
+                    // FIXME: set this to (1 / MyAvatar.sensorToWorldScale) once the
+                    // camera joint uses identity scaling like the sensor joint
+                    var sensorScaleFactor = HMD_UI_SCALE_FACTOR;
                     var lineHeight = HMD_LINE_HEIGHT;
                     height = lineHeight + (2 * entityTopMargin);
                     extraLine = breaks * lineHeight;
@@ -126,7 +128,10 @@
                         "leftMargin": entityLeftMargin * sensorScaleFactor,
                         "topMargin": entityTopMargin * sensorScaleFactor,
                         "unlit": true,
-                        "renderLayer": "hud"
+                        // FIXME: The HUD layer is sometimes corrupted or invisible #1439
+                        "renderLayer": "front",
+                        "grab": { "grabbable": false },
+                        "ignorePickIntersection": true,
                     };
                     if (notifications[i].entityID === Uuid.NONE){
                         properties.text =  notifications[i].dataText;
@@ -147,7 +152,10 @@
                             "emissive": true,
                             "visible": true,
                             "alpha": alpha,
-                            "renderLayer": "hud"
+                            // FIXME: The HUD layer is sometimes corrupted or invisible #1439
+                            "renderLayer": "front",
+                            "grab": { "grabbable": false },
+                            "ignorePickIntersection": true,
                         };                        
                         if (notifications[i].imageEntityID === Uuid.NONE){
                             properties.imageURL = notifications[i].dataImage.path;
@@ -235,10 +243,10 @@
     function createMainHMDnotificationContainer() {
         if (mainHMDnotificationContainerID === Uuid.NONE) {
             var properties = {
-                "type": "Shape",
-                "shape": "Cube",
-                "visible": false,
-                "dimensions": {"x": 0.1, "y": 0.1, "z":0.1},
+                "name": "Notifications Root",
+                "type": "Empty",
+                "grab": { "grabbable": false },
+                "ignorePickIntersection": true,
                 "parentID": MyAvatar.sessionUUID,
                 "parentJointIndex": CAMERA_MATRIX_INDEX,
                 "localPosition": hmdPanelLocalPosition,


### PR DESCRIPTION
Fixes #1668

I think this is as good as I can get the scaling on Text entities for now. Scripts still need some workarounds for other scaling bugs, but this fixes the otherwise impossible to work around bug with the Text background quad being forced to a scale of 1.

Also reverts the text-flattening in #2131 so the text doesn't Z-fight with the background, most noticeably on the context menu (which it shouldn't have been doing anyway, idk what's happening there)

I've also modified `notifications.js` to scale properly and ignore laser input, since previously the notification bubbles were grabbable.