### PR TITLE
Only notify user connect/disconnect when they actually join or leave

### DIFF
--- a/scripts/communityScripts/armored-chat/armored_chat.js
+++ b/scripts/communityScripts/armored-chat/armored_chat.js
@@ -33,11 +33,23 @@
     Messages.subscribe("Chat"); // Floofchat
     Messages.subscribe("chat");
     Messages.messageReceived.connect(receivedMessage);
+
+    // We have Users.avatarDisconnected which only emits when
+    // a client really leaves the server, but there's no signal
+    // for when a client really joins the server. Keep track of
+    // what avatar IDs we've seen so if one gets hidden and then
+    // unhidden, we don't do the "user connected" notification again.
+    let connectedAvatars = new Set();
+
     AvatarManager.avatarAddedEvent.connect((sessionId) => {
-        _avatarAction("connected", sessionId);
+        if (!connectedAvatars.has(sessionId)) {
+            connectedAvatars.add(sessionId);
+            _avatarAction("connected", sessionId);
+        }
     });
-    AvatarManager.avatarRemovedEvent.connect((sessionId) => {
+    Users.avatarDisconnected.connect((sessionId) => {
         _avatarAction("left", sessionId);
+        connectedAvatars.delete(sessionId);
     });
 
     startup();


### PR DESCRIPTION
Fixes #1372
I'll do a similar fix for the Qt6 chat in a separate PR

### Master
[shield-spam-master.webm](https://github.com/user-attachments/assets/b856e81a-80cf-4daf-9f18-ad944a4aca8f)

### This PR
[shield-spam-fixed.webm](https://github.com/user-attachments/assets/6312e758-a035-439e-8c28-5eeab661b145)
