### PR TITLE
nix: add a vulkan option and enable xcb QT platform by default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
             ...
           }:
           {
-            packages = {
+            packages = rec {
               glad = pkgs.callPackage ./nix/glad.nix { };
               etc2comp = pkgs.callPackage ./nix/etc2comp.nix { };
 
@@ -51,6 +51,8 @@
                   ;
                 libv8 = pkgs.nodejs_22.libv8;
               };
+
+              overte-full-vulkan = overte-full.override { renderingBackend = "Vulkan"; };
 
               # TODO: update/remove when overte updates to more modern version
               draco = pkgs.callPackage ./nix/draco.nix { };


### PR DESCRIPTION
Those changes make add a "overte-full-vulkan" package, that is overte-full but with Vulkan. It also set the default QT platform to xcb. Runnable with ``NIXPKGS_ALLOW_INSECURE=1 nix build .#overte-full-vulkan --impure`` (insecure and impure needed due to the outdated vulnerable qtwebengine, that https://github.com/overte-org/overte/pull/2012 fixes)

I figured that https://github.com/overte-org/overte/pull/2012 also sets the default QT platform to xcb. This will create a merge conflict (which should likely be easily fixed once one or the other PR is merged). I’ll go review this other PR.

Ping @RTUnreal things you might want to take a look at that.