### PR TITLE
Fix backwards depth biasing, use depth offset for Text entity content instead of physical offset

### DIFF
--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -122,6 +122,9 @@ ItemKey TextEntityRenderer::getKey() {
 }
 
 ShapeKey TextEntityRenderer::getShapeKey() {
+    // FIXME: ShapeKey::Builder has no way of setting a specific
+    // depth offset like we'd need to offset both the background
+    // and payload in order
     auto builder = render::ShapeKey::Builder().withDepthBias();
     updateShapeKeyBuilderFromMaterials(builder);
     return builder.build();
@@ -294,7 +297,10 @@ ShapeKey entities::TextPayload::getShapeKey() const {
         if (renderable) {
             auto textRenderable = std::static_pointer_cast<TextEntityRenderer>(renderable);
 
-            auto builder = render::ShapeKey::Builder().withOwnPipeline();
+            // FIXME: ShapeKey::Builder has no way of setting a specific
+            // depth offset like we'd need to offset both the background
+            // and payload in order
+            auto builder = render::ShapeKey::Builder().withOwnPipeline().withDepthBias();
             if (textRenderable->isTextTransparent()) {
                 builder.withTranslucent();
             }
@@ -382,7 +388,7 @@ void entities::TextPayload::render(RenderArgs* args) {
     if (fontHeight > 0.0f) {
         scale = textRenderable->_lineHeight / fontHeight;
     }
-    transform.postTranslate(glm::vec3(-0.5, 0.5, 1.0f + EPSILON / dimensions.z));
+    transform.postTranslate(glm::vec3(-0.5f, 0.5f, 0.0f));
     transform.setScale(scale);
     batch.setModelTransform(transform, _prevRenderTransform);
     if (args->_renderMode == Args::RenderMode::DEFAULT_RENDER_MODE || args->_renderMode == Args::RenderMode::MIRROR_RENDER_MODE) {

--- a/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.cpp
@@ -122,9 +122,10 @@ ItemKey TextEntityRenderer::getKey() {
 }
 
 ShapeKey TextEntityRenderer::getShapeKey() {
-    // FIXME: ShapeKey::Builder has no way of setting a specific
+    // TODO: ShapeKey::Builder has no way of setting a specific
     // depth offset like we'd need to offset both the background
-    // and payload in order
+    // and payload in order, so the text payload is hardcoded
+    // to have a higher depth bias (-2) than the background (-1)
     auto builder = render::ShapeKey::Builder().withDepthBias();
     updateShapeKeyBuilderFromMaterials(builder);
     return builder.build();
@@ -297,9 +298,10 @@ ShapeKey entities::TextPayload::getShapeKey() const {
         if (renderable) {
             auto textRenderable = std::static_pointer_cast<TextEntityRenderer>(renderable);
 
-            // FIXME: ShapeKey::Builder has no way of setting a specific
+            // TODO: ShapeKey::Builder has no way of setting a specific
             // depth offset like we'd need to offset both the background
-            // and payload in order
+            // and payload in order, so the text payload is hardcoded
+            // to have a higher depth bias (-2) than the background (-1)
             auto builder = render::ShapeKey::Builder().withOwnPipeline().withDepthBias();
             if (textRenderable->isTextTransparent()) {
                 builder.withTranslucent();

--- a/libraries/gpu-vk/src/gpu/vk/VKPipelineCache.cpp
+++ b/libraries/gpu-vk/src/gpu/vk/VKPipelineCache.cpp
@@ -457,11 +457,14 @@ Cache::PipelineLayout Cache::getPipeline(const vks::Context& context) {
     {
         auto& rasterizationState = builder.rasterizationState;
         rasterizationState.cullMode = (VkCullModeFlagBits)stateData.cullMode;
-        //Bool32 ra.depthBiasEnable;
-        //float ra.depthBiasConstantFactor;
-        //float ra.depthBiasClamp;
-        //float ra.depthBiasSlopeFactor;
-        //ra.depthClampEnable = VK_TRUE;
+        rasterizationState.depthBiasEnable = (stateData.depthBias != 0.0f && stateData.depthBiasSlopeScale != 0.0f);
+        // VKTODO: How come the depth bias values behave differently on OpenGL vs Vulkan?
+        // Facing a Text entity face-on that's directly touching another wall will sometimes
+        // clip into the wall, though in most cases it works perfectly fine. Weirdly,
+        // this doesn't seem to affect Image entities in the same situation.
+        rasterizationState.depthBiasConstantFactor = stateData.depthBias;
+        rasterizationState.depthBiasSlopeFactor = stateData.depthBiasSlopeScale;
+        rasterizationState.depthBiasClamp = 0.0f;
         rasterizationState.depthClampEnable = stateData.flags.depthClampEnable ? VK_TRUE : VK_FALSE;  // VKTODO
         rasterizationState.frontFace =
             stateData.flags.frontFaceClockwise ? VK_FRONT_FACE_CLOCKWISE : VK_FRONT_FACE_COUNTER_CLOCKWISE;

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -2194,7 +2194,6 @@ void GeometryCache::useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend) {
 void GeometryCache::useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer, bool transparent, bool forward) {
     if (_gridPipelines.empty()) {
         using namespace shader::render_utils::program;
-        const float DEPTH_BIAS = 0.001f;
 
         static const std::vector<std::tuple<bool, bool, uint32_t>> keys = {
             std::make_tuple(false, false, grid), std::make_tuple(false, true, grid_forward), std::make_tuple(true, false, grid_translucent), std::make_tuple(true, true, grid_translucent_forward)
@@ -2212,7 +2211,8 @@ void GeometryCache::useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer, bo
                 gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
                 gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
             state->setCullMode(gpu::State::CULL_NONE);
-            state->setDepthBias(DEPTH_BIAS);
+            state->setDepthBias(-1.0f);
+            state->setDepthBiasSlopeScale(-1.0f);
 
             _gridPipelines[{std::get<0>(key), std::get<1>(key)}] = gpu::Pipeline::create(gpu::Shader::createProgram(std::get<2>(key)), state);
         }
@@ -2357,8 +2357,8 @@ gpu::PipelinePointer GeometryCache::getSimplePipeline(bool textured, bool transp
     }
     state->setDepthTest(true, !config.isTransparent(), ComparisonFunction::LESS_EQUAL);
     if (config.hasDepthBias()) {
-        state->setDepthBias(1.0f);
-        state->setDepthBiasSlopeScale(1.0f);
+        state->setDepthBias(-1.0f);
+        state->setDepthBiasSlopeScale(-1.0f);
     }
     state->setBlendFunction(config.isTransparent(),
         gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,

--- a/libraries/render-utils/src/RenderPipelinesInit.cpp.in
+++ b/libraries/render-utils/src/RenderPipelinesInit.cpp.in
@@ -145,8 +145,8 @@ void addPlumberPipeline(ShapePlumber& plumber,
             }
             if (isBiased) {
                 builder.withDepthBias();
-                state->setDepthBias(1.0f);
-                state->setDepthBiasSlopeScale(1.0f);
+                state->setDepthBias(-1.0f);
+                state->setDepthBiasSlopeScale(-1.0f);
             }
 
             auto baseBatchSetter = (forceLightBatchSetter || key.isTranslucent() || key.isMToon()) ? &lightBatchSetter : &batchSetter;

--- a/libraries/render-utils/src/sdf_text3D.slv
+++ b/libraries/render-utils/src/sdf_text3D.slv
@@ -78,9 +78,4 @@ void main() {
 
     const vec3 normal = vec3(0, 0, 1);
     <$transformModelToWorldDir(obj, normal, _normalWS)$>
-
-    // TODO: We don't support setting depth biases to anything other than "off" or "on",
-    // so manually offset the text a little bit further from the background
-    // FIXME: withDepthBias isn't working on TextPayload::getShapeKey?
-    gl_Position.z -= 1.0 / 256.0;
 }

--- a/libraries/render-utils/src/sdf_text3D.slv
+++ b/libraries/render-utils/src/sdf_text3D.slv
@@ -78,4 +78,9 @@ void main() {
 
     const vec3 normal = vec3(0, 0, 1);
     <$transformModelToWorldDir(obj, normal, _normalWS)$>
+
+    // TODO: We don't support setting depth biases to anything other than "off" or "on",
+    // so manually offset the text a little bit further from the background
+    // FIXME: withDepthBias isn't working on TextPayload::getShapeKey?
+    gl_Position.z -= 1.0 / 256.0;
 }

--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -393,6 +393,13 @@ void Font::setupGPU() {
             } else {
                 PrepareStencil::testMaskDrawShape(*state);
             }
+
+            // TODO: Revisit this once we support specifying depth bias values in ShapeKey
+            // assume the text payload is in front of an already-biased background (bias of -1),
+            // so push the text a little further out so it doesn't z-fight
+            state->setDepthBias(-2.0f);
+            state->setDepthBiasSlopeScale(-2.0f);
+
             _pipelines[std::make_tuple(transparent, unlit, forward, mirror, fade)] = gpu::Pipeline::create(gpu::Shader::createProgram(std::get<5>(key)), state);
         }
 


### PR DESCRIPTION
Supersedes #2007, and should work properly on all four backends
Fixes #2130

### Box entity with a Text entity and Image entity placed exactly on its faces
[depth-bias-box.json](https://github.com/user-attachments/files/26159236/depth-bias-box.json)

| Master | This PR
| --- | ---
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/f31aae7d-160c-4619-926b-85d2190a1c38" /> | <img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/01df39ba-0c7b-4884-91df-64c5679b3672" />

Depth biasing now works on the Vulkan backend, but there's some weirdness on my system when facing a Text entity almost head-on:
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/4229d14a-e42f-454d-8503-ff34290fe01a" />
Weirdly, this doesn't seem to affect Image entities, or at least the one that's attached to the test cube.