### PR TITLE
some nix build fixes

### DIFF
--- a/nix/overte.nix
+++ b/nix/overte.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation {
 
   dontWrapQtApps = true;
 
-  # TODO: remove set QT_PLUGIN_PATH after qt6 update
+  # TODO: remove unset QT_PLUGIN_PATH after qt6 update
   installPhase = ''
     runHook preInstall
 
@@ -162,7 +162,7 @@ stdenv.mkDerivation {
       cp interface/interface "$I"/
       ln -s "$I"/interface $out/bin/overte-client
       makeWrapper "$I"/interface $out/bin/overte-client \
-        --set QT_PLUGIN_PATH ''' \
+        --unset QT_PLUGIN_PATH \
         "''${qtWrapperArgs[@]}"
     ''
   )


### PR DESCRIPTION
This includes fixes for changes (probably) introduced by vulkan branch as well some improvements.

run with `NIXPKGS_ALLOW_INSECURE=1 nix run github:overte-org/overte?ref=fix_nix_build#overte-full --no-pure-eval`