### PR TITLE
Fix segfault on assigning undefined to bool in FlickableWebViewCore

### DIFF
--- a/interface/resources/qml/controls/+webengine/FlickableWebViewCore.qml
+++ b/interface/resources/qml/controls/+webengine/FlickableWebViewCore.qml
@@ -18,7 +18,11 @@ Item {
     // property alias webViewCoreProfile: webViewCore.profile
     property string webViewCoreUserAgent
 
-    property bool useBackground: webViewCore.useBackground
+    property bool useBackground: false
+    Component.onCompleted: {
+        useBackground = Qt.binding(function() { return webViewCore.useBackground ?? false; })
+    }
+
     property string userAgent: webViewCore.profile.httpUserAgent
     property string userScriptUrl: ""
     property string urlTag: "noDownload=false";


### PR DESCRIPTION
Sometimes a tablet app tries to assign a non-existent webViewCore.useBackground to bool useBackground in +webengine/FlickableWebViewCore.qml. Defers assignment with Component.onCompleted to avoid warnings and segfaults.

Fixes #1149
Fixes #1956