### PR TITLE
Web URL API

### DIFF
--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -47,6 +47,7 @@
 #include "ScriptContext.h"
 #include "XMLHttpRequestClass.h"
 #include "WebSocketClass.h"
+#include "URLClass.h"
 #include "ScriptEngine.h"
 #include "ScriptEngineCast.h"
 #include "ScriptEngineLogging.h"
@@ -869,6 +870,11 @@ void ScriptManager::init() {
 
         scriptEngine->registerGlobalObject(sgp, "UserActivityLogger", DependencyManager::get<UserActivityLoggerScriptingInterface>().data());
     }
+
+    ScriptValue urlValue = scriptEngine->newFunction(URLClass::constructor);
+    urlValue.setProperty("parse", scriptEngine->newFunction(URLClass::parse));
+    urlValue.setProperty("canParse", scriptEngine->newFunction(URLClass::canParse));
+    scriptEngine->globalObject().setProperty("URL", urlValue);
 
 #if DEV_BUILD || PR_BUILD
     scriptEngine->registerGlobalObject(sgp, "StackTest", new StackTestScriptingInterface(this));

--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -808,8 +808,13 @@ void ScriptManager::init() {
         // For test scripts we want to minimize the amount of functionality available, for the least
         // amount of dependencies and faster test system startup.
 
-        ScriptValue xmlHttpRequestConstructorValue = scriptEngine->newFunction(XMLHttpRequestClass::constructor);
-        scriptEngine->globalObject().setProperty("XMLHttpRequest", xmlHttpRequestConstructorValue);
+        ScriptValue xhrValue = scriptEngine->newFunction(XMLHttpRequestClass::constructor);
+        xhrValue.setProperty("UNSENT", XMLHttpRequestClass::UNSENT);
+        xhrValue.setProperty("OPENED", XMLHttpRequestClass::OPENED);
+        xhrValue.setProperty("HEADERS_RECEIVED", XMLHttpRequestClass::HEADERS_RECEIVED);
+        xhrValue.setProperty("LOADING", XMLHttpRequestClass::LOADING);
+        xhrValue.setProperty("DONE", XMLHttpRequestClass::DONE);
+        scriptEngine->globalObject().setProperty("XMLHttpRequest", xhrValue);
 
         ScriptValue webSocketConstructorValue = scriptEngine->newFunction(WebSocketClass::constructor);
         scriptEngine->globalObject().setProperty("WebSocket", webSocketConstructorValue);

--- a/libraries/script-engine/src/URLClass.cpp
+++ b/libraries/script-engine/src/URLClass.cpp
@@ -1,0 +1,255 @@
+//
+//  URLClass.cpp
+//  libraries/script-engine/src/
+//
+//  Created by Ada <ada@thingvellir.net> on 2026-04-09
+//  Copyright 2026 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ScriptContext.h"
+#include "URLClass.h"
+
+URLClass::URLClass(ScriptEngine* engine, QUrl url) : _engine(engine), _url(url) {}
+
+ScriptValue URLClass::constructor(ScriptContext *context, ScriptEngine *engine) {
+    if (context->argumentCount() == 0) {
+        engine->raiseException("URL constructor requires at least one argument");
+        return engine->nullValue();
+    }
+
+    QString argUrl = context->argument(0).toString();
+    QString argBase;
+
+    if (context->argumentCount() > 1) {
+        argBase = context->argument(1).toString();
+    }
+
+    auto value = URLClass::parse(engine, argUrl, argBase);
+
+    if (value.isNull()) {
+        engine->raiseException("URL could not be parsed");
+        return engine->nullValue();
+    }
+
+    return value;
+}
+
+bool URLClass::canParse(const QString& argUrl, const QString& argBase) {
+    auto url = QUrl(argUrl);
+    auto base = QUrl(argBase);
+
+    if (!url.isValid()) { return false; }
+
+    if (url.isRelative() && !base.isValid()) { return false; }
+
+    auto full = base.resolved(url);
+
+    return full.isValid();
+}
+
+ScriptValue URLClass::canParse(ScriptContext* context, ScriptEngine* engine) {
+    if (context->argumentCount() == 0) {
+        engine->raiseException("URL.canParse requires at least one argument");
+        return engine->nullValue();
+    }
+
+    QString argUrl = context->argument(0).toString();
+    QString argBase;
+
+    if (context->argumentCount() > 1) {
+        argBase = context->argument(1).toString();
+    }
+
+    return engine->newValue(URLClass::canParse(argUrl, argBase));
+}
+
+ScriptValue URLClass::parse(ScriptContext* context, ScriptEngine* engine) {
+    if (context->argumentCount() == 0) {
+        engine->raiseException("URL.parse requires at least one argument");
+        return engine->nullValue();
+    }
+
+    QString argUrl = context->argument(0).toString();
+    QString argBase;
+
+    if (context->argumentCount() > 1) {
+        argBase = context->argument(1).toString();
+    }
+
+    return URLClass::parse(engine, argUrl, argBase);
+}
+
+ScriptValue URLClass::parse(ScriptEngine* engine, const QString& argUrl, const QString& argBase) {
+    auto url = QUrl(argUrl);
+    auto base = QUrl(argBase);
+
+    if (!url.isValid()) { return engine->nullValue(); }
+
+    if (url.isRelative() && !base.isValid()) {
+        return engine->nullValue();
+    }
+
+    if (base.isValid()) {
+        url = base.resolved(url);
+    }
+
+    return engine->newQObject(new URLClass(engine, url), ScriptEngine::ScriptOwnership);
+}
+
+QString URLClass::getHash() const {
+    if (_url.hasFragment()) {
+        return QString("#%1").arg(_url.fragment(QUrl::FullyEncoded));
+    } else {
+        return "";
+    }
+}
+
+QString URLClass::getHost() const {
+    if (_url.port() == -1) {
+        return _url.host();
+    } else {
+        return QString("%1:%2").arg(_url.host()).arg(_url.port());
+    }
+}
+
+QString URLClass::getHostname() const {
+    return _url.host();
+}
+
+QString URLClass::getHref() const {
+    return _url.toString(QUrl::FullyEncoded);
+}
+
+QString URLClass::getOrigin() const {
+    return QString("%1://%2").arg(_url.scheme()).arg(getHost());
+}
+
+QString URLClass::getPassword() const {
+    return _url.password();
+}
+
+QString URLClass::getPathname() const {
+    auto path = _url.path();
+
+    if (path.isEmpty()) {
+        if (
+            auto scheme = _url.scheme();
+            scheme == "http" ||
+            scheme == "https" ||
+            scheme == "file"
+        ) {
+            return "/";
+        }
+    }
+
+    return path;
+}
+
+QString URLClass::getPort() const {
+    if (auto port = _url.port(); port != -1) {
+        return QString::number(port);
+    } else {
+        return "";
+    }
+}
+
+QString URLClass::getProtocol() const {
+    return QString("%1:").arg(_url.scheme());
+}
+
+QString URLClass::getSearch() const {
+    if (auto query = _url.query(QUrl::FullyEncoded); !query.isEmpty()) {
+        return QString("?%1").arg(query);
+    } else {
+        return "";
+    }
+}
+
+QString URLClass::getUsername() const {
+    return _url.userName();
+}
+
+void URLClass::setHash(const QString& value) {
+    if (value.startsWith('#')) {
+        // QT6TODO: use QString::slice instead
+        _url.setFragment(QString(value.constData() + 1, value.size() - 1));
+    } else {
+        _url.setFragment(value);
+    }
+}
+
+void URLClass::setHost(const QString& value) {
+    if (value.contains(':')) {
+        auto parts = value.split(':');
+    } else {
+        _url.setHost(value);
+        _url.setPort(-1);
+    }
+}
+
+void URLClass::setHostname(const QString& value) {
+    _url.setHost(value);
+}
+
+void URLClass::setHref(const QString& value) {
+    auto tmp = QUrl(value);
+
+    if (!tmp.isValid()) {
+        _engine->raiseException("Invalid URL");
+        return;
+    }
+
+    _url = tmp;
+}
+
+void URLClass::setPassword(const QString& value) {
+    _url.setPassword(value);
+}
+
+void URLClass::setPathname(const QString& value) {
+    _url.setPath(value);
+}
+
+void URLClass::setPort(const QString& value) {
+    if (value.isEmpty()) {
+        _url.setPort(-1);
+        return;
+    }
+
+    bool ok = false;
+    int port = value.toInt(&ok);
+
+    if (!ok) {
+        _engine->raiseException("Invalid port");
+        return;
+    }
+
+    _url.setPort(port);
+}
+
+void URLClass::setProtocol(const QString& value) {
+    if (value.isEmpty()) {
+        _url.setScheme("");
+    } else if (value.endsWith(':')) {
+        _url.setScheme(QString(value.constData(), value.size() - 1));
+    } else {
+        _url.setScheme(value);
+    }
+}
+
+void URLClass::setSearch(const QString& value) {
+    if (value.startsWith('?')) {
+        // QT6TODO: use QString::slice instead
+        _url.setQuery(QString(value.constData() + 1, value.size() - 1));
+    } else {
+        _url.setQuery(value);
+    }
+}
+
+void URLClass::setUsername(const QString& value) {
+    _url.setUserName(value);
+}

--- a/libraries/script-engine/src/URLClass.cpp
+++ b/libraries/script-engine/src/URLClass.cpp
@@ -185,6 +185,21 @@ void URLClass::setHash(const QString& value) {
 void URLClass::setHost(const QString& value) {
     if (value.contains(':')) {
         auto parts = value.split(':');
+
+        _url.setHost(parts[0]);
+
+        if (parts.size() > 1) {
+            bool ok = false;
+            auto port = parts[1].toInt(&ok);
+
+            if (ok && port > 0 && port < 65536) {
+                _url.setPort(port);
+            } else {
+                _url.setPort(-1);
+            }
+        } else {
+            _url.setPort(-1);
+        }
     } else {
         _url.setHost(value);
         _url.setPort(-1);

--- a/libraries/script-engine/src/URLClass.h
+++ b/libraries/script-engine/src/URLClass.h
@@ -1,0 +1,146 @@
+//
+//  URLClass.h
+//  libraries/script-engine/src/
+//
+//  Created by Ada <ada@thingvellir.net> on 2026-04-09
+//  Copyright 2026 Overte e.V.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+/// @addtogroup ScriptEngine
+/// @{
+
+#ifndef hifi_URLClass_h
+#define hifi_URLClass_h
+
+#include <QUrl>
+
+#include "ScriptEngine.h"
+#include "ScriptValue.h"
+
+class ScriptContext;
+
+/*@jsdoc
+ * Provides a means to parse and construct URLs. It is a near-complete implementation
+ * of <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL">the Web URL API
+ * as described on MDN.</a>
+ *
+ * <p><code>URL.createObjectURL</code> and <code>URL.revokeObjectURL</code>
+ * are not currently supported.</p>
+ *
+ * @class URL
+ * @param {string} url - An absolute or relative URL. If relative, then <code>base</code> must be specified.
+ * @param {string} [base] - The absolute base URL to resolve <code>url</code> against.
+ *
+ * @hifi-interface
+ * @hifi-client-entity
+ * @hifi-avatar
+ * @hifi-server-entity
+ * @hifi-assignment-client
+ *
+ * @property {string} hash - The fragment part.
+ * @property {string} host - The domain hostname and port separated by ':', if present.
+ * @property {string} hostname - The domain hostname.
+ * @property {string} href - Contains the whole URL as a string.
+ * @property {string} origin - The scheme, domain hostname, and port. <em>Read-only.</em>
+ * @property {string} password - The password in the userinfo part, before the hostname.
+ * @property {string} pathname - The path part, starting with '/' and not including the query or fragment parts.
+ * @property {string} port - A string of the host port number.
+ * @property {string} protocol - The protocol scheme of the URL including the trailing ':': i.e. <code>https:</code> or <code>file:</code>.
+ * @property {string} search - The query part of the URL, as one whole string.
+ * @property {string} username - The username in the userinfo part, before the hostname.
+ */
+class URLClass : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString hash READ getHash WRITE setHash)
+    Q_PROPERTY(QString host READ getHost WRITE setHost)
+    Q_PROPERTY(QString hostname READ getHostname WRITE setHostname)
+    Q_PROPERTY(QString href READ getHref WRITE setHref)
+    Q_PROPERTY(QString origin READ getOrigin)
+    Q_PROPERTY(QString password READ getPassword WRITE setPassword)
+    Q_PROPERTY(QString pathname READ getPathname WRITE setPathname)
+    Q_PROPERTY(QString port READ getPort WRITE setPort)
+    Q_PROPERTY(QString protocol READ getProtocol WRITE setProtocol)
+    Q_PROPERTY(QString search READ getSearch WRITE setSearch)
+    // TODO: ScriptValue Map support?
+    // Q_PROPERTY(ScriptValue searchParams READ getSearchParams)
+    Q_PROPERTY(QString username READ getUsername WRITE setUsername)
+
+public:
+    URLClass(ScriptEngine* engine, QUrl url);
+
+    operator QString() const { return getHref(); }
+
+    static ScriptValue constructor(ScriptContext* context, ScriptEngine* engine);
+
+    /*@jsdoc
+     * Allows you to check if a URL is valid without needing to use a <code>try...catch</code>
+     * block with the <code>URL</code> constructor.
+     * <strong>Static method</strong>. Only available on the global <code>URL</code> object.
+     * @function URL.canParse
+     * @param {string} url
+     * @param {string} [base]
+     * @returns {boolean} <code>true</code> if a URL string can be parsed and <code>false</code> otherwise.
+     */
+    static ScriptValue canParse(ScriptContext* context, ScriptEngine* engine);
+    static bool canParse(const QString& url, const QString& base = QString());
+
+    /*@jsdoc
+     * A non-throwing alternative to the <code>URL</code> constructor.
+     * <strong>Static method</strong>. Only available on the global <code>URL</code> object.
+     * @function URL.parse
+     * @param {string} url
+     * @param {string} [base]
+     * @returns {?URL} A <code>URL</code> object, or <code>null</code> if the URL can't be parsed.
+     */
+    static ScriptValue parse(ScriptContext* context, ScriptEngine* engine);
+    static ScriptValue parse(ScriptEngine* engine, const QString& url, const QString& base = QString());
+
+    /*@jsdoc
+     * Equivalent to <code>URL.href</code>.
+     * @function URL#toString
+     * @returns {string} A string containing the whole URL.
+     */
+    Q_INVOKABLE QString toString() const { return getHref(); }
+
+    /*@jsdoc
+     * Equivalent to <code>URL.href</code>.
+     * @function URL#toJSON
+     * @returns {string} A string containing the whole URL.
+     */
+    Q_INVOKABLE QString toJSON() const { return getHref(); }
+
+private:
+    QString getHash() const;
+    QString getHost() const;
+    QString getHostname() const;
+    QString getHref() const;
+    QString getOrigin() const;
+    QString getPassword() const;
+    QString getPathname() const;
+    QString getPort() const;
+    QString getProtocol() const;
+    QString getSearch() const;
+    QString getUsername() const;
+
+    void setHash(const QString& value);
+    void setHost(const QString& value);
+    void setHostname(const QString& value);
+    void setHref(const QString& value);
+    void setPassword(const QString& value);
+    void setPathname(const QString& value);
+    void setPort(const QString& value);
+    void setProtocol(const QString& value);
+    void setSearch(const QString& value);
+    void setUsername(const QString& value);
+
+    ScriptEngine* _engine;
+    QUrl _url;
+};
+
+#endif // hifi_URLCLass_h
+
+/// @}


### PR DESCRIPTION
Fixes #1902

Also adds the `readyState` constants onto the `XMLHttpRequest` global, like it is on the Web.

This can be tested by viewing the object dump of `URL.parse("whatever url you want")` and `URL.parse("/some/subpath", "http://some.website")` in the JS console.