### PR TITLE
Read glxContext field so compiler doesn't incorrectly optimise it out

### DIFF
--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -12,6 +12,11 @@
 #include <QString>
 #include <QGuiApplication>
 
+#if defined(Q_OS_LINUX)
+#include <QOpenGLContext>
+#include <QtPlatformHeaders/QGLXNativeContext>
+#endif
+
 #if defined(HAVE_VULKAN)
 #include <QMessageBox>
 #endif
@@ -515,6 +520,15 @@ bool OpenXrContext::initSession() {
             .glxDrawable = glXGetCurrentDrawable(),
             .glxContext = glXGetCurrentContext(),
         };
+
+        // HACK: Is this a compiler bug? How come adding this check fixes
+        // the XR_ERROR_GRAPHICS_DEVICE_INVALID (glxContext is null) error??
+        // Putting glxContext into a separate variable and checking that *doesn't*
+        // work, but checking it after xlibBinding has been initialised with it *does*?
+        if (!xlibBinding.glxContext) {
+            qCCritical(xr_context_cat, "glXContext is null");
+            return false;
+        }
 
         info.next = &xlibBinding;
     }

--- a/plugins/openxr/src/OpenXrDisplayPlugin.cpp
+++ b/plugins/openxr/src/OpenXrDisplayPlugin.cpp
@@ -489,6 +489,8 @@ void OpenXrDisplayPlugin::updatePresentPose() {
         return;
     }
 
+    if (!_context->_isSessionRunning) { return; }
+
     if (_lastFrameState.predictedDisplayTime == 0) { return; }
 
     _context->_lastPredictedDisplayTime = _lastFrameState.predictedDisplayTime;


### PR DESCRIPTION
*Extremely* cursed bug that somehow gets OpenXR working on GLX again for me

Also short-circuits the LocateViews calls so they only happen once the session has started, cutting down on error log spam