### PR TITLE
Correct MyAvatar.standingModeChanged doc, only pick domain entities in bounding-box Clipboard.exportEntities

### DIFF
--- a/interface/src/Application_Entities.cpp
+++ b/interface/src/Application_Entities.cpp
@@ -199,7 +199,11 @@ bool Application::exportEntities(const QString& filename, float x, float y, floa
     QVector<QUuid> entities;
     auto entityTree = getEntities()->getTree();
     entityTree->withReadLock([&] {
-        entityTree->evalEntitiesInCube(boundingCube, PickFilter(), entities);
+        entityTree->evalEntitiesInCube(
+            boundingCube,
+            PickFilter(PickFilter::getBitMask(PickFilter::DOMAIN_ENTITIES)),
+            entities
+        );
     });
     return exportEntities(filename, entities, &center, options);
 }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2331,7 +2331,7 @@ signals:
 
     /*@jsdoc
      * Triggered when {@link MyAvatar.standingMode} is changed.
-     * @function MyAvatar.standingMode
+     * @function MyAvatar.standingModeChanged
      * @param {MyAvatar.StandingMode} mode
      * @returns {Signal}
      */


### PR DESCRIPTION
Fixes #2086 and a typo that slipped into #1620 that made the bounding-box overload of `Clipboard.exportEntities` also export avatar and local entities sorry ;;