### PR TITLE
Fix NaN blotches and super bright single-pixel sparkles on bloom

### DIFF
--- a/libraries/render-utils/src/ShadingModel.slh
+++ b/libraries/render-utils/src/ShadingModel.slh
@@ -99,7 +99,9 @@ float specularDistribution(SurfaceData surface) {
     float smithInvG1NdotL = evalSmithInvG1(surface.roughness4, surface.ndotl);
     denom *= surface.smithInvG1NdotV * smithInvG1NdotL;
     // Don't divide by PI as this is part of the light normalization factor
-    float power = surface.roughness4 / denom;
+    // NOTE: Epsilon limit has to be here or infinities and unreasonably-bright
+    // pixels can sneak in and break the bloom pass rendering
+    float power = surface.roughness4 / max(0.001, denom);
     return power;
 }
 


### PR DESCRIPTION
Fixes #2081
I *think* this fixes #1231 too, before the tutorial had lots of single-pixel sparkles on the tree leaves which are gone with this PR

### Before
<img width="681" height="497" alt="image" src="https://github.com/user-attachments/assets/6c1fa3d6-9b91-4c09-a530-6b8b3787a70c" />

### After
<img width="680" height="496" alt="image" src="https://github.com/user-attachments/assets/349d103a-fa50-497a-aed9-495e463c24c1" />