### PR TITLE
Keyboard.emitKeyEvent, keycodes helper module

### DIFF
--- a/interface/src/scripting/KeyboardScriptingInterface.cpp
+++ b/interface/src/scripting/KeyboardScriptingInterface.cpp
@@ -9,6 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "ScriptPermissions.h"
 #include "KeyboardScriptingInterface.h"
 #include "ui/Keyboard.h"
 
@@ -66,4 +67,12 @@ bool KeyboardScriptingInterface::getPreferMalletsOverLasers() const {
 
 bool KeyboardScriptingInterface::containsID(const QUuid& id) const {
     return DependencyManager::get<Keyboard>()->containsID(id);
+}
+
+void KeyboardScriptingInterface::emitKeyEvent(const KeyEvent& event, bool pressed) const {
+    if (!ScriptPermissions::isCurrentScriptAllowed(ScriptPermissions::Permission::SCRIPT_PERMISSION_KEYBOARD_EVENTS)) {
+        return;
+    }
+
+    DependencyManager::get<Keyboard>()->emitKeyEvent(event, pressed);
 }

--- a/interface/src/scripting/KeyboardScriptingInterface.h
+++ b/interface/src/scripting/KeyboardScriptingInterface.h
@@ -16,6 +16,7 @@
 #include <QtCore/QUuid>
 
 #include "DependencyManager.h"
+#include "KeyEvent.h"
 
 /*@jsdoc
  * The <code>Keyboard</code> API provides facilities to use an in-world, virtual keyboard. When enabled, this keyboard is 
@@ -101,6 +102,14 @@ public:
      * @returns {boolean} <code>true</code> if the entity is part of the virtual keyboard, <code>false</code> if it isn't.
      */
     Q_INVOKABLE bool containsID(const QUuid& overlayID) const;
+
+    /*@jsdoc
+     * Emits a virtual key event. Protected by the "keyboard events" script permission.
+     * @function Keyboard.emitKeyEvent
+     * @param {KeyEvent} event
+     * @param {boolean} pressed
+     */
+    Q_INVOKABLE void emitKeyEvent(const KeyEvent& event, bool pressed) const;
 
 private:
     bool getPreferMalletsOverLasers() const;

--- a/interface/src/scripting/KeyboardScriptingInterface.h
+++ b/interface/src/scripting/KeyboardScriptingInterface.h
@@ -108,6 +108,34 @@ public:
      * @function Keyboard.emitKeyEvent
      * @param {KeyEvent} event
      * @param {boolean} pressed
+     * @example
+     * // Presses and holds W for two seconds, then releases it.
+     * const KeyCodes = require("keycodes");
+     *
+     * const keyEvent = { key: KeyCodes.w };
+     *
+     * Keyboard.emitKeyEvent(keyEvent, true);
+     *
+     * Script.setTimeout(() => Keyboard.emitKeyEvent(keyEvent, false), 2000);
+     * @example
+     * // Binds the left VR controller primary button to Ctrl+Z
+     * const KeyCodes = require("keycodes");
+     *
+     * let wasPressed = false;
+     * const undoKey = { key: KeyCodes.z, isControl: true };
+     *
+     * let mapping = Controller.newMapping();
+     * mapping.from(Controller.Actions.LeftPrimaryThumb).to(value => {
+     *     const pressed = value > 0.5;
+     *
+     *     if (pressed === wasPressed) { return; }
+     *
+     *     Keyboard.emitKeyEvent(undoKey, pressed);
+     *
+     *     wasPressed = pressed;
+     * });
+     *
+     * Script.scriptEnding.connect(() => mapping.disable());
      */
     Q_INVOKABLE void emitKeyEvent(const KeyEvent& event, bool pressed) const;
 

--- a/interface/src/ui/Keyboard.cpp
+++ b/interface/src/ui/Keyboard.cpp
@@ -46,6 +46,7 @@
 #include "raypick/StylusPointer.h"
 #include "GLMHelpers.h"
 #include "Application.h"
+#include "KeyEvent.h"
 
 static const int LEFT_HAND_CONTROLLER_INDEX = 0;
 static const int RIGHT_HAND_CONTROLLER_INDEX = 1;
@@ -1094,4 +1095,42 @@ bool Keyboard::containsID(const QUuid& id) const {
     return resultWithReadLock<bool>([&] {
         return _itemsToIgnore.contains(id) || _backPlate.entityID == id;
     });
+}
+
+void Keyboard::emitKeyEvent(const KeyEvent& event, bool pressed) const {
+    Qt::KeyboardModifiers modifiers {};
+
+    if (event.isShifted) {
+        modifiers |= Qt::KeyboardModifier::ShiftModifier;
+    }
+
+    if (event.isControl) {
+        modifiers |= Qt::KeyboardModifier::ControlModifier;
+    }
+
+    if (event.isMeta) {
+        modifiers |= Qt::KeyboardModifier::MetaModifier;
+    }
+
+    if (event.isAlt) {
+        modifiers |= Qt::KeyboardModifier::AltModifier;
+    }
+
+    if (event.isKeypad) {
+        modifiers |= Qt::KeyboardModifier::KeypadModifier;
+    }
+
+    QKeyEvent* qEvent = new QKeyEvent(
+        pressed ? QEvent::KeyPress : QEvent::KeyRelease,
+        event.key,
+        modifiers,
+        event.text,
+        event.isAutoRepeat
+    );
+
+    if (_inputToHudUI) {
+        QCoreApplication::postEvent(qApp->getPrimaryWidget(), qEvent);
+    } else {
+        QCoreApplication::postEvent(QCoreApplication::instance(), qEvent);
+    }
 }

--- a/interface/src/ui/Keyboard.h
+++ b/interface/src/ui/Keyboard.h
@@ -26,6 +26,7 @@
 #include <SettingHandle.h>
 
 class PointerEvent;
+class KeyEvent;
 
 
 class Key {
@@ -124,6 +125,8 @@ public:
     void loadKeyboardFile(const QString& keyboardFile);
     QSet<QUuid> getKeyIDs();
     QUuid getAnchorID();
+
+    void emitKeyEvent(const KeyEvent& event, bool pressed) const;
 
 public slots:
     void handleTriggerBegin(const QUuid& id, const PointerEvent& event);

--- a/libraries/script-engine/src/ScriptPermissions.cpp
+++ b/libraries/script-engine/src/ScriptPermissions.cpp
@@ -25,6 +25,8 @@ extern const std::array<QString, static_cast<int>(ScriptPermissions::Permission:
     "Permission to get user's avatar URL",
     // SCRIPT_PERMISSION_BOOKMARKS
     "Permission to view user's bookmarked locations",
+    // SCRIPT_PERMISSION_KEYBOARD_EVENTS
+    "Permission to emit virtual keyboard events",
 };
 
 extern const std::array<QString, static_cast<int>(ScriptPermissions::Permission::SCRIPT_PERMISSIONS_SIZE)> scriptPermissionSettingKeyNames {
@@ -32,6 +34,8 @@ extern const std::array<QString, static_cast<int>(ScriptPermissions::Permission:
     "private/scriptPermissionGetAvatarURLSafeURLs",
     // SCRIPT_PERMISSION_BOOKMARKS
     "private/scriptPermissionBookmarksSafeURLs",
+    // SCRIPT_PERMISSION_KEYBOARD_EVENTS
+    "private/scriptPermissionKeyboardEventsSafeURLs",
 };
 
 extern const std::array<QString, static_cast<int>(ScriptPermissions::Permission::SCRIPT_PERMISSIONS_SIZE)> scriptPermissionSettingEnableKeyNames {
@@ -39,12 +43,16 @@ extern const std::array<QString, static_cast<int>(ScriptPermissions::Permission:
     "private/scriptPermissionGetAvatarURLEnable",
     // SCRIPT_PERMISSION_BOOKMARKS
     "private/scriptPermissionBookmarksEnable",
+    // SCRIPT_PERMISSION_KEYBOARD_EVENTS
+    "private/scriptPermissionKeyboardEventsEnable",
 };
 
 extern const std::array<bool, static_cast<int>(ScriptPermissions::Permission::SCRIPT_PERMISSIONS_SIZE)> scriptPermissionSettingEnableDefaultValues {
     // SCRIPT_PERMISSION_GET_AVATAR_URL
     true,
     // SCRIPT_PERMISSION_BOOKMARKS
+    true,
+    // SCRIPT_PERMISSION_KEYBOARD_EVENTS
     true,
 };
 

--- a/libraries/script-engine/src/ScriptPermissions.h
+++ b/libraries/script-engine/src/ScriptPermissions.h
@@ -21,6 +21,7 @@ public:
     enum class Permission {
         SCRIPT_PERMISSION_GET_AVATAR_URL,
         SCRIPT_PERMISSION_BOOKMARKS,
+        SCRIPT_PERMISSION_KEYBOARD_EVENTS,
         SCRIPT_PERMISSIONS_SIZE
     };
 

--- a/scripts/modules/keycodes.js
+++ b/scripts/modules/keycodes.js
@@ -1,0 +1,192 @@
+// keycodes.js
+// Created by Ada <ada@thingvellir.net> 2026-02-14
+// SPDX-License-Identifier: Apache-2.0
+"use strict";
+
+// QT6TODO: swap the "also see" link to the Qt6 docs
+
+/**
+ * @module KeyCodes
+ * Helper module for common keycodes reported by {@link KeyEvent.key}.
+ * Dead keys, media keys, shortcut keys, and function keys above F12 are omitted.
+ *
+ * Also see {@link https://doc.qt.io/qt-5/qt.html#Key-enum}, which this is translated from,
+ * and has the constants for keycodes not listed in this module.
+ */
+module.exports = {
+    space:      0x20,
+    exclam:     0x21,
+    quoteDbl:   0x22,
+    numberSign: 0x23,
+    dollar:     0x24,
+    percent:    0x25,
+    ampersand:  0x26,
+    apostrophe: 0x27,
+    parenLeft:  0x28,
+    parenRight: 0x29,
+    asterisk:   0x2a,
+    plus:       0x2b,
+    comma:      0x2c,
+    minus:      0x2d,
+    period:     0x2e,
+    slash:      0x2f,
+
+    zero:       0x30,
+    one:        0x31,
+    two:        0x32,
+    three:      0x33,
+    four:       0x34,
+    five:       0x35,
+    six:        0x36,
+    seven:      0x37,
+    eight:      0x38,
+    nine:       0x39,
+
+    colon:      0x3a,
+    semicolon:  0x3b,
+    less:       0x3c,
+    equal:      0x3d,
+    greater:    0x3e,
+    question:   0x3f,
+    at:         0x40,
+
+    // convenience ASCII aliases
+    " ":        0x20,
+    "!":        0x21,
+    '"':        0x22,
+    "#":        0x23,
+    "$":        0x24,
+    "%":        0x25,
+    "&":        0x26,
+    "'":        0x27,
+    "(":        0x28,
+    ")":        0x29,
+    "*":        0x2a,
+    "+":        0x2b,
+    ",":        0x2c,
+    "-":        0x2d,
+    ".":        0x2e,
+    "/":        0x2f,
+
+    "0":        0x30,
+    "1":        0x31,
+    "2":        0x32,
+    "3":        0x33,
+    "4":        0x34,
+    "5":        0x35,
+    "6":        0x36,
+    "7":        0x37,
+    "8":        0x38,
+    "9":        0x39,
+
+    ":":        0x3a,
+    ";":        0x3b,
+    "<":        0x3c,
+    "=":        0x3d,
+    ">":        0x3e,
+    "?":        0x3f,
+    "@":        0x40,
+
+    a:          0x41,
+    b:          0x42,
+    c:          0x43,
+    d:          0x44,
+    e:          0x45,
+    f:          0x46,
+    g:          0x47,
+    h:          0x48,
+    i:          0x49,
+    j:          0x4a,
+    k:          0x4b,
+    l:          0x4c,
+    m:          0x4d,
+    n:          0x4e,
+    o:          0x4f,
+    p:          0x50,
+    q:          0x51,
+    r:          0x52,
+    s:          0x53,
+    t:          0x54,
+    u:          0x55,
+    v:          0x56,
+    w:          0x57,
+    x:          0x58,
+    y:          0x59,
+    z:          0x5a,
+
+    bracketLeft:  0x5b,
+    backslash:    0x5c,
+    bracketRight: 0x5d,
+    asciiCircum:  0x5e,
+    underscore:   0x5f,
+    quoteLeft:    0x60,
+    // 0x61-0x7a are unused, in ASCII they're the uppercase letters
+    braceLeft:    0x7b,
+    bar:          0x7c,
+    braceRight:   0x7d,
+    asciiTilde:   0x7e,
+
+    "[":          0x5b,
+    "\\":         0x5c,
+    "]":          0x5d,
+    "^":          0x5e,
+    "_":          0x5f,
+    "`":          0x60,
+    "{":          0x7b,
+    "|":          0x7c,
+    "}":          0x7d,
+    "~":          0x7e,
+
+    escape:     0x01000000,
+    tab:        0x01000001,
+    backTab:    0x01000002,
+    backspace:  0x01000003,
+    /** The 'return' or 'enter' key on the main part of the keyboard. */
+    return:     0x01000004,
+    /** The 'enter' key on the numpad. */
+    enter:      0x01000005,
+    insert:     0x01000006,
+    delete:     0x01000007,
+    /** Pause/Break key */
+    pause:      0x01000008,
+    print:      0x01000009,
+    sysReq:     0x0100000a,
+    clear:      0x0100000b,
+    // 0x0100000c-0x0100000f are unused
+    home:       0x01000010,
+    end:        0x01000011,
+    /** Left arrow key */
+    left:       0x01000012,
+    /** Up arrow key */
+    up:         0x01000013,
+    /** Right arrow key */
+    right:      0x01000014,
+    /** Down arrow key */
+    down:       0x01000015,
+    pageUp:     0x01000016,
+    pageDown:   0x01000017,
+    /** May be either the left or right shift key. */
+    shift:      0x01000020,
+    /** Translated to the Command key on macOS. May be either the left or right control key. */
+    control:    0x01000021,
+    /** Also known as the Windows key. Translated to Control on macOS. May be either the left or right meta key. */
+    meta:       0x01000022,
+    /** May be either the left or right alt key. */
+    alt:        0x01000023,
+    capsLock:   0x01000024,
+    numLock:    0x01000025,
+    scrollLock: 0x01000026,
+
+    f1:         0x01000030,
+    f2:         0x01000031,
+    f3:         0x01000032,
+    f4:         0x01000033,
+    f5:         0x01000034,
+    f6:         0x01000035,
+    f7:         0x01000036,
+    f8:         0x01000037,
+    f9:         0x01000038,
+    f10:        0x01000039,
+    f11:        0x0100003a,
+    f12:        0x0100003b,
+};


### PR DESCRIPTION
Script API for injecting `KeyEvent` to Interface, and a module with named constants for common keycodes (I got tired of looking up `Qt::Key` and writing constants for them in my own scripts when receiving `Controller.key{Press,Release}Event` lol)

Considered locking this behind QML only, but it'd need to be exposed to Web entity QML for a virtual keyboard, which has the same security as the other script permissions anyway (`file://` and `qrc:/` allowed, `http(s)://` blocked unless the script is given special permission thru the permission settings dialog)

### Testing
[key-injection.js](https://raw.githubusercontent.com/ada-tv/overte-scripts/refs/heads/main/tests/key-injection.js)

Presses the W key, waits two seconds, and then releases it

Should work when run from `file://`, should be blocked when run from `http://` (ie with `python -m http.server` or directly from the github link)

---

Closes #1829