### PR TITLE
Update system scripts to use strict mode (#2144)

### DIFF
--- a/scripts/system/controllers/controllerModules/inEditMode.js
+++ b/scripts/system/controllers/controllerModules/inEditMode.js
@@ -1,4 +1,4 @@
-"no use strict";
+"use strict";
 
 //  inEditMode.js
 //

--- a/scripts/system/controllers/controllerModules/inVREditMode.js
+++ b/scripts/system/controllers/controllerModules/inVREditMode.js
@@ -1,4 +1,4 @@
-"no use strict";
+"use strict";
 
 //  inVREditMode.js
 //

--- a/scripts/system/controllers/controllerModules/stylusInput.js
+++ b/scripts/system/controllers/controllerModules/stylusInput.js
@@ -1,4 +1,4 @@
-"no use strict";
+"use strict";
 
 //  stylusInput.js
 //

--- a/scripts/system/create/modules/createWindow.js
+++ b/scripts/system/create/modules/createWindow.js
@@ -1,4 +1,4 @@
-"no use strict";
+"use strict";
 
 //  createWindow.js
 //


### PR DESCRIPTION
Fixes #2144
Hi! I have updated the system scripts (like inEditMode.js, createWindow.js, etc.) to use strict mode as requested.
During my search, I also found "no use strict"; at the top of some bundled/vendor files (like the Ace/JSHint worker scripts). However, I intentionally left them unchanged, as enforcing strict mode on third-party minified libraries often breaks them.
Please let me know if you'd like me to update those as well, or if this PR is good to go!