### PR TITLE
Nicer grid shader

### DIFF
--- a/libraries/render-utils/src/grid.slf
+++ b/libraries/render-utils/src/grid.slf
@@ -32,25 +32,34 @@ UNIFORM_BUFFER(0, gridBuffer) {
 };
 
 INPUT(GPU_ATTR_TEXCOORD0, vec2, varTexCoord0);
+INPUT(GPU_ATTR_TEXCOORD1, vec2, varTexCoord1);
 INPUT(GPU_ATTR_COLOR, vec4, varColor);
 
 
 void main(void) {
+    const float SQRT_2 = 1.4142135623730951;
+
     float gridLine = mix(paintGridMajorMinor(varTexCoord0, grid.offset, grid.period, grid.edge),
                       paintGrid(varTexCoord0, grid.offset.xy, grid.period.xy, grid.edge.xy),
                       float(grid.edge.z == 0.0));
-    if (gridLine <= 0.0) {
-        discard;
-    }
+
+    // multiply by sqrt(2) to hide the chunk pop-in on the corners
+    float fade = clamp(1.0 - (length(varTexCoord1) * SQRT_2), 0.0, 1.0);
+    float gridWeight = gridLine * fade;
+
+    if (gridWeight <= 0.0) { discard; }
+
+    vec4 color = varColor;
+    color.a *= gridWeight;
 
 <@if not HIFI_USE_FORWARD@>
     <@if not HIFI_USE_TRANSLUCENT@>
         vec3 NORMAL = vec3(1.0, 0.0, 0.0);
-        packDeferredFragmentUnlit(_prevPositionCS, NORMAL, 1.0, varColor.rgb);
+        packDeferredFragmentUnlit(_prevPositionCS, NORMAL, 1.0, color.rgb);
     <@else@>
-        packDeferredFragmentTranslucentUnlit(varColor.a, varColor.rgb);
+        packDeferredFragmentTranslucentUnlit(color.a, color.rgb);
     <@endif@>
 <@else@>
-    _fragColor0 = varColor;
+    _fragColor0 = color;
 <@endif@>
 }

--- a/libraries/render-utils/src/grid.slv
+++ b/libraries/render-utils/src/grid.slv
@@ -19,6 +19,7 @@
 
 OUTPUT(RENDER_UTILS_ATTR_PREV_POSITION_CS, vec4, _prevPositionCS);
 OUTPUT(GPU_ATTR_TEXCOORD0, vec2, varTexCoord0);
+OUTPUT(GPU_ATTR_TEXCOORD1, vec2, varTexCoord1);
 OUTPUT(GPU_ATTR_COLOR, vec4, varColor);
 
 void main(void) {
@@ -29,4 +30,17 @@ void main(void) {
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
     <$transformModelToClipPosAndPrevClipPos(cam, obj, inPosition, gl_Position, _prevPositionCS)$>
+
+    // varTexCoord1 is the UV offset transformed so it's at a constant
+    // position relative to the camera. This allows us to do a distance-fade
+    // effect to hide the square edges of the grid popping in and out.
+
+    // transform the camera position into model-space
+    vec4 localCamPos = obj._modelInverse * vec4(getEyeWorldPos(), 1.0);
+    varTexCoord1 = varTexCoord0;
+    varTexCoord1.x -= localCamPos.x;
+    varTexCoord1.y -= localCamPos.y;
+
+    varTexCoord1.x = 2.0 * (varTexCoord1.x - 0.5);
+    varTexCoord1.y = 2.0 * (varTexCoord1.y - 0.5);
 }


### PR DESCRIPTION
### This PR

| Alpha 0.999 (to force it to be transparent) | Opaque, Alpha 1
| --- | ---
|<p>The nice antialiasing was already in the shader, but it was being ignored and was only used for discard tests previously, I added a fade so you don't see the edge chunks popping in</p>![overte-snap-by-ada-tv-on-2026-03-23_01-32-13](https://github.com/user-attachments/assets/d16a2d26-fc46-486b-a3ee-0d3b1f0895d0) | <p>The edge fade also applies on opaque mode, so even though it looks rougher the edge chunks don't pop in</p> ![overte-snap-by-ada-tv-on-2026-03-23_01-32-28](https://github.com/user-attachments/assets/54e6178c-9037-44ce-8da5-3bb03cbbfc73)

### Master
| Alpha 0.999 | Opaque, Alpha 1
| --- | ---
| <p>The alpha was only used when the discard test passed, so it was pixelated both when transparent and opaque</p> ![overte-snap-by-ada-tv-on-2026-03-23_01-37-24](https://github.com/user-attachments/assets/79da34ae-8769-462c-9577-8b6a5a958cf8) | ![overte-snap-by-ada-tv-on-2026-03-23_01-37-38](https://github.com/user-attachments/assets/e9d01beb-08b9-4c15-9071-73c77e2b5925)