### PR TITLE
Dont build AppImage on system libs build

### DIFF
--- a/cmake/macros/GenerateInstallers.cmake
+++ b/cmake/macros/GenerateInstallers.cmake
@@ -111,7 +111,7 @@ macro(GENERATE_INSTALLERS)
       # hide the special Icon? file
       install(CODE "execute_process(COMMAND SetFile -a V \${CMAKE_INSTALL_PREFIX}/${ESCAPED_DMG_SUBFOLDER_NAME}/Icon\\r)")
     endif ()
-  elseif (LINUX)
+  elseif (LINUX AND NOT OVERTE_USE_SYSTEM_LIBS)
     # Produce Interface AppImage using our own scripts.
     set(CPACK_GENERATOR "External")
 


### PR DESCRIPTION
Master fails to build on nixos with `OVERTE_USE_SYSTEM_LIBS=ON` due to trying to build with AppImage build.

@JulianGro (you kinda broke it and made me aware of the issue, lol)