### PR TITLE
Support EGL on Linux, MNDX_egl_enable support in OpenXR

### DIFF
--- a/libraries/gl/CMakeLists.txt
+++ b/libraries/gl/CMakeLists.txt
@@ -5,3 +5,8 @@ link_hifi_libraries(shared)
 set(OpenGL_GL_PREFERENCE "GLVND")
 target_opengl()
 target_glad()
+
+# support EGL on Linux for Wayland
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_egl()
+endif()

--- a/libraries/gl/src/gl/Config.cpp
+++ b/libraries/gl/src/gl/Config.cpp
@@ -21,7 +21,8 @@
 #include <OpenGL/CGLTypes.h>
 #include <OpenGL/CGLCurrent.h>
 #include <dlfcn.h>
-#else
+#elif defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+#include <EGL/egl.h>
 #include <GL/glx.h>
 #include <dlfcn.h>
 #endif
@@ -73,8 +74,7 @@ static void* getGlProcessAddress(const char *namez) {
     return dlsym(GL_LIB, namez);
 }
 
-#else
-
+#elif defined(Q_OS_LINUX) && !defined(Q_OS_ANDORID)
 
 typedef Bool (*PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC) (int attribute, unsigned int *value);
 typedef int (*PFNGLXSWAPINTERVALMESAPROC)(unsigned int interval);
@@ -94,9 +94,13 @@ PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC QueryCurrentRendererIntegerMESA;
 PFNGLXSWAPINTERVALMESAPROC SwapIntervalMESA;
 PFNGLXGETSWAPINTERVALMESAPROC GetSwapIntervalMESA;
 
-static void* getGlProcessAddress(const char *namez) {
-    return (void*)glXGetProcAddressARB((const GLubyte*)namez);
-}
+// EGL has its own swap interval functions, so the MESA ones aren't needed there
+static bool contextIsEGL = false;
+static int previousSwapInterval = 1;
+
+// the real GetProcAddress functions return a placeholder function
+// pointer type (void (*)(void)), but glad expects one returning void*
+static void* (*getGlProcessAddress)(const char *namez) = nullptr;
 
 #endif
 
@@ -105,6 +109,16 @@ static void* getGlProcessAddress(const char *namez) {
 void gl::initModuleGl() {
     static std::once_flag once;
     std::call_once(once, [] {
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    contextIsEGL = eglGetCurrentContext() != nullptr;
+
+    if (contextIsEGL) {
+        getGlProcessAddress = reinterpret_cast<decltype(getGlProcessAddress)>(eglGetProcAddress);
+    } else {
+        getGlProcessAddress = reinterpret_cast<decltype(getGlProcessAddress)>(glXGetProcAddressARB);
+    }
+#endif
+
 #if defined(Q_OS_WIN)
         wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)getGlProcessAddress("wglSwapIntervalEXT");
         wglGetSwapIntervalEXT = (PFNWGLGETSWAPINTERVALEXTPROC)getGlProcessAddress("wglGetSwapIntervalEXT");
@@ -113,9 +127,11 @@ void gl::initModuleGl() {
 #endif
 
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-        QueryCurrentRendererIntegerMESA = (PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC)getGlProcessAddress("glXQueryCurrentRendererIntegerMESA");
-        SwapIntervalMESA = (PFNGLXSWAPINTERVALMESAPROC)getGlProcessAddress("glXSwapIntervalMESA");
-        GetSwapIntervalMESA = (PFNGLXGETSWAPINTERVALMESAPROC)getGlProcessAddress("glXGetSwapIntervalMESA");
+        if (!contextIsEGL) {
+            QueryCurrentRendererIntegerMESA = (PFNGLXQUERYCURRENTRENDERERINTEGERMESAPROC)getGlProcessAddress("glXQueryCurrentRendererIntegerMESA");
+            SwapIntervalMESA = (PFNGLXSWAPINTERVALMESAPROC)getGlProcessAddress("glXSwapIntervalMESA");
+            GetSwapIntervalMESA = (PFNGLXGETSWAPINTERVALMESAPROC)getGlProcessAddress("glXGetSwapIntervalMESA");
+        }
 #endif
 
 #if defined(USE_GLES)
@@ -134,7 +150,11 @@ int gl::getSwapInterval() {
     CGLGetParameter(CGLGetCurrentContext(), kCGLCPSwapInterval, &interval);
     return interval;
 #elif defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-    if (GetSwapIntervalMESA) {
+    // EGL doesn't have a function for getting the current swap interval,
+    // so just use whatever we previously set in setSwapInterval below
+    if (contextIsEGL) {
+        return previousSwapInterval;
+    } else if (GetSwapIntervalMESA) {
         return GetSwapIntervalMESA();
     } else {
         return 1;
@@ -151,8 +171,13 @@ void gl::setSwapInterval(int interval) {
     CGLSetParameter(CGLGetCurrentContext(), kCGLCPSwapInterval, &interval);
 #elif defined(Q_OS_ANDROID)
     eglSwapInterval(eglGetCurrentDisplay(), interval);
-#elif defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-    if (SwapIntervalMESA) {
+#elif defined(Q_OS_LINUX)
+    if (contextIsEGL) {
+        // FIXME: This doesn't seem to work on OpenXR+Wayland?
+        // The VR view is still capped to 1FPS if the desktop window is obscured
+        eglSwapInterval(eglGetCurrentDisplay(), interval);
+        previousSwapInterval = interval;
+    } else if (SwapIntervalMESA) {
         SwapIntervalMESA(interval);
     }
 #else
@@ -161,11 +186,11 @@ void gl::setSwapInterval(int interval) {
 }
 
 bool gl::queryCurrentRendererIntegerMESA(int attr, unsigned int *value) {
-    #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-    if (QueryCurrentRendererIntegerMESA) {
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+    if (!contextIsEGL && QueryCurrentRendererIntegerMESA) {
         return QueryCurrentRendererIntegerMESA(attr, value);
     }
-    #endif
+#endif
 
     *value = 0;
     return false;

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -18,6 +18,7 @@
 #include <QtCore/QProcessEnvironment>
 #include <QtGui/QInputMethodEvent>
 #include <QtQuick/QQuickWindow>
+#include <QGuiApplication>
 
 #include <OffscreenUi.h>
 #include <controllers/Pose.h>
@@ -95,9 +96,19 @@ std::string getOpenVrDeviceName() {
 }
 
 bool openVrSupported() {
-    static const QString DEBUG_FLAG("HIFI_DEBUG_OPENVR");
-    static bool enableDebugOpenVR = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);
-    return (enableDebugOpenVR || !isOculusPresent()) && vr::VR_IsHmdPresent();
+#if defined(HAVE_VULKAN)
+    qCDebug(displayplugins) << "OpenVR is not supported on the Vulkan backend.";
+    return false;
+#else
+    if (qApp->platformName().startsWith("wayland")) {
+        qCDebug(displayplugins) << "OpenVR is not supported on Wayland. Use QT_QPA_PLATFORM=xcb to run Overte through XWayland.";
+        return false;
+    } else {
+        static const QString DEBUG_FLAG("HIFI_DEBUG_OPENVR");
+        static bool enableDebugOpenVR = QProcessEnvironment::systemEnvironment().contains(DEBUG_FLAG);
+        return (enableDebugOpenVR || !isOculusPresent()) && vr::VR_IsHmdPresent();
+    }
+#endif
 }
 
 QString getVrSettingString(const char* section, const char* setting) {

--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -12,7 +12,7 @@
 #include <QString>
 #include <QGuiApplication>
 
-#if defined(Q_OS_LINUX)
+#if defined(HAVE_VULKAN)
 #include <QMessageBox>
 #endif
 
@@ -53,10 +53,16 @@ static bool loadXrFunction(XrInstance instance, const char* name, PFN_xrVoidFunc
 }
 
 OpenXrContext::OpenXrContext() {
+#if defined(HAVE_VULKAN)
+    _isSupported = false;
+    qCCritical(xr_context_cat, "OpenXR is not supported on the Vulkan backend yet.");
+    QMessageBox::critical(nullptr, "OpenXR", "OpenXR is not supported on the Vulkan backend yet.");
+#else
     _isSupported = initPreGraphics();
     if (!_isSupported) {
         qCWarning(xr_context_cat, "OpenXR is not supported.");
     }
+#endif
 }
 
 OpenXrContext::~OpenXrContext() {
@@ -71,14 +77,10 @@ OpenXrContext::~OpenXrContext() {
 }
 
 bool OpenXrContext::initInstance() {
-#if defined(Q_OS_LINUX)
-    if (qApp->platformName() == "wayland") {
-        qCCritical(xr_context_cat) << "The OpenXR plugin can't run on Wayland yet. This will hopefully be resolved with Qt 6.";
-        QMessageBox::warning(nullptr, "Warning", "Overte cannot use OpenXR on Wayland yet. Use the QT_QPA_PLATFORM=xcb environment variable to launch Overte through XWayland.");
-        return false;
-    }
-#endif
-
+#if defined(HAVE_VULKAN)
+    // VKTODO
+    return false;
+#else
     uint32_t count = 0;
     XrResult result = xrEnumerateInstanceExtensionProperties(nullptr, 0, &count, nullptr);
 
@@ -108,6 +110,7 @@ bool OpenXrContext::initInstance() {
     bool palmPoseSupported = false;
     bool MNDX_xdevSpaceSupported = false;
     bool HTCX_viveTrackerInteractionSupported = false;
+    bool MNDX_eglEnableSupported = false;
 
     qCInfo(xr_context_cat, "Runtime supports %d extensions:", count);
     for (uint32_t i = 0; i < count; i++) {
@@ -126,6 +129,8 @@ bool OpenXrContext::initInstance() {
             HTCX_viveTrackerInteractionSupported = true;
         } else if (strcmp(XR_EXT_PALM_POSE_EXTENSION_NAME, properties[i].extensionName) == 0) {
             palmPoseSupported = true;
+        } else if (strcmp(XR_MNDX_EGL_ENABLE_EXTENSION_NAME, properties[i].extensionName) == 0) {
+            MNDX_eglEnableSupported = true;
         }
     }
 
@@ -163,6 +168,13 @@ bool OpenXrContext::initInstance() {
         enabled.push_back(XR_EXT_PALM_POSE_EXTENSION_NAME);
         _palmPoseSupported = true;
     }
+
+#if defined(XR_USE_PLATFORM_EGL)
+    if (MNDX_eglEnableSupported) {
+        enabled.push_back(XR_MNDX_EGL_ENABLE_EXTENSION_NAME);
+        _MNDX_eglEnableSupported = true;
+    }
+#endif
 
     XrInstanceCreateInfo info = {
         .type = XR_TYPE_INSTANCE_CREATE_INFO,
@@ -207,6 +219,7 @@ bool OpenXrContext::initInstance() {
     }
 
     return true;
+#endif
 }
 
 bool OpenXrContext::initSystem() {
@@ -363,9 +376,14 @@ bool OpenXrContext::initSystem() {
 }
 
 bool OpenXrContext::initGraphics() {
+#if defined(HAVE_VULKAN)
+    // VKTODO
+    return false;
+#else
     XrGraphicsRequirementsOpenGLKHR requirements = { .type = XR_TYPE_GRAPHICS_REQUIREMENTS_OPENGL_KHR };
     XrResult result = pfnGetOpenGLGraphicsRequirementsKHR(_instance, _systemId, &requirements);
     return xrCheck(_instance, result, "Failed to get OpenGL graphics requirements!");
+#endif
 }
 
 bool OpenXrContext::requestExitSession() {
@@ -376,6 +394,10 @@ bool OpenXrContext::requestExitSession() {
 }
 
 bool OpenXrContext::initSession() {
+#if defined(HAVE_VULKAN)
+    // VKTODO
+    return false;
+#else
     if (_session != XR_NULL_HANDLE) { return true; }
 
     XrSessionCreateInfo info = {
@@ -384,44 +406,133 @@ bool OpenXrContext::initSession() {
         .systemId = _systemId,
     };
 
-#if defined(Q_OS_LINUX)
-    // if (wayland) {
-    // blah blah...
-    // info.next = &wlBinding;
-    // } else
+    bool eglBindingAvailable = false;
 
-    auto* xDisplay = XOpenDisplay(nullptr);
-    int fbConfigCount = 0;
-    auto* fbConfigs = glXGetFBConfigs(xDisplay, 0, &fbConfigCount);
-
-    XrGraphicsBindingOpenGLXlibKHR xlibBinding = {
-        .type = XR_TYPE_GRAPHICS_BINDING_OPENGL_XLIB_KHR,
-        .xDisplay = xDisplay,
-
-        // not actually used anywhere but monado now
-        // requires these to be non-null (in-line with the spec)
-        .visualid = 1,
-        .glxFBConfig = fbConfigs[0],
-
-        .glxDrawable = glXGetCurrentDrawable(),
-        .glxContext = glXGetCurrentContext(),
+#if defined(XR_USE_PLATFORM_EGL)
+    XrGraphicsBindingEGLMNDX eglBinding = {
+        .type = XR_TYPE_GRAPHICS_BINDING_EGL_MNDX,
+        .next = nullptr,
     };
 
-    info.next = &xlibBinding;
-#elif defined(Q_OS_WIN)
-    XrGraphicsBindingOpenGLWin32KHR binding = {
-        .type = XR_TYPE_GRAPHICS_BINDING_OPENGL_WIN32_KHR,
-        .hDC = wglGetCurrentDC(),
-        .hGLRC = wglGetCurrentContext(),
-    };
+    // try egl first since it should work on any platform
+    // do-while so we can break out early
+    do {
+        if (!_MNDX_eglEnableSupported) { break; }
 
-    info.next = &binding;
+        auto eglContext = eglGetCurrentContext();
+        auto eglDisplay = eglGetCurrentDisplay();
+
+        if (!eglContext || !eglDisplay) { break; }
+
+        auto attribs = std::to_array<EGLint>({
+            EGL_RED_SIZE, 8,
+            EGL_GREEN_SIZE, 8,
+            EGL_RED_SIZE, 8,
+            EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+#if defined(Q_OS_ANDROID)
+            EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
 #else
-  #error "Unsupported platform"
+            EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT | EGL_OPENGL_ES3_BIT,
+#endif
+            EGL_NONE // terminator
+        });
+
+        EGLConfig eglConfig;
+        EGLint configCount = 0;
+        if (
+            !eglChooseConfig(eglDisplay, attribs.data(), &eglConfig, 1, &configCount) ||
+            configCount != 1 ||
+            !eglConfig
+        ) {
+            qCWarning(xr_context_cat, "Failed to get EGL config");
+            break;
+        }
+
+        eglBinding.getProcAddress = eglGetProcAddress;
+        eglBinding.display = eglDisplay;
+        eglBinding.config = eglConfig;
+        eglBinding.context = eglContext;
+        info.next = &eglBinding;
+
+        eglBindingAvailable = true;
+    } while(0);
+#endif
+
+#if defined(Q_OS_ANDROID)
+    // ANDROID TODO: This is untested and will need changes in
+    // OpenXrDisplayPlugin to use the OpenGLES structs instead
+    if (!eglBindingAvailable) {
+        auto eglContext = eglGetCurrentContext();
+        auto eglDisplay = eglGetCurrentDisplay();
+
+        auto attribs = std::to_array<EGLint>({
+            EGL_RED_SIZE, 8,
+            EGL_GREEN_SIZE, 8,
+            EGL_RED_SIZE, 8,
+            EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+            EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+            EGL_NONE // terminator
+        });
+
+        EGLConfig eglConfig;
+        EGLint configCount = 0;
+        if (
+            !eglChooseConfig(eglDisplay, attribs.data(), &eglConfig, 1, &configCount) ||
+            configCount != 1 ||
+            !eglConfig
+        ) {
+            qCWarning(xr_context_cat, "Failed to get EGL config");
+            return false;
+        }
+
+        XrGraphicsBindingOpenGLESAndroidKHR androidBinding = {
+            .type = XR_TYPE_GRAPHICS_BINDING_OPENGL_ES_ANDROID_KHR,
+            .next = nullptr,
+            .display = eglDisplay,
+            .config = eglConfig,
+            .context = eglContext,
+        };
+
+        info.next = &androidBinding;
+    }
+#elif defined(Q_OS_LINUX)
+    if (!eglBindingAvailable) {
+        auto* xDisplay = XOpenDisplay(nullptr);
+        int fbConfigCount = 0;
+        auto* fbConfigs = glXGetFBConfigs(xDisplay, 0, &fbConfigCount);
+
+        XrGraphicsBindingOpenGLXlibKHR xlibBinding = {
+            .type = XR_TYPE_GRAPHICS_BINDING_OPENGL_XLIB_KHR,
+            .xDisplay = xDisplay,
+
+            // not actually used anywhere but monado now
+            // requires these to be non-null (in-line with the spec)
+            .visualid = 1,
+            .glxFBConfig = fbConfigs[0],
+
+            .glxDrawable = glXGetCurrentDrawable(),
+            .glxContext = glXGetCurrentContext(),
+        };
+
+        info.next = &xlibBinding;
+    }
+#elif defined(Q_OS_WIN)
+    if (!eglBindingAvailable) {
+        XrGraphicsBindingOpenGLWin32KHR binding = {
+            .type = XR_TYPE_GRAPHICS_BINDING_OPENGL_WIN32_KHR,
+            .hDC = wglGetCurrentDC(),
+            .hGLRC = wglGetCurrentContext(),
+        };
+
+        info.next = &binding;
+    }
+#else
+    #error "Unsupported platform"
 #endif
 
     XrResult result = xrCreateSession(_instance, &info, &_session);
     return xrCheck(_instance, result, "Failed to create session");
+#endif
 }
 
 bool OpenXrContext::initSpaces() {

--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -129,8 +129,10 @@ bool OpenXrContext::initInstance() {
             HTCX_viveTrackerInteractionSupported = true;
         } else if (strcmp(XR_EXT_PALM_POSE_EXTENSION_NAME, properties[i].extensionName) == 0) {
             palmPoseSupported = true;
+#if defined(XR_USE_PLATFORM_EGL)
         } else if (strcmp(XR_MNDX_EGL_ENABLE_EXTENSION_NAME, properties[i].extensionName) == 0) {
             MNDX_eglEnableSupported = true;
+#endif
         }
     }
 

--- a/plugins/openxr/src/OpenXrContext.h
+++ b/plugins/openxr/src/OpenXrContext.h
@@ -16,25 +16,44 @@
 
 #include "gpu/gl/GLBackend.h"
 
-#if defined(Q_OS_LINUX)
-    #define XR_USE_PLATFORM_XLIB
-    #include <GL/glx.h>
-    // Unsorted from glx.h conflicts with qdir.h
-    #undef Unsorted
-    // MappingPointer from X11 conflicts with one from controllers/Forward.h
-    #undef MappingPointer
-    // CursorShape conflicts with QCursor
-    #undef CursorShape
-#elif defined(Q_OS_WIN)
-    #define XR_USE_PLATFORM_WIN32
-    #include <Unknwn.h>
-    #include <Windows.h>
+#if defined(HAVE_VULKAN)
+    #warning "OpenXR plugin doesn't support Vulkan yet and will always fail on startup"
+    #define XR_USE_GRAPHICS_API_VULKAN
 #else
-    #error "Unimplemented platform"
+    #if defined(Q_OS_ANDROID)
+        #define XR_USE_GRAPHICS_API_OPENGL_ES
+        #define XR_USE_PLATFORM_ANDROID
+        #define XR_USE_PLATFORM_EGL
+    #elif defined(Q_OS_LINUX)
+        #define XR_USE_GRAPHICS_API_OPENGL
+        // Wayland uses XR_USE_PLATFORM_EGL, XR_USE_PLATFORM_WAYLAND
+        // is deprecated and never worked anyway
+        #define XR_USE_PLATFORM_EGL
+        #define XR_USE_PLATFORM_XLIB
+        #include <GL/glx.h>
+        // Unsorted from glx.h conflicts with qdir.h
+        #undef Unsorted
+        // MappingPointer from X11 conflicts with one from controllers/Forward.h
+        #undef MappingPointer
+        // CursorShape conflicts with QCursor
+        #undef CursorShape
+    #elif defined(Q_OS_WIN)
+        // TODO: We can't support EGL on Windows yet, because we create
+        // the OpenGL contexts ourselves using WGL on Windows.
+        #define XR_USE_GRAPHICS_API_OPENGL
+        #define XR_USE_PLATFORM_WIN32
+        #include <Unknwn.h>
+        #include <Windows.h>
+    #else
+        #error "Unsupported platform"
+    #endif
+
+    #if defined(XR_USE_PLATFORM_EGL)
+        #include <EGL/egl.h>
+    #endif
 #endif
 
 
-#define XR_USE_GRAPHICS_API_OPENGL
 #include <openxr/openxr_platform.h>
 
 #include <glm/glm.hpp>
@@ -100,6 +119,8 @@ public:
 
     bool _HTCX_viveTrackerInteractionSupported = false;
     PFN_xrEnumerateViveTrackerPathsHTCX xrEnumerateViveTrackerPathsHTCX = nullptr;
+
+    bool _MNDX_eglEnableSupported = false;
 
 private:
     XrSessionState _lastSessionState = XR_SESSION_STATE_UNKNOWN;


### PR DESCRIPTION
Gets Interface running on Wayland without need for `QT_QPA_PLATFORM=xcb`. Previously it would just try to call a null function pointer and crash, since GLX and `glXGetProcAddressARB` don't work on Wayland.

Also adds a check to prevent OpenVR from starting on Wayland, and adds ifdef guards for Vulkan for both OpenVR and OpenXR, since neither works on it yet.

A bug I haven't been able to figure out is why `eglSwapInterval` doesn't seem to be doing anything to unlock the VR framerate from the desktop window's, though with printf debugging it looks like the calls are successful and a swap interval of zero is supported. If the desktop window is obscured on Wayland, then VR is limited to 1 FPS too.

EGL could be supported on Windows too in the future, but since we currently create OpenGL contexts ourselves using WGL there'll never be an EGL context.

---

Now that Wayland works properly, we should look into packaging the Wayland QPA plugins into the AppImages again.