### PR TITLE
Use int handles for script timers instead of QTimer*

### DIFF
--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -1171,32 +1171,37 @@ void ScriptManager::run() {
 // NOTE: This is private because it must be called on the same thread that created the timers, which is why
 // we want to only call it in our own run "shutdown" processing.
 void ScriptManager::stopAllTimers() {
-    QMutableHashIterator<QTimer*, CallbackData> i(_timerFunctionMap);
-    int j {0};
-    while (i.hasNext()) {
-        i.next();
-        QTimer* timer = i.key();
-        qCDebug(scriptengine) << getFilename() << "stopAllTimers[" << j++ << "]";
-        stopTimer(timer);
+    for (const auto& [handle, value] : _timerFunctionMap) {
+        QTimer* timer = std::get<0>(value);
+
+        timer->stop();
+        delete timer;
     }
+
+    _timerFunctionMap.clear();
+    _timerHandleCounter = 1;
 }
 
 void ScriptManager::stopAllTimersForEntityScript(const EntityItemID& entityID) {
-     // We could maintain a separate map of entityID => QTimer, but someone will have to prove to me that it's worth the complexity. -HRS
-    QVector<QTimer*> toDelete;
-    QMutableHashIterator<QTimer*, CallbackData> i(_timerFunctionMap);
-    while (i.hasNext()) {
-        i.next();
-        if (i.value().definingEntityIdentifier != entityID) {
-            continue;
-        }
-        QTimer* timer = i.key();
-        toDelete << timer; // don't delete while we're iterating. save it.
-    }
-    for (auto timer:toDelete) { // now reap 'em
-        stopTimer(timer);
+    std::vector<int> toDelete;
+
+    for (const auto& [handle, value] : _timerFunctionMap) {
+        const auto& [timer, callbackData] = value;
+
+        if (callbackData.definingEntityIdentifier != entityID) { continue; }
+
+        timer->stop();
+        delete timer;
+
+        toDelete.push_back(handle);
     }
 
+    for (auto handle : toDelete) {
+        _timerFunctionMap.erase(handle);
+    }
+
+    // the timer map is potentially shared across multiple entity scripts,
+    // so don't clear it or reset the handle counter
 }
 
 void ScriptManager::stop(bool marshal) {
@@ -1220,7 +1225,7 @@ void ScriptManager::updateMemoryCost(const qint64& deltaSize) {
     _engine->updateMemoryCost(deltaSize);
 }
 
-void ScriptManager::timerFired() {
+void ScriptManager::timerFired(int handle) {
     if (isStopped()) {
         scriptWarningMessage("Script.timerFired() while shutting down is ignored... parent script:" + getFilename(), getFilename(), -1);
         return; // bail early
@@ -1242,25 +1247,29 @@ void ScriptManager::timerFired() {
     callTimer.start();
 #endif
 
-    QTimer* callingTimer = reinterpret_cast<QTimer*>(sender());
-    CallbackData timerData = _timerFunctionMap.value(callingTimer);
+    if (!_timerFunctionMap.contains(handle)) {
+        qCWarning(scriptengine) << "timerFired -- not in _timerFunctionMap" << handle;
+        return;
+    }
 
-    if (!callingTimer->isActive()) {
+    auto [timer, data] = _timerFunctionMap.at(handle);
+
+    if (!timer->isActive()) {
         // this timer is done, we can kill it
-        _timerFunctionMap.remove(callingTimer);
-        delete callingTimer;
+        _timerFunctionMap.erase(handle);
+        delete timer;
     }
 
     // call the associated JS function, if it exists
-    if (timerData.function.isValid()) {
+    if (data.function.isValid()) {
         PROFILE_RANGE(script, __FUNCTION__);
         auto preTimer = p_high_resolution_clock::now();
-        callWithEnvironment(timerData.definingEntityIdentifier, timerData.definingSandboxURL, timerData.function, timerData.function, ScriptValueList());
+        callWithEnvironment(data.definingEntityIdentifier, data.definingSandboxURL, data.function, data.function, ScriptValueList());
         auto postTimer = p_high_resolution_clock::now();
         auto elapsed = (postTimer - preTimer);
         _totalTimerExecution += std::chrono::duration_cast<std::chrono::microseconds>(elapsed);
     } else {
-        qCWarning(scriptengine) << "timerFired -- invalid function" << timerData.function.toVariant().toString();
+        qCWarning(scriptengine) << "timerFired -- invalid function" << data.function.toVariant().toString();
     }
 
 #ifdef SCRIPT_TIMER_PERFORMANCE_STATISTICS
@@ -1268,7 +1277,10 @@ void ScriptManager::timerFired() {
 #endif
 }
 
-QTimer* ScriptManager::setupTimerWithInterval(const ScriptValue& function, int intervalMS, bool isSingleShot) {
+int ScriptManager::setupTimerWithInterval(const ScriptValue& function, int intervalMS, bool isSingleShot) {
+    int handle = _timerHandleCounter;
+    _timerHandleCounter += 1;
+
     // create the timer, add it to the map, and start it
     QTimer* newTimer = new QTimer(this);
     newTimer->setSingleShot(isSingleShot);
@@ -1279,14 +1291,13 @@ QTimer* ScriptManager::setupTimerWithInterval(const ScriptValue& function, int i
         newTimer->setTimerType(Qt::PreciseTimer);
     }
 
-    connect(newTimer, &QTimer::timeout, this, &ScriptManager::timerFired);
+    connect(newTimer, &QTimer::timeout, [this, handle]() { timerFired(handle); });
 
     // make sure the timer stops when the script does
     connect(this, &ScriptManager::scriptEnding, newTimer, &QTimer::stop);
 
-
     CallbackData timerData = { function, currentEntityIdentifier, currentSandboxURL };
-    _timerFunctionMap.insert(newTimer, timerData);
+    _timerFunctionMap.insert({ handle, { newTimer, timerData } });
 
     if (intervalMS < 0) {
         int lineNumber = -1;
@@ -1302,10 +1313,10 @@ QTimer* ScriptManager::setupTimerWithInterval(const ScriptValue& function, int i
         newTimer->start(intervalMS);
     }
 
-    return newTimer;
+    return handle;
 }
 
-QTimer* ScriptManager::setInterval(const ScriptValue& function, int intervalMS) {
+int ScriptManager::setInterval(const ScriptValue& function, int intervalMS) {
     if (isStopped()) {
         int lineNumber = -1;
         QString fileName = getFilename();
@@ -1315,13 +1326,13 @@ QTimer* ScriptManager::setInterval(const ScriptValue& function, int intervalMS) 
             fileName = context->currentFileName();
         }
         scriptWarningMessage("Script.setInterval() while shutting down is ignored... parent script:" + getFilename(), fileName, lineNumber);
-        return NULL; // bail early
+        return 0; // bail early
     }
 
     return setupTimerWithInterval(function, intervalMS, false);
 }
 
-QTimer* ScriptManager::setTimeout(const ScriptValue& function, int timeoutMS) {
+int ScriptManager::setTimeout(const ScriptValue& function, int timeoutMS) {
     if (isStopped()) {
         int lineNumber = -1;
         QString fileName = getFilename();
@@ -1331,19 +1342,20 @@ QTimer* ScriptManager::setTimeout(const ScriptValue& function, int timeoutMS) {
             fileName = context->currentFileName();
         }
         scriptWarningMessage("Script.setTimeout() while shutting down is ignored... parent script:" + getFilename(), fileName, lineNumber);
-        return NULL; // bail early
+        return 0; // bail early
     }
 
     return setupTimerWithInterval(function, timeoutMS, true);
 }
 
-void ScriptManager::stopTimer(QTimer *timer) {
-    if (_timerFunctionMap.contains(timer)) {
+void ScriptManager::stopTimer(int handle) {
+    if (_timerFunctionMap.contains(handle)) {
+        auto [timer, callbackData] = _timerFunctionMap.at(handle);
         timer->stop();
-        _timerFunctionMap.remove(timer);
+        _timerFunctionMap.erase(handle);
         delete timer;
     } else {
-        qCDebug(scriptengine) << "stopTimer -- not in _timerFunctionMap" << timer;
+        qCDebug(scriptengine) << "stopTimer -- not in _timerFunctionMap" << handle;
     }
 }
 

--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -1171,8 +1171,8 @@ void ScriptManager::run() {
 // NOTE: This is private because it must be called on the same thread that created the timers, which is why
 // we want to only call it in our own run "shutdown" processing.
 void ScriptManager::stopAllTimers() {
-    for (const auto& [handle, value] : _timerFunctionMap) {
-        QTimer* timer = std::get<0>(value);
+    for (const auto& pair : _timerFunctionMap) {
+        QTimer* timer = std::get<0>(pair);
 
         timer->stop();
         delete timer;
@@ -1183,10 +1183,15 @@ void ScriptManager::stopAllTimers() {
 }
 
 void ScriptManager::stopAllTimersForEntityScript(const EntityItemID& entityID) {
-    std::vector<int> toDelete;
+    std::vector<int> toDelete = {};
 
-    for (const auto& [handle, value] : _timerFunctionMap) {
-        const auto& [timer, callbackData] = value;
+    for (
+        auto i = _timerFunctionMap.constKeyValueBegin();
+        i != _timerFunctionMap.constKeyValueEnd();
+        ++i
+    ) {
+        const auto& handle = i->first;
+        const auto& [timer, callbackData] = i->second;
 
         if (callbackData.definingEntityIdentifier != entityID) { continue; }
 
@@ -1197,7 +1202,7 @@ void ScriptManager::stopAllTimersForEntityScript(const EntityItemID& entityID) {
     }
 
     for (auto handle : toDelete) {
-        _timerFunctionMap.erase(handle);
+        _timerFunctionMap.remove(handle);
     }
 
     // the timer map is potentially shared across multiple entity scripts,
@@ -1252,11 +1257,11 @@ void ScriptManager::timerFired(int handle) {
         return;
     }
 
-    auto [timer, data] = _timerFunctionMap.at(handle);
+    auto [timer, data] = _timerFunctionMap.value(handle);
 
     if (!timer->isActive()) {
         // this timer is done, we can kill it
-        _timerFunctionMap.erase(handle);
+        _timerFunctionMap.remove(handle);
         delete timer;
     }
 
@@ -1278,8 +1283,7 @@ void ScriptManager::timerFired(int handle) {
 }
 
 int ScriptManager::setupTimerWithInterval(const ScriptValue& function, int intervalMS, bool isSingleShot) {
-    int handle = _timerHandleCounter;
-    _timerHandleCounter += 1;
+    int handle = _timerHandleCounter++;
 
     // create the timer, add it to the map, and start it
     QTimer* newTimer = new QTimer(this);
@@ -1297,7 +1301,7 @@ int ScriptManager::setupTimerWithInterval(const ScriptValue& function, int inter
     connect(this, &ScriptManager::scriptEnding, newTimer, &QTimer::stop);
 
     CallbackData timerData = { function, currentEntityIdentifier, currentSandboxURL };
-    _timerFunctionMap.insert({ handle, { newTimer, timerData } });
+    _timerFunctionMap.insert(handle, { newTimer, timerData });
 
     if (intervalMS < 0) {
         int lineNumber = -1;
@@ -1350,9 +1354,9 @@ int ScriptManager::setTimeout(const ScriptValue& function, int timeoutMS) {
 
 void ScriptManager::stopTimer(int handle) {
     if (_timerFunctionMap.contains(handle)) {
-        auto [timer, callbackData] = _timerFunctionMap.at(handle);
+        auto [timer, callbackData] = _timerFunctionMap.value(handle);
         timer->stop();
-        _timerFunctionMap.erase(handle);
+        _timerFunctionMap.remove(handle);
         delete timer;
     } else {
         qCDebug(scriptengine) << "stopTimer -- not in _timerFunctionMap" << handle;

--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -14,6 +14,7 @@
 #include "ScriptManager.h"
 
 #include <chrono>
+#include <memory>
 #include <thread>
 
 #include <QtCore/QCoreApplication>
@@ -1171,40 +1172,12 @@ void ScriptManager::run() {
 // NOTE: This is private because it must be called on the same thread that created the timers, which is why
 // we want to only call it in our own run "shutdown" processing.
 void ScriptManager::stopAllTimers() {
-    for (const auto& pair : _timerFunctionMap) {
-        QTimer* timer = std::get<0>(pair);
-
-        timer->stop();
-        delete timer;
-    }
-
     _timerFunctionMap.clear();
     _timerHandleCounter = 1;
 }
 
 void ScriptManager::stopAllTimersForEntityScript(const EntityItemID& entityID) {
-    std::vector<int> toDelete = {};
-
-    for (
-        auto i = _timerFunctionMap.constKeyValueBegin();
-        i != _timerFunctionMap.constKeyValueEnd();
-        ++i
-    ) {
-        const auto& handle = i->first;
-        const auto& [timer, callbackData] = i->second;
-
-        if (callbackData.definingEntityIdentifier != entityID) { continue; }
-
-        timer->stop();
-        delete timer;
-
-        toDelete.push_back(handle);
-    }
-
-    for (auto handle : toDelete) {
-        _timerFunctionMap.remove(handle);
-    }
-
+    std::erase_if(_timerFunctionMap, [entityID](auto& i) { return i.second.second.definingEntityIdentifier == entityID; });
     // the timer map is potentially shared across multiple entity scripts,
     // so don't clear it or reset the handle counter
 }
@@ -1257,12 +1230,13 @@ void ScriptManager::timerFired(int handle) {
         return;
     }
 
-    auto [timer, data] = _timerFunctionMap.value(handle);
+    auto& functionPair = _timerFunctionMap[handle];
+    auto& timer = functionPair.first;
+    auto data = functionPair.second;
 
     if (!timer->isActive()) {
         // this timer is done, we can kill it
-        _timerFunctionMap.remove(handle);
-        delete timer;
+        _timerFunctionMap.erase(handle);
     }
 
     // call the associated JS function, if it exists
@@ -1286,7 +1260,9 @@ int ScriptManager::setupTimerWithInterval(const ScriptValue& function, int inter
     int handle = _timerHandleCounter++;
 
     // create the timer, add it to the map, and start it
-    QTimer* newTimer = new QTimer(this);
+    CallbackData timerData = { function, currentEntityIdentifier, currentSandboxURL };
+    auto& newTimer =
+        _timerFunctionMap.emplace(handle, std::make_pair(std::make_unique<QTimer>(), timerData)).first->second.first;
     newTimer->setSingleShot(isSingleShot);
 
     // The default timer type is not very accurate below about 200ms http://doc.qt.io/qt-5/qt.html#TimerType-enum
@@ -1295,13 +1271,7 @@ int ScriptManager::setupTimerWithInterval(const ScriptValue& function, int inter
         newTimer->setTimerType(Qt::PreciseTimer);
     }
 
-    connect(newTimer, &QTimer::timeout, [this, handle]() { timerFired(handle); });
-
-    // make sure the timer stops when the script does
-    connect(this, &ScriptManager::scriptEnding, newTimer, &QTimer::stop);
-
-    CallbackData timerData = { function, currentEntityIdentifier, currentSandboxURL };
-    _timerFunctionMap.insert(handle, { newTimer, timerData });
+    connect(newTimer.get(), &QTimer::timeout, [this, handle]() { timerFired(handle); });
 
     if (intervalMS < 0) {
         int lineNumber = -1;
@@ -1354,10 +1324,7 @@ int ScriptManager::setTimeout(const ScriptValue& function, int timeoutMS) {
 
 void ScriptManager::stopTimer(int handle) {
     if (_timerFunctionMap.contains(handle)) {
-        auto [timer, callbackData] = _timerFunctionMap.value(handle);
-        timer->stop();
-        _timerFunctionMap.remove(handle);
-        delete timer;
+        _timerFunctionMap.erase(handle);
     } else {
         qCDebug(scriptengine) << "stopTimer -- not in _timerFunctionMap" << handle;
     }

--- a/libraries/script-engine/src/ScriptManager.h
+++ b/libraries/script-engine/src/ScriptManager.h
@@ -763,9 +763,9 @@ public:
     *
     * @param function Function to call
     * @param intervalMS Interval at which to call the function, in ms
-    * @return QTimer* A pointer to the timer
+    * @return int A handle for the timer
     */
-    Q_INVOKABLE QTimer* setInterval(const ScriptValue& function, int intervalMS);
+    Q_INVOKABLE int setInterval(const ScriptValue& function, int intervalMS);
 
 
     /**
@@ -775,41 +775,23 @@ public:
      *
      * @param function Function to call
      * @param timeoutMS How long to wait before calling the function, in ms
-     * @return QTimer* A pointer to the timer
+     * @return int A handle for the timer
      */
-    Q_INVOKABLE QTimer* setTimeout(const ScriptValue& function, int timeoutMS);
+    Q_INVOKABLE int setTimeout(const ScriptValue& function, int timeoutMS);
 
     /**
      * @brief Stops an interval timer
      *
      * @param timer Timer to stop
      */
-    Q_INVOKABLE void clearInterval(QTimer* timer) { stopTimer(timer); }
-
-    /**
-     * @brief Stops an interval timer
-     *
-     * Overloaded version is needed in case the timer has expired
-     *
-     * @param timer Timer to stop
-     */
-    Q_INVOKABLE void clearInterval(QVariantMap timer) { ; }
+    Q_INVOKABLE void clearInterval(int timer) { stopTimer(timer); }
 
     /**
      * @brief Stops a timeout timer
      *
      * @param timer Timer to stop
      */
-    Q_INVOKABLE void clearTimeout(QTimer* timer) { stopTimer(timer); }
-
-    /**
-     * @brief Stops a timeout timer
-     * Overloaded version is needed in case the timer has expired
-     *
-     * @param timer Timer to stop
-     */
-
-    Q_INVOKABLE void clearTimeout(QVariantMap timer) { ; }
+    Q_INVOKABLE void clearTimeout(int timer) { stopTimer(timer); }
 
 
     /**
@@ -1562,7 +1544,7 @@ protected:
      * @return QString Exception formatted as a string
      */
     QString logException(const ScriptValue& exception);
-    void timerFired();
+    void timerFired(int timer);
     void stopAllTimers();
     void stopAllTimersForEntityScript(const EntityItemID& entityID);
     void refreshFileScript(const EntityItemID& entityID, const QString& scriptURL);
@@ -1604,16 +1586,16 @@ protected:
      * @param function Function to call when the interval elapses
      * @param intervalMS Interval in milliseconds
      * @param isSingleShot Whether the timer happens continuously or a single time
-     * @return QTimer*
+     * @return int
      */
-    QTimer* setupTimerWithInterval(const ScriptValue& function, int intervalMS, bool isSingleShot);
+    int setupTimerWithInterval(const ScriptValue& function, int intervalMS, bool isSingleShot);
 
     /**
      * @brief Stops a timer
      *
-     * @param timer Timer to stop
+     * @param int Timer to stop
      */
-    void stopTimer(QTimer* timer);
+    void stopTimer(int timer);
 
     QHash<EntityItemID, RegisteredEventHandlers> _registeredHandlers;
 
@@ -1678,7 +1660,8 @@ protected:
     std::atomic<bool> _isDoneRunning { false };
     bool _areMetaTypesInitialized { false };
     bool _isInitialized { false };
-    QHash<QTimer*, CallbackData> _timerFunctionMap;
+    std::unordered_map<int, std::tuple<QTimer*, CallbackData>> _timerFunctionMap;
+    int _timerHandleCounter { 1 };
     QSet<QUrl> _includedURLs;
     mutable QReadWriteLock _entityScriptsLock { QReadWriteLock::Recursive };
     QHash<EntityItemID, QHash<QString, EntityScriptDetails>> _entityScripts;

--- a/libraries/script-engine/src/ScriptManager.h
+++ b/libraries/script-engine/src/ScriptManager.h
@@ -1660,7 +1660,7 @@ protected:
     std::atomic<bool> _isDoneRunning { false };
     bool _areMetaTypesInitialized { false };
     bool _isInitialized { false };
-    std::unordered_map<int, std::tuple<QTimer*, CallbackData>> _timerFunctionMap;
+    QHash<int, std::pair<QTimer*, CallbackData>> _timerFunctionMap;
     int _timerHandleCounter { 1 };
     QSet<QUrl> _includedURLs;
     mutable QReadWriteLock _entityScriptsLock { QReadWriteLock::Recursive };

--- a/libraries/script-engine/src/ScriptManager.h
+++ b/libraries/script-engine/src/ScriptManager.h
@@ -1660,7 +1660,7 @@ protected:
     std::atomic<bool> _isDoneRunning { false };
     bool _areMetaTypesInitialized { false };
     bool _isInitialized { false };
-    QHash<int, std::pair<QTimer*, CallbackData>> _timerFunctionMap;
+    std::map<int, std::pair<std::unique_ptr<QTimer>, CallbackData>> _timerFunctionMap;
     int _timerHandleCounter { 1 };
     QSet<QUrl> _includedURLs;
     mutable QReadWriteLock _entityScriptsLock { QReadWriteLock::Recursive };

--- a/libraries/script-engine/src/ScriptManagerScriptingInterface.h
+++ b/libraries/script-engine/src/ScriptManagerScriptingInterface.h
@@ -298,26 +298,26 @@ public:
      * @function Script.setInterval
      * @param {function} function - The function to call. This can be either the name of a function or an in-line definition.
      * @param {number} interval - The interval at which to call the function, in ms.
-     * @returns {object} A handle to the interval timer. This can be used in {@link Script.clearInterval}.
+     * @returns {number} A handle to the interval timer. This can be used in {@link Script.clearInterval}.
      * @example <caption>Print a message every second.</caption>
      * Script.setInterval(function () {
      *     print("Interval timer fired");
      * }, 1000);
     */
-    Q_INVOKABLE QTimer* setInterval(const ScriptValue& function, int intervalMS) { return _manager->setInterval(function, intervalMS); }
+    Q_INVOKABLE int setInterval(const ScriptValue& function, int intervalMS) { return _manager->setInterval(function, intervalMS); }
 
     /*@jsdoc
      * Calls a function once, after a delay.
      * @function Script.setTimeout
      * @param {function} function - The function to call. This can be either the name of a function or an in-line definition.
      * @param {number} timeout - The delay after which to call the function, in ms.
-     * @returns {object} A handle to the timeout timer. This can be used in {@link Script.clearTimeout}.
+     * @returns {number} A handle to the timeout timer. This can be used in {@link Script.clearTimeout}.
      * @example <caption>Print a message once, after a second.</caption>
      * Script.setTimeout(function () {
      *     print("Timeout timer fired");
      * }, 1000);
      */
-    Q_INVOKABLE QTimer* setTimeout(const ScriptValue& function, int timeoutMS) { return _manager->setTimeout(function, timeoutMS); };
+    Q_INVOKABLE int setTimeout(const ScriptValue& function, int timeoutMS) { return _manager->setTimeout(function, timeoutMS); };
 
     /*@jsdoc
      * Stops an interval timer set by {@link Script.setInterval|setInterval}.
@@ -335,10 +335,7 @@ public:
      *     Script.clearInterval(timer);
      * }, 10000);
      */
-    Q_INVOKABLE void clearInterval(QTimer* timer) { _manager->clearInterval(timer); }
-
-    // Overloaded version is needed in case the timer has expired
-    Q_INVOKABLE void clearInterval(QVariantMap timer) { ; }
+    Q_INVOKABLE void clearInterval(int timer) { _manager->clearInterval(timer); }
 
     /*@jsdoc
      * Stops a timeout timer set by {@link Script.setTimeout|setTimeout}.
@@ -353,10 +350,7 @@ public:
      * // Uncomment the following line to stop the timer from firing.
      * //Script.clearTimeout(timer);
      */
-    Q_INVOKABLE void clearTimeout(QTimer* timer) { _manager->clearTimeout(timer); }
-
-    // Overloaded version is needed in case the timer has expired
-    Q_INVOKABLE void clearTimeout(QVariantMap timer) { ; }
+    Q_INVOKABLE void clearTimeout(int timer) { _manager->clearTimeout(timer); }
 
     /*@jsdoc
      * Prints a message to the program log and emits {@link Script.printedMessage}.


### PR DESCRIPTION
[`Script.setTimeout` and `Script.setInterval` now have mostly-standard JS timer return values](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#return_value)

The timer handle map is per-context, so calling `clearTimeout` on a handle exposed by a module won't work properly.

Should fix #2098

### Test script
* Master logs warnings about invalid proxy objects because the `QTimer*` deletes itself or something
* This PR will instead log a warning when trying to cancel an expired timer (should also resolve the `QVariantMap` to `QTimer*` conversion error in #2098, but I'm not 100% sure how else to reproduce it)

```js
let t1 = Script.setTimeout(() => console.info("test timeout"), 1000);

Script.setTimeout(() => {
	console.info("trying to cancel an expired timeout", t1);
	Script.clearTimeout(t1);
}, 2000);

Script.setTimeout(() => {
	console.info("trying to cancel a canceled timeout", t1);
	Script.clearTimeout(t1);
}, 3000);

let t2 = Script.setTimeout(() => console.info("test timeout 2"), 5000);

Script.setTimeout(() => {
	console.info("canceling a timeout normally, before it expires", t2);
	Script.clearTimeout(t2);
}, 4000);
```