### PR TITLE
Fix invisible CONFIRM button in Avatar App popups

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/MessageBoxes.qml
+++ b/interface/resources/qml/hifi/avatarapp/MessageBoxes.qml
@@ -4,6 +4,7 @@ MessageBox {
     id: popup
 
     function showSpecifyAvatarUrl(url, callback, linkCallback) {
+        popup.dialogButtons.yesButton.visible = true;
         popup.onButton2Clicked = callback;
         popup.titleText = 'Specify Avatar URL'
         popup.bodyText = 'This will not overwrite your existing favorite if you are wearing one.<br>' +
@@ -36,6 +37,7 @@ MessageBox {
     }
 
     function showSpecifyWearableUrl(callback) {
+        popup.dialogButtons.yesButton.visible = true;
         popup.button2text = 'CONFIRM'
         popup.button1text = 'CANCEL'
         popup.titleText = 'Specify Wearable URL'
@@ -57,6 +59,7 @@ MessageBox {
     }
 
     function showDeleteFavorite(favoriteName, callback) {
+        popup.dialogButtons.yesButton.visible = true;
         popup.titleText = 'Delete Favorite: {AvatarName}'.replace('{AvatarName}', favoriteName)
         popup.bodyText = 'This will delete your favorite. You will retain access to the wearables and avatar that made up the favorite from Inventory.'
         popup.imageSource = null;
@@ -74,6 +77,7 @@ MessageBox {
     }
 
     function showLoadFavorite(favoriteName, callback) {
+        popup.dialogButtons.yesButton.visible = true;
         popup.button2text = 'CONFIRM'
         popup.button1text = 'CANCEL'
         popup.titleText = 'Load Favorite: {AvatarName}'.replace('{AvatarName}', favoriteName)


### PR DESCRIPTION
Saw this bug appear in the wild https://youtu.be/C88PzyVCpa8?t=250 and realized I wasn't the only one.  Just a quick fix because I think I heard somewhere the qml apps were getting replaced.

showBuyAvatars was setting dialogButtons.yesButton.visible = false without resetting it, causing the CONFIRM button to remain hidden in subsequent dialogs. Added visible = true reset to all show* functions that use a CONFIRM button.