### PR TITLE
Update libiconv to 1.18 to fix a build failure on Fedora 43

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -86,6 +86,8 @@ class Overte(ConanFile):
         self.requires("zlib/1.3.1")
         self.requires("glm/0.9.9.5", force=True) # FIXME: update to version 1.0.1
         self.requires("jsoncpp/1.9.6", force=True)
+        self.requires("libiconv/1.18", force=True)
+
         openssl = "openssl/1.1.1q"
 
         if self.options.qt_source == "system":


### PR DESCRIPTION
It blows up with:

```
In file included from /home/dale/.conan2/p/b/libicb06e5c9e14b9d/b/src/lib/loops.h:23,
                 from /home/dale/.conan2/p/b/libicb06e5c9e14b9d/b/src/lib/iconv.c:148:
/home/dale/.conan2/p/b/libicb06e5c9e14b9d/b/src/lib/loop_wchar.h:39:17: error: conflicting types for 'mbrtowc'; have 'size_t(void)' {aka 'long unsigned int(void)'}
   39 |   extern size_t mbrtowc ();
      |                 ^~~~~~~
In file included from ../include/iconv.h:118,
                 from /home/dale/.conan2/p/b/libicb06e5c9e14b9d/b/src/lib/iconv.c:20:
/usr/include/wchar.h:321:15: note: previous declaration of 'mbrtowc' with type 'size_t(wchar_t * restrict,  const char * restrict,  size_t,  mbstate_t * restrict)' {aka 'long unsigned int(int * restrict,  const char * restrict,  long unsigned int,  mbstate_t * restrict)'}
  321 | extern size_t mbrtowc (wchar_t *__restrict __pwc,
      |               ^~~~~~~
/home/dale/.conan2/p/b/libicb06e5c9e14b9d/b/src/lib/loop_wchar.h: In function 'wchar_to_loop_convert':
/home/dale/.conan2/p/b/libicb06e5c9e14b9d/b/src/lib/loop_wchar.h:356:15: error: too many arguments to function 'mbrtowc'; expected 0, have 4
  356 |         res = mbrtowc(&wc,buf,bufcount,&state);
      |               ^~~~~~~ ~~~
/home/dale/.conan2/p/b/libicb06e5c9e14b9d/b/src/lib/loop_wchar.h:39:17: note: declared here
   39 |   extern size_t mbrtowc ();
      |                 ^~~~~~~
make[1]: *** [Makefile:87: iconv.lo] Error 1
make[1]: Leaving directory '/home/dale/.conan2/p/b/libicb06e5c9e14b9d/b/build-release/lib'
make: *** [Makefile:33: all] Error 2
```

