### PR TITLE
Fix Vulkan texture transfer barriers

### DIFF
--- a/libraries/gpu-vk/src/gpu/vk/VKTexture.cpp
+++ b/libraries/gpu-vk/src/gpu/vk/VKTexture.cpp
@@ -531,25 +531,25 @@ void VKStrictResourceTexture::postTransfer(VKBackend &backend) {
     // VKTODO: in the future this needs to be streamlined as a part of frame command buffer.
     VkCommandBuffer graphicsCmd = device->createCommandBuffer(device->graphicsCommandPool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
 
-        VkImageSubresourceRange subresourceRange = {};
-        subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        subresourceRange.baseMipLevel = 0;
-        subresourceRange.levelCount = _transferData.mips.size();
-        if (_gpuObject.getType() == Texture::TEX_CUBE) {
-            subresourceRange.layerCount = 6;
-        }else{
-            subresourceRange.layerCount = 1;
-        }
-        vks::tools::setImageLayout(
-            graphicsCmd,
-            _vkImage,
-            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-            subresourceRange,
-            device->queueFamilyIndices.transfer,
-            device->queueFamilyIndices.graphics,
-            VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-            VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    VkImageSubresourceRange subresourceRange = {};
+    subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    subresourceRange.baseMipLevel = 0;
+    subresourceRange.levelCount = _transferData.mips.size();
+    if (_gpuObject.getType() == Texture::TEX_CUBE) {
+        subresourceRange.layerCount = 6;
+    }else{
+        subresourceRange.layerCount = 1;
+    }
+    vks::tools::setImageLayout(
+        graphicsCmd,
+        _vkImage,
+        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        subresourceRange,
+        device->queueFamilyIndices.transfer,
+        device->queueFamilyIndices.graphics,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
     device->flushCommandBuffer(graphicsCmd, backend.getContext().graphicsQueue, device->graphicsCommandPool);
     // Image is ready to use now.

--- a/libraries/gpu-vk/src/gpu/vk/VKTexture.cpp
+++ b/libraries/gpu-vk/src/gpu/vk/VKTexture.cpp
@@ -506,13 +506,18 @@ void VKStrictResourceTexture::transfer(VKBackend &backend) {
     );
 
     // Change texture image layout to shader read after all mip levels have been copied
-    _vkImageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    // The barrier command needs to be run on both transfer and graphics queues. Only then image layout changes.
+    _vkImageLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     vks::tools::setImageLayout(
         copyCmd,
         _vkImage,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        _vkImageLayout,
-        subresourceRange);
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        subresourceRange,
+        device->queueFamilyIndices.transfer,
+        device->queueFamilyIndices.graphics,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
     device->flushCommandBuffer(copyCmd, backend.getContext().transferQueue, device->transferCommandPool);
 
@@ -523,6 +528,33 @@ void VKStrictResourceTexture::transfer(VKBackend &backend) {
 
 void VKStrictResourceTexture::postTransfer(VKBackend &backend) {
     auto device = backend.getContext().device;
+    // VKTODO: in the future this needs to be streamlined as a part of frame command buffer.
+    VkCommandBuffer graphicsCmd = device->createCommandBuffer(device->graphicsCommandPool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, true);
+
+        VkImageSubresourceRange subresourceRange = {};
+        subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        subresourceRange.baseMipLevel = 0;
+        subresourceRange.levelCount = _transferData.mips.size();
+        if (_gpuObject.getType() == Texture::TEX_CUBE) {
+            subresourceRange.layerCount = 6;
+        }else{
+            subresourceRange.layerCount = 1;
+        }
+        vks::tools::setImageLayout(
+            graphicsCmd,
+            _vkImage,
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+            subresourceRange,
+            device->queueFamilyIndices.transfer,
+            device->queueFamilyIndices.graphics,
+            VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+            VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+
+    device->flushCommandBuffer(graphicsCmd, backend.getContext().graphicsQueue, device->graphicsCommandPool);
+    // Image is ready to use now.
+    _vkImageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
     // Create sampler
     VkSamplerCreateInfo samplerCreateInfo = {};
     samplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;

--- a/libraries/vk/src/vk/VulkanTools.cpp
+++ b/libraries/vk/src/vk/VulkanTools.cpp
@@ -174,6 +174,8 @@ namespace vks
             VkImageLayout oldImageLayout,
             VkImageLayout newImageLayout,
             VkImageSubresourceRange subresourceRange,
+            uint32_t srcQueueFamilyIndex,
+            uint32_t dstQueueFamilyIndex,
             VkPipelineStageFlags srcStageMask,
             VkPipelineStageFlags dstStageMask)
         {
@@ -183,6 +185,8 @@ namespace vks
             imageMemoryBarrier.newLayout = newImageLayout;
             imageMemoryBarrier.image = image;
             imageMemoryBarrier.subresourceRange = subresourceRange;
+            imageMemoryBarrier.srcQueueFamilyIndex = srcQueueFamilyIndex;
+            imageMemoryBarrier.dstQueueFamilyIndex = dstQueueFamilyIndex;
 
             // Source layouts (old)
             // Source access mask controls actions that have to be finished on the old layout

--- a/libraries/vk/src/vk/VulkanTools.h
+++ b/libraries/vk/src/vk/VulkanTools.h
@@ -94,6 +94,8 @@ namespace vks
             VkImageLayout oldImageLayout,
             VkImageLayout newImageLayout,
             VkImageSubresourceRange subresourceRange,
+            uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            uint32_t dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
             VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
             VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
         // Uses a fixed sub resource layout with first mip level and layer


### PR DESCRIPTION
This fixes new validation error that happens on texture transfers.

## Funding

This project is funded through [NGI0 Entrust](https://nlnet.nl/entrust), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) program. Learn more at the [NLnet project page](https://nlnet.nl/project/Overte).

[<img src="https://nlnet.nl/logo/banner.png" alt="NLnet foundation logo" width="20%" />](https://nlnet.nl)
[<img src="https://nlnet.nl/image/logos/NGI0_tag.svg" alt="NGI Zero Logo" width="20%" />](https://nlnet.nl/entrust)