### PR TITLE
Fix culling frustum in OpenVR and OpenXR plugins

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -362,7 +362,7 @@ glm::mat4 OpenVrDisplayPlugin::getEyeProjection(Eye eye, const glm::mat4& basePr
     }
 }
 
-inline static glm::mat4 fovToCullingProjection(const std::array<float, 4> fov, const float near, const float far) {
+inline static glm::mat4 fovToCullingProjection(const std::array<float, 4> fov, const float _near, const float _far) {
     const float left = fov[0];
     const float right = fov[1];
     const float down = fov[2];
@@ -373,11 +373,11 @@ inline static glm::mat4 fovToCullingProjection(const std::array<float, 4> fov, c
 
     const float m11 = 2 / width;
     const float m22 = 2 / height;
-    const float m33 = -(far + near) / (far - near);
+    const float m33 = -(_far + _near) / (_far - _near);
 
     const float m31 = (right + left) / width;
     const float m32 = (up + down) / height;
-    const float m43 = -(far * (near + near)) / (far - near);
+    const float m43 = -(_far * (_near + _near)) / (_far - _near);
 
     // clang-format off
     const float mat[16] = {

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -362,17 +362,63 @@ glm::mat4 OpenVrDisplayPlugin::getEyeProjection(Eye eye, const glm::mat4& basePr
     }
 }
 
+inline static glm::mat4 fovToCullingProjection(const std::array<float, 4> fov, const float near, const float far) {
+    const float left = fov[0];
+    const float right = fov[1];
+    const float down = fov[2];
+    const float up = fov[3];
+
+    const float width = right - left;
+    const float height = up - down;
+
+    const float m11 = 2 / width;
+    const float m22 = 2 / height;
+    const float m33 = -(far + near) / (far - near);
+
+    const float m31 = (right + left) / width;
+    const float m32 = (up + down) / height;
+    const float m43 = -(far * (near + near)) / (far - near);
+
+    // clang-format off
+    const float mat[16] = {
+        m11, 0  , 0  ,  0,
+        0  , m22, 0  ,  0,
+        m31, m32, m33, -1,
+        0  , 0  , m43,  0,
+    };
+    // clang-format on
+
+    return glm::make_mat4(mat);
+}
+
 glm::mat4 OpenVrDisplayPlugin::getCullingProjection(const glm::mat4& baseProjection) const {
-    if (_system) {
-        ViewFrustum baseFrustum;
-        baseFrustum.setProjection(baseProjection);
-        float baseNearClip = baseFrustum.getNearClip();
-        float baseFarClip = baseFrustum.getFarClip();
-        // FIXME Calculate the proper combined projection by using GetProjectionRaw values from both eyes
-        return toGlm(_system->GetProjectionMatrix((vr::EVREye)0, baseNearClip, baseFarClip));
-    } else {
+    if (!_system) {
         return baseProjection;
     }
+
+    std::array<std::array<float, 4>, 2> fovs;
+
+    for (auto i = 0; i < 2; i++) {
+        _system->GetProjectionRaw(
+            (vr::EVREye)i,
+            &fovs[i][0],
+            &fovs[i][1],
+            &fovs[i][2],
+            &fovs[i][3]
+        );
+    }
+
+    // behavior copied from OculusMobileDisplayPlugin
+    std::array<float, 4> fovMax = {
+        std::min(fovs[0][0], fovs[1][0]) * 1.5f, // left
+        std::max(fovs[0][1], fovs[1][1]) * 1.5f, // right
+        std::min(fovs[0][2], fovs[1][2]) * 1.5f, // bottom (flipped)
+        std::max(fovs[0][3], fovs[1][3]) * 1.5f, // top (flipped)
+    };
+
+    ViewFrustum frustum;
+    frustum.setProjection(baseProjection);
+    return fovToCullingProjection(fovMax, frustum.getNearClip(), frustum.getFarClip());
 }
 
 float OpenVrDisplayPlugin::getTargetFrameRate() const {
@@ -460,8 +506,7 @@ bool OpenVrDisplayPlugin::internalActivate() {
             _eyeOffsets[eye] = toGlm(_system->GetEyeToHeadTransform(eye));
             _eyeProjections[eye] = toGlm(_system->GetProjectionMatrix(eye, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP));
         });
-        // FIXME Calculate the proper combined projection by using GetProjectionRaw values from both eyes
-        _cullingProjection = _eyeProjections[0];
+        _cullingProjection = getCullingProjection(_eyeProjections[0]);
     });
 
     // enable async time warp

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -408,12 +408,16 @@ glm::mat4 OpenVrDisplayPlugin::getCullingProjection(const glm::mat4& baseProject
         );
     }
 
-    // behavior copied from OculusMobileDisplayPlugin
+    // FIXME: OpenVR gives us tan(angle), how can we clamp
+    // this to within ~170° when multiplied by margin?
+    // const float maxAngle = 0.9f * PI;
+    const float margin = 1.1f;
+
     std::array<float, 4> fovMax = {
-        std::min(fovs[0][0], fovs[1][0]) * 1.5f, // left
-        std::max(fovs[0][1], fovs[1][1]) * 1.5f, // right
-        std::min(fovs[0][2], fovs[1][2]) * 1.5f, // bottom (flipped)
-        std::max(fovs[0][3], fovs[1][3]) * 1.5f, // top (flipped)
+        std::min(fovs[0][0], fovs[1][0]) * margin, // left
+        std::max(fovs[0][1], fovs[1][1]) * margin, // right
+        std::min(fovs[0][2], fovs[1][2]) * margin, // bottom (flipped)
+        std::max(fovs[0][3], fovs[1][3]) * margin, // top (flipped)
     };
 
     ViewFrustum frustum;

--- a/plugins/openxr/src/OpenXrDisplayPlugin.cpp
+++ b/plugins/openxr/src/OpenXrDisplayPlugin.cpp
@@ -36,7 +36,6 @@ bool OpenXrDisplayPlugin::isSupported() const {
     return _context->_isValid && _context->_isSupported;
 }
 
-// Slightly differs from glm::ortho
 inline static glm::mat4 fovToProjection(const XrFovf fov, const float near, const float far) {
     const float left = tanf(fov.angleLeft);
     const float right = tanf(fov.angleRight);
@@ -78,7 +77,23 @@ glm::mat4 OpenXrDisplayPlugin::getEyeProjection(Eye eye, const glm::mat4& basePr
 
 // TODO: interface/src/Application_Graphics.cpp:535
 glm::mat4 OpenXrDisplayPlugin::getCullingProjection(const glm::mat4& baseProjection) const {
-    return getEyeProjection(Left, baseProjection);
+    if (!_views.has_value()) {
+        return baseProjection;
+    }
+
+    ViewFrustum frustum;
+    frustum.setProjection(baseProjection);
+
+    std::array<XrFovf, 2> fovs = { _views.value()[0].fov, _views.value()[1].fov };
+
+    // behavior copied from OculusMobileDisplayPlugin
+    XrFovf fovMax;
+    fovMax.angleDown = std::min(fovs[0].angleDown, fovs[1].angleDown) * 1.5f;
+    fovMax.angleLeft = std::min(fovs[0].angleLeft, fovs[1].angleLeft) * 1.5f;
+    fovMax.angleRight = std::max(fovs[0].angleRight, fovs[1].angleRight) * 1.5f;
+    fovMax.angleUp = std::max(fovs[0].angleUp, fovs[1].angleUp) * 1.5f;
+
+    return fovToProjection(fovMax, frustum.getNearClip(), frustum.getFarClip());
 }
 
 float OpenXrDisplayPlugin::getTargetFrameRate() const {

--- a/plugins/openxr/src/OpenXrDisplayPlugin.cpp
+++ b/plugins/openxr/src/OpenXrDisplayPlugin.cpp
@@ -86,12 +86,14 @@ glm::mat4 OpenXrDisplayPlugin::getCullingProjection(const glm::mat4& baseProject
 
     std::array<XrFovf, 2> fovs = { _views.value()[0].fov, _views.value()[1].fov };
 
-    // behavior copied from OculusMobileDisplayPlugin
+    const float maxAngle = 0.9f * PI;
+    const float margin = 1.1f;
+
     XrFovf fovMax;
-    fovMax.angleDown = std::min(fovs[0].angleDown, fovs[1].angleDown) * 1.5f;
-    fovMax.angleLeft = std::min(fovs[0].angleLeft, fovs[1].angleLeft) * 1.5f;
-    fovMax.angleRight = std::max(fovs[0].angleRight, fovs[1].angleRight) * 1.5f;
-    fovMax.angleUp = std::max(fovs[0].angleUp, fovs[1].angleUp) * 1.5f;
+    fovMax.angleDown = std::clamp(std::min(fovs[0].angleDown, fovs[1].angleDown) * margin, -maxAngle, maxAngle);
+    fovMax.angleLeft = std::clamp(std::min(fovs[0].angleLeft, fovs[1].angleLeft) * margin, -maxAngle, maxAngle);
+    fovMax.angleRight = std::clamp(std::max(fovs[0].angleRight, fovs[1].angleRight) * margin, -maxAngle, maxAngle);
+    fovMax.angleUp = std::clamp(std::max(fovs[0].angleUp, fovs[1].angleUp) * margin, -maxAngle, maxAngle);
 
     return fovToProjection(fovMax, frustum.getNearClip(), frustum.getFarClip());
 }


### PR DESCRIPTION
*Note: I don't have a good way of testing this myself.* The bug is very hard to see in my Vive, so all I've had to work with is Monado's `qwerty` driver display, where I've at least fixed a small strip on the right edge of the right eye that was incorrect. I'd really appreciate QA on a headset with canted displays, like the Index, since this bug is far more apparent on those.

The behavior is copied from the Oculus mobile plugin, which takes the maximum FOV of both eyes together, multiplied by 1.5 for a bit of extra wiggle room so local lighting doesn't flicker and objects don't pop in at the edges if the game thread is going slow.

Closes #666