### PR TITLE
Fix skybox haze on forward renderer

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
@@ -180,9 +180,11 @@ void GLBackend::TransformStageState::preUpdate(size_t commandIndex, const Stereo
             _viewProjectionState._correctedView = _viewProjectionState._view;
         }
 
-        if (_skybox) {
+        // FIXME: zeroing this out breaks skybox haze on the
+        // forward renderer, will the skybox quad break if this is removed?
+        /*if (_skybox) {
             _viewProjectionState._correctedView.setTranslation(vec3());
-        }
+        }*/
         // This is when the _view matrix gets assigned
         _viewProjectionState._correctedView.getInverseMatrix(_camera._view);
     }

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
@@ -180,11 +180,6 @@ void GLBackend::TransformStageState::preUpdate(size_t commandIndex, const Stereo
             _viewProjectionState._correctedView = _viewProjectionState._view;
         }
 
-        // FIXME: zeroing this out breaks skybox haze on the
-        // forward renderer, will the skybox quad break if this is removed?
-        /*if (_skybox) {
-            _viewProjectionState._correctedView.setTranslation(vec3());
-        }*/
         // This is when the _view matrix gets assigned
         _viewProjectionState._correctedView.getInverseMatrix(_camera._view);
     }

--- a/libraries/gpu-vk/src/gpu/vk/VKBackend.cpp
+++ b/libraries/gpu-vk/src/gpu/vk/VKBackend.cpp
@@ -361,9 +361,6 @@ void VKBackend::TransformStageState::preUpdate(size_t commandIndex, const Stereo
             _viewProjectionState._correctedView = _viewProjectionState._view;
         }
 
-        if (_skybox) {
-            _viewProjectionState._correctedView.setTranslation(vec3());
-        }
         // This is when the _view matrix gets assigned
         _viewProjectionState._correctedView.getInverseMatrix(_camera._view);
     }

--- a/libraries/gpu/src/gpu/Backend.cpp
+++ b/libraries/gpu/src/gpu/Backend.cpp
@@ -91,9 +91,11 @@ Backend::TransformCamera Backend::TransformCamera::getMonoCamera(bool isSkybox,
                                                                  Vec2 normalizedJitter) const {
     TransformCamera result = *this;
 
-    if (isSkybox) {
+    // FIXME: zeroing this out might break skybox haze on the
+    // forward renderer, will the skybox quad break if this is removed?
+    /*if (isSkybox) {
         previousView.setTranslation(vec3());
-    }
+    }*/
     result._projection[2][0] += normalizedJitter.x;
     result._projection[2][1] += normalizedJitter.y;
 

--- a/libraries/gpu/src/gpu/Backend.cpp
+++ b/libraries/gpu/src/gpu/Backend.cpp
@@ -91,11 +91,6 @@ Backend::TransformCamera Backend::TransformCamera::getMonoCamera(bool isSkybox,
                                                                  Vec2 normalizedJitter) const {
     TransformCamera result = *this;
 
-    // FIXME: zeroing this out might break skybox haze on the
-    // forward renderer, will the skybox quad break if this is removed?
-    /*if (isSkybox) {
-        previousView.setTranslation(vec3());
-    }*/
     result._projection[2][0] += normalizedJitter.x;
     result._projection[2][1] += normalizedJitter.y;
 

--- a/libraries/graphics/src/graphics/Skybox.cpp
+++ b/libraries/graphics/src/graphics/Skybox.cpp
@@ -106,13 +106,14 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
     viewFrustum.evalViewTransform(viewTransform);
 
     // Orientate view transform to be relative to zone
-    viewTransform.setRotation(skybox.getOrientation() * viewTransform.getRotation());
+    Transform modelTransform;
+    modelTransform.setRotation(skybox.getOrientation());
 
     batch.setProjectionTransform(projMat);
     batch.setViewTransform(viewTransform);
     // This is needed if we want to have motion vectors on the sky
     batch.saveViewProjectionTransform(transformSlot);
-    batch.setModelTransform(Transform()); // only for Mac
+    batch.setModelTransform(modelTransform);
 
     batch.setPipeline(_pipelines[forward]);
     skybox.prepare(batch);

--- a/libraries/graphics/src/graphics/skybox.slf
+++ b/libraries/graphics/src/graphics/skybox.slf
@@ -26,14 +26,16 @@
     <$declarePackDeferredFragmentSky()$>
 <@endif@>
 
-INPUT(0, vec3, _normal);
+INPUT(0, vec3, _skyUV);
+INPUT(1, vec3, _normalWS);
 <@if not HIFI_USE_FORWARD@>
-    INPUT(1, vec4, _prevPositionCS);
+    INPUT(2, vec4, _prevPositionCS);
 <@endif@>
 
 void main(void) {
-    vec3 normal = normalize(_normal);
-    vec3 skyboxTexel = texture(cubeMap, normal).rgb;
+    vec3 skyUV = normalize(_skyUV);
+    vec3 normalWS = normalize(_normalWS);
+    vec3 skyboxTexel = texture(cubeMap, skyUV).rgb;
     vec3 skyboxColor = skybox.color.rgb;
     vec3 color = applySkyboxColorMix(skyboxTexel, skyboxColor, skybox.color.a);
 
@@ -45,7 +47,7 @@ void main(void) {
         vec4 eyePositionWS = cam._viewInverse[3];
         // We choose an arbitrary large number > BLEND_DISTANCE in Haze.slh
         const float SKYBOX_DISTANCE = 32000.0;
-        vec4 fragPositionWS = eyePositionWS + SKYBOX_DISTANCE * vec4(normal, 0.0);
+        vec4 fragPositionWS = eyePositionWS + SKYBOX_DISTANCE * vec4(normalWS, 0.0);
         vec4 fragPositionES = cam._view * fragPositionWS;
 
         Light light = getKeyLight();

--- a/libraries/graphics/src/graphics/skybox.slv
+++ b/libraries/graphics/src/graphics/skybox.slv
@@ -14,9 +14,10 @@
 <@include gpu/Transform.slh@>
 <$declareStandardTransform()$>
 
-OUTPUT(0, vec3, _normal);
+OUTPUT(0, vec3, _skyUV);
+OUTPUT(1, vec3, _normalWS);
 <@if not HIFI_USE_FORWARD@>
-    OUTPUT(1, vec4, _prevPositionCS);
+    OUTPUT(2, vec4, _prevPositionCS);
 <@endif@>
 
 void main(void) {
@@ -39,10 +40,13 @@ void main(void) {
 
     // standard transform
     TransformCamera cam = getTransformCamera();
+    TransformObject obj = getTransformObject();
     vec3 clipDir = UNIT_QUAD[gl_VertexID].xyz;
     vec3 eyeDir;
     <$transformClipToEyeDir(cam, clipDir, eyeDir)$>
-    <$transformEyeToWorldDir(cam, eyeDir, _normal)$>
+    <$transformEyeToWorldDir(cam, eyeDir, _normalWS)$>
+
+    _skyUV = mat3(obj._model) * _normalWS;
 
 <@if not HIFI_USE_FORWARD@>
     // FIXME: this is probably wrong


### PR DESCRIPTION
### Before (master)
The camera's position is always set to zero, and the haze is incorrectly rotated because the skybox was modifying the *view matrix* rather than making use of the model matrix to rotate the cubemap.

Note that world elements *already had* correct haze, it was only the skybox that was broken.

#### Tutorial
<img width="1273" height="932" alt="image" src="https://github.com/user-attachments/assets/884e6fc9-58fa-45c7-b940-259097931eee" />

#### Alezia's CTF-Facing-Worlds
<img width="1274" height="934" alt="image" src="https://github.com/user-attachments/assets/1a1c3b19-c307-4579-a5d2-a025721bb652" />

### After (this PR, matches deferred renderer)
#### Tutorial
<img width="1269" height="932" alt="image" src="https://github.com/user-attachments/assets/02139421-7fe1-4533-bfcf-b314eb16a44b" />

#### Alezia's CTF-Facing-Worlds
<img width="1275" height="935" alt="image" src="https://github.com/user-attachments/assets/fc0f1ddc-b877-4e63-86f2-4c84114797ef" />