### PR TITLE
Qt5 source AppImages: CI

### DIFF
--- a/.github/actions/conan-install/action.yml
+++ b/.github/actions/conan-install/action.yml
@@ -23,5 +23,6 @@ runs:
     run: |
       # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
       # `--format=json > build.json` creates a graph of dependencies, which can later be used to check for cache misses.
-      conan install . -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o 'Overte/*:qt_source='${{ inputs.qt_source }} -b missing -pr=${{ inputs.conan_profile }} -of build --format=json > build.json
+      # `--build="glib/*"` works around https://github.com/conan-io/conan-center-index/issues/17876 by always building glib from source, instead of using the too outdated binary cache on ConanCenter.
+      conan install . -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o 'Overte/*:qt_source='${{ inputs.qt_source }} -b missing --build="glib/*" -pr=${{ inputs.conan_profile }} -of build --format=json > build.json
       conan install . -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o 'Overte/*:qt_source='${{ inputs.qt_source }} -b missing -pr=${{ inputs.conan_profile }} -of build

--- a/.github/actions/conan-install/action.yml
+++ b/.github/actions/conan-install/action.yml
@@ -23,6 +23,5 @@ runs:
     run: |
       # Run twice to work around OpenSSL not being found. See: https://github.com/overte-org/overte-conan-recipes/issues/1
       # `--format=json > build.json` creates a graph of dependencies, which can later be used to check for cache misses.
-      # `--build="glib/*"` works around https://github.com/conan-io/conan-center-index/issues/17876 by always building glib from source, instead of using the too outdated binary cache on ConanCenter.
-      conan install . -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o 'Overte/*:qt_source='${{ inputs.qt_source }} -b missing --build="glib/*" -pr=${{ inputs.conan_profile }} -of build --format=json > build.json
+      conan install . -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o 'Overte/*:qt_source='${{ inputs.qt_source }} -b missing -pr=${{ inputs.conan_profile }} -of build --format=json > build.json
       conan install . -s compiler.cppstd=${{ inputs.cppstd }} -s build_type=${{ inputs.build_type }} -o 'Overte/*:qt_source='${{ inputs.qt_source }} -b missing -pr=${{ inputs.conan_profile }} -of build

--- a/.github/actions/debug-info/action.yml
+++ b/.github/actions/debug-info/action.yml
@@ -9,14 +9,22 @@ runs:
       continue-on-error: true
       run: df -h
 
+    - name: Output system statistics
+      if: ${{ always() }}
+      shell: bash
+      continue-on-error: true
+      run: |
+        lscpu || true
+        lsblk || true
+        free --human || true
+
     - name: Output Windows installer logs
       if: startsWith(matrix.os, 'Windows')
       shell: bash
-      working-directory: build
-      run: cat ./_CPack_Packages/win64/NSIS/NSISOutput.log || echo "No NSIS log found. Continuing…"
+      run: cat ./build/_CPack_Packages/win64/NSIS/NSISOutput.log || echo "No NSIS log found. Continuing…"
 
     - name: Output CodeChecker JSON compilation database
       if: matrix.id == 'codechecker'
       shell: bash
       continue-on-error: true
-      run: cat ${{ env.GITHUB_WORKSPACE }}/codechecker_codechecker_compilation_database.json
+      run: cat ${{ env.GITHUB_WORKSPACE }}/codechecker_codechecker_compilation_database.json || echo "No CodeChecker compilation database found. Continuing…"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
             rendering_backend: OpenGL  # Which OVERTE_RENDERING_BACKEND to build.
           - id: ubuntu-opengl-amd64
             os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
+            image: docker.io/overte/overte-full-build:2026-06-21-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
             runner: depot-ubuntu-24.04-16
             arch: amd64
             cmake_build_type: Release
@@ -81,7 +81,7 @@ jobs:
             rendering_backend: OpenGL
           - id: ubuntu-vulkan-amd64
             os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-amd64
+            image: docker.io/overte/overte-full-build:2026-06-21-ubuntu-22.04-amd64
             runner: depot-ubuntu-24.04-16
             arch: amd64
             cmake_build_type: Release
@@ -89,7 +89,7 @@ jobs:
             rendering_backend: Vulkan
           - id: ubuntu-opengl-aarch64
             os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-aarch64
+            image: docker.io/overte/overte-full-build:2026-06-21-ubuntu-22.04-aarch64
             runner: depot-ubuntu-24.04-arm-16
             arch: aarch64
             cmake_build_type: Release
@@ -97,7 +97,7 @@ jobs:
             rendering_backend: OpenGL
           - id: ubuntu-vulkan-aarch64
             os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-aarch64
+            image: docker.io/overte/overte-full-build:2026-06-21-ubuntu-22.04-aarch64
             runner: depot-ubuntu-24.04-arm-16
             arch: aarch64
             cmake_build_type: Release
@@ -105,7 +105,7 @@ jobs:
             rendering_backend: Vulkan
           - id: codechecker
             os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-amd64
+            image: docker.io/overte/overte-full-build:2026-06-21-ubuntu-22.04-amd64
             runner: depot-ubuntu-24.04-16
             arch: amd64
             cmake_build_type: Debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,10 @@ jobs:
             ${{ env.CONAN_HOME }}/sources
             ${{ env.CONAN_HOME }}/p
 
+    - name: Output debug information
+      if: always()
+      uses: ./.github/actions/debug-info
+
     - name: Install Conan dependencies
       uses: ./.github/actions/conan-install
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,8 @@ jobs:
           - id: codechecker
             os: Ubuntu 22.04
             image: docker.io/overte/overte-full-build:2026-06-21-ubuntu-22.04-amd64
-            runner: depot-ubuntu-24.04-16
+            # depot-ubuntu-24.04-16 runs out of disk space when building debug Qt.
+            runner: depot-ubuntu-24.04-32
             arch: amd64
             cmake_build_type: Debug
             qt_source: source

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,34 +74,34 @@ jobs:
           - id: ubuntu-opengl-amd64
             os: Ubuntu 22.04
             image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
-            runner: ubuntu-latest
+            runner: depot-ubuntu-24.04-16
             arch: amd64
             cmake_build_type: Release
-            qt_source: system
+            qt_source: source
             rendering_backend: OpenGL
           - id: ubuntu-vulkan-amd64
             os: Ubuntu 22.04
             image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-amd64
-            runner: ubuntu-latest
+            runner: depot-ubuntu-24.04-16
             arch: amd64
             cmake_build_type: Release
-            qt_source: system
+            qt_source: source
             rendering_backend: Vulkan
           - id: ubuntu-opengl-aarch64
             os: Ubuntu 22.04
             image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-aarch64
-            runner: ubuntu-24.04-arm
+            runner: depot-ubuntu-24.04-arm-16
             arch: aarch64
             cmake_build_type: Release
-            qt_source: system
+            qt_source: source
             rendering_backend: OpenGL
           - id: ubuntu-vulkan-aarch64
             os: Ubuntu 22.04
             image: docker.io/overte/overte-full-build:2026-06-12-ubuntu-22.04-aarch64
-            runner: ubuntu-24.04-arm
+            runner: depot-ubuntu-24.04-arm-16
             arch: aarch64
             cmake_build_type: Release
-            qt_source: system
+            qt_source: source
             rendering_backend: Vulkan
           - id: codechecker
             os: Ubuntu 22.04
@@ -109,7 +109,7 @@ jobs:
             runner: depot-ubuntu-24.04-16
             arch: amd64
             cmake_build_type: Debug
-            qt_source: system
+            qt_source: source
             rendering_backend: OpenGL
             job_name_prefix: 'CodeChecker '
       fail-fast: false

--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -49,6 +49,11 @@ Verify OpenGL:
   - First install mesa-utils with the command `sudo apt install mesa-utils -y`.
   - Then run `glxinfo | grep "OpenGL version"`.
 
+- Qt5 source package:
+```bash
+sudo apt install libpulse-dev libasound2-dev python3-html5lib
+```
+
 ## Extra dependencies to compile Interface on a server
 - Install the following:
 ```bash

--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -114,12 +114,12 @@ If you don't do this, Conan will still complain if it notices system packages be
 Install the dependencies with conan
 ```bash
 cd overte
-conan install . -s build_type=Release -b missing -pr:b=tools/conan-profiles/linux -of build -c tools.cmake.cmaketoolchain:generator="Ninja Multi-Config"
+conan install . -s build_type=Release -b missing -pr:a=tools/conan-profiles/linux -of build -c tools.cmake.cmaketoolchain:generator="Ninja Multi-Config"
 ```
 
 If you want to build Debug or RelWithDebInfo versions, change the `build_type` to `Debug` or `RelWithDebInfo` and run the command again. E.g.:
 ```bash
-conan install . -s build_type=Debug -b missing -pr:b=tools/conan-profiles/linux -of build -c tools.cmake.cmaketoolchain:generator="Ninja Multi-Config"
+conan install . -s build_type=Debug -b missing -pr:a=tools/conan-profiles/linux -of build -c tools.cmake.cmaketoolchain:generator="Ninja Multi-Config"
 ```
 
 Prepare ninja files:

--- a/cmake/macros/GenerateInstallers.cmake
+++ b/cmake/macros/GenerateInstallers.cmake
@@ -129,7 +129,9 @@ macro(GENERATE_INSTALLERS)
     endif()
 
     # Find and pass QMake to GenerateAppImage.cmake, since QMake tells linuxdeploy-plugin-qt where to find Qt.
-    find_package(Qt5 COMPONENTS qmake QUIET REQUIRED)
+    # system Qt5 on Debian doesn't have a Qt5qmakeConfig.cmake or qt5qmake-config.cmake file.
+    # On Qt6 we can try looking for the qmake component on system Qt again.
+    find_package(Qt5 COMPONENTS Core QUIET REQUIRED)
     get_target_property(Qt_qmake_Executable Qt5::qmake LOCATION)
     # Every variable starting with CPACK_* is automatically available inside CPack scripts.
     set(CPACK_QMAKE_EXECUTABLE ${Qt_qmake_Executable})

--- a/cmake/macros/GenerateInstallers.cmake
+++ b/cmake/macros/GenerateInstallers.cmake
@@ -129,14 +129,12 @@ macro(GENERATE_INSTALLERS)
     endif()
 
     # Find and pass QMake to GenerateAppImage.cmake, since QMake tells linuxdeploy-plugin-qt where to find Qt.
-    find_package(Qt5 COMPONENTS Core QUIET REQUIRED)
-    get_target_property(Qt_Core_Location Qt5::Core LOCATION)
-    get_filename_component(QT_BIN_DIR ${Qt_Core_Location} DIRECTORY)
-    find_program(QMAKE_EXECUTABLE qmake PATHS ${QT_BIN_DIR} PATH_SUFFIXES qt5/bin NO_DEFAULT_PATH)
+    find_package(Qt5 COMPONENTS qmake QUIET REQUIRED)
+    get_target_property(Qt_qmake_Executable Qt5::qmake LOCATION)
     # Every variable starting with CPACK_* is automatically available inside CPack scripts.
-    set(CPACK_QMAKE_EXECUTABLE ${QMAKE_EXECUTABLE})
+    set(CPACK_QMAKE_EXECUTABLE ${Qt_qmake_Executable})
     if (NOT CPACK_QMAKE_EXECUTABLE)
-        message(FATAL_ERROR "Could not find QMake at ${QT_BIN_DIR}. QMake is required by linuxdeploy-plugin-qt for finding Qt.")
+        message(FATAL_ERROR "Could not find QMake at ${Qt_qmake_Executable}. QMake is required by linuxdeploy-plugin-qt for finding Qt.")
     endif ()
     set(CPACK_OVERTE_RENDERING_BACKEND ${OVERTE_RENDERING_BACKEND})
   endif ()

--- a/conanfile.py
+++ b/conanfile.py
@@ -90,10 +90,12 @@ class Overte(ConanFile):
         if self.options.qt_source == "system":
             self.requires("qt/5.15.2@overte/system", force=True)
             if self.settings.os == "Linux":
-                openssl = "openssl/system@anotherfoxguy/stable"
+                openssl = "openssl/system@overte/stable#24c4df65c52791c4955f7d47d9faef0d"
         elif self.options.qt_source == "aqt":
             self.requires("qt/5.15.2@overte/aqt", force=True)
         else:
+            # Use system OpenSSL to work around OpenSSL being missing from libnode's rpath and this cascading down to Interface.
+            openssl = "openssl/system@overte/stable#24c4df65c52791c4955f7d47d9faef0d"
             self.requires("qt/5.15.18@overte/experimental#3a9079f3023351a7319be352cc6f4665", force=True)
 
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -94,8 +94,9 @@ class Overte(ConanFile):
         elif self.options.qt_source == "aqt":
             self.requires("qt/5.15.2@overte/aqt", force=True)
         else:
-            # Use system OpenSSL to work around OpenSSL being missing from libnode's rpath and this cascading down to Interface.
-            openssl = "openssl/system@overte/stable#24c4df65c52791c4955f7d47d9faef0d"
+            if self.settings.os == "Linux":
+                # Use system OpenSSL to work around OpenSSL being missing from libnode's rpath and this cascading down to Interface.
+                openssl = "openssl/system@overte/stable#24c4df65c52791c4955f7d47d9faef0d"
             self.requires("qt/5.15.18@overte/experimental#3a9079f3023351a7319be352cc6f4665", force=True)
 
         if self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,6 +98,8 @@ class Overte(ConanFile):
                 # Use system OpenSSL to work around OpenSSL being missing from libnode's rpath and this cascading down to Interface.
                 openssl = "openssl/system@overte/stable#24c4df65c52791c4955f7d47d9faef0d"
             self.requires("qt/5.15.18@overte/experimental#3a9079f3023351a7319be352cc6f4665", force=True)
+            # Replace Conan Center's glib package with our own duplicate to avoid their outdated binary cache. https://github.com/conan-io/conan-center-index/issues/17876
+            self.requires("glib/2.78.3@overte/conancenter", override=True)
 
         if self.settings.os == "Windows":
             self.requires("neuron/12.2@overte/prebuild")

--- a/conanfile.py
+++ b/conanfile.py
@@ -94,7 +94,7 @@ class Overte(ConanFile):
         elif self.options.qt_source == "aqt":
             self.requires("qt/5.15.2@overte/aqt", force=True)
         else:
-            self.requires("qt/5.15.18-2026.01.04@overte/stable#4fc772a2dbcd84731eb6ff9904e6e358", force=True)
+            self.requires("qt/5.15.18-2026.01.04@overte/experimental#42988562cdf97056b01d01c5f2c4df39", force=True)
 
         if self.settings.os == "Windows":
             self.requires("neuron/12.2@overte/prebuild")

--- a/conanfile.py
+++ b/conanfile.py
@@ -94,7 +94,7 @@ class Overte(ConanFile):
         elif self.options.qt_source == "aqt":
             self.requires("qt/5.15.2@overte/aqt", force=True)
         else:
-            self.requires("qt/5.15.18-2026.01.04@overte/experimental#42988562cdf97056b01d01c5f2c4df39", force=True)
+            self.requires("qt/5.15.18@overte/experimental#3a9079f3023351a7319be352cc6f4665", force=True)
 
         if self.settings.os == "Windows":
             self.requires("neuron/12.2@overte/prebuild")

--- a/conanfile.py
+++ b/conanfile.py
@@ -97,6 +97,7 @@ class Overte(ConanFile):
             if self.settings.os == "Linux":
                 # Use system OpenSSL to work around OpenSSL being missing from libnode's rpath and this cascading down to Interface.
                 openssl = "openssl/system@overte/stable#24c4df65c52791c4955f7d47d9faef0d"
+                self.requires("fcitx5-qt/5.1.13@overte/stable#41b7ae9082f32e1ad83fd8a43a2c8460")
             self.requires("qt/5.15.18@overte/experimental#3a9079f3023351a7319be352cc6f4665", force=True)
             # Replace Conan Center's glib package with our own duplicate to avoid their outdated binary cache. https://github.com/conan-io/conan-center-index/issues/17876
             self.requires("glib/2.78.3@overte/conancenter", override=True)

--- a/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte
-# Example build: docker build --no-cache --progress=plain -t overte/overte-full-build:2026-06-12-ubuntu-22.04-amd64 -f Dockerfile_build_ubuntu-22.04 .
+# Example build: docker build --no-cache --progress=plain -t overte/overte-full-build:2026-06-21-ubuntu-22.04-amd64 -f Dockerfile_build_ubuntu-22.04 .
 FROM ubuntu:22.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for full Overte builds"

--- a/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
@@ -64,6 +64,9 @@ libqt5multimedia5-plugins
 qt5-image-formats-plugins  # Runtime dependency required for WebP texture support.
 fcitx5-frontend-qt5  # Runtime dependency for IME support.
 npm  # For Interface's JavaScript console completion and building server-console.
+libpulse-dev  # Qt5 source Conan package cannot find it's own Pulseaudio
+libasound2-dev  # Qt5 source Conan package cannot find it's own ALSA
+python3-html5lib  # Qt5 source Conan package cannot install html5lib itself yet. (Required by Qt WebEngine.)
 # Tools for package creation
 sudo
 chrpath

--- a/tools/conan-profiles/linux
+++ b/tools/conan-profiles/linux
@@ -36,3 +36,4 @@ nss*:shared=True
 nspr*:shared=True
 # Work around `undefined reference` errors when building NSS.
 sqlite3*:shared=True
+qt*:with_dbus=True

--- a/tools/conan-profiles/linux
+++ b/tools/conan-profiles/linux
@@ -23,6 +23,8 @@ qt*:with_mysql=False
 qt*:with_pulseaudio=True
 # Required by qt:with_pulseaudio
 pulseaudio*:with_glib=True
+# PulseAudio cannot find system OpenSSL, so we just build without.
+pulseaudio*:with_openssl=False
 # Required for PulseAudio support in Qt.
 qt*:with_glib=True
 # libpq build error and not needed (PostgreSQL).


### PR DESCRIPTION
The Qt5 package source used is this one: https://github.com/overte-org/overte-conan-recipes/pull/51/changes
The Fcitx-Qt plugin source used: https://github.com/overte-org/overte-conan-recipes/pull/61

To work around `alsa/asoundlib.h` and `pulse/pulseaudio.h` not being found, `libasound2-dev` and `libpulse-dev` need to be installed. If I recall correctly neither of those are used on Qt6, so we won't need to manually install them in the future even without a proper fix.

Tested on Windows and Linux.