### PR TITLE
Allow UDP packets to be fragmented

### DIFF
--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -63,22 +63,6 @@ void Socket::bind(SocketType socketType, const QHostAddress& address, quint16 po
 
     if (_shouldChangeSocketOptions) {
         setSystemBufferSizes(socketType);
-        if (socketType == SocketType::WebRTC) {
-            return;
-        }
-
-#if defined(Q_OS_LINUX)
-        auto sd = _networkSocket.socketDescriptor(socketType);
-        int val = IP_PMTUDISC_DONT;
-        setsockopt(sd, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof(val));
-#elif defined(Q_OS_WIN)
-        auto sd = _networkSocket.socketDescriptor(socketType);
-        int val = 0; // false
-        if (setsockopt(sd, IPPROTO_IP, IP_DONTFRAGMENT, (const char *)&val, sizeof(val))) {
-            auto wsaErr = WSAGetLastError();
-            qCWarning(networking) << "Socket::bind Cannot setsockopt IP_DONTFRAGMENT" << wsaErr;
-        }
-#endif
     }
 }
 


### PR DESCRIPTION
Experment to allow Overte to fragment packets, as it was explicitly disabling it before. Since it's known that some packets do go beyond MTU limits, those packets are guaranteed to be dropped in transit, so this might be a workaround for now until the packet sizes are fixed.

(cc @zedwick)