### PR TITLE
basic light fading

### DIFF
--- a/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
@@ -38,8 +38,8 @@ void LightEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPoint
 
     light->setColor(toGlm(entity->getColor()));
 
-    float intensity = entity->getIntensity();//* entity->getFadingRatio();
-    light->setIntensity(intensity);
+    _intensity = entity->getIntensity();
+    light->setIntensity(_intensity);
 
     light->setFalloffRadius(entity->getFalloffRadius());
 
@@ -65,6 +65,11 @@ Item::Bound LightEntityRenderer::getBound(RenderArgs* args) {
 }
 
 void LightEntityRenderer::doRender(RenderArgs* args) {
+    bool fading = ShapeKey(args->_itemShapeKey).isFaded();
+    if (fading) {
+        float fadeRatio = 1.0f - std::clamp(getFadeParams(args->_scene).baseOffsetAndThreshold.w, 0.0f, 1.0f);
+        auto light = _lightPayload->editLight();
+        light->setIntensity(_intensity * fadeRatio);
+    }
     _lightPayload->render(args);
 }
-

--- a/libraries/entities-renderer/src/RenderableLightEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableLightEntityItem.h
@@ -34,6 +34,7 @@ protected:
 
 private:
     const LightPayload::Pointer _lightPayload{ std::make_shared<LightPayload>() };
+    float _intensity { 1.0f };
 };
 
 } } // namespace 

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -36,8 +36,11 @@ void render::renderItems(const RenderContextPointer& renderContext, const ItemBo
     }
     for (auto i = 0; i < numItemsToDraw; ++i) {
         auto& item = scene->getItem(inItems[i].id);
+        auto key = item.getShapeKey();
+        args->_itemShapeKey = key._flags.to_ulong();
         item.render(args);
     }
+    args->_itemShapeKey = 0;
 }
 
 namespace {

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -3065,7 +3065,7 @@ const GROUPS_PER_TYPE = {
   Model: [ 'base', 'model', 'spatial', 'behavior', 'grabAndEquip', 'scripts', 'collision', 'physics', 'fading', 'children' ],
   Image: [ 'base', 'image', 'spatial', 'behavior', 'grabAndEquip', 'scripts', 'collision', 'physics', 'fading', 'children' ],
   Web: [ 'base', 'web', 'spatial', 'behavior', 'grabAndEquip', 'scripts', 'collision', 'physics', 'fading', 'children' ],
-  Light: [ 'base', 'light', 'spatial', 'behavior', 'grabAndEquip', 'scripts', 'collision', 'physics', 'children' ],
+  Light: ['base', 'light', 'spatial', 'behavior', 'grabAndEquip', 'scripts', 'collision', 'physics', 'fading', 'children' ],
   Material: [ 'base', 'material', 'spatial', 'behavior', 'grabAndEquip', 'scripts', 'physics', 'children' ],
   ParticleEffect: [ 'base', 'particles', 'particles_emit', 'particles_size', 'particles_color', 
                     'particles_behavior', 'particles_constraints', 'spatial', 'behavior', 'grabAndEquip', 'scripts', 'physics', 'children' ],


### PR DESCRIPTION
fix #2050 

lights now do a basic intensity fade in/out based on their properties (really just the mode + duration).  the other fade properties are ignored, although maybe we could add some color tinting later.  they still show in create right now because we don't have a way to support multiple "showPropertyRule"s in create