### PR TITLE
Add getControllerWorldLocation to apidocs

### DIFF
--- a/scripts/system/libraries/controllers.js
+++ b/scripts/system/libraries/controllers.js
@@ -45,7 +45,42 @@ const getGrabPointSphereOffset = function(handController, ignoreSensorToWorldSca
     }
 };
 
-// controllerWorldLocation is where the controller would be, in-world, with an added offset
+/*@jsdoc
+ *
+ * This is a javascript library and is not included by default. To use the method(s) below, you must first include the library.
+ *
+ * @example <caption>Include this library in your script.</caption>
+ * Script.include("/~/system/libraries/controllers.js");
+ * @namespace Controllers
+ */
+
+/*@jsdoc
+ * @typedef {Object} Controllers.controllerWorldLocation
+ * @property {Vec3} position - The position of the controller, relative to the world
+ * @property {Vec3} translation - Deprecated: Use position instead.
+ * @property {Quat} orientation - The orientation of the controller, relative to the world
+ * @property {Quat} rotation - Deprecated: Use orientation instead.
+ * @property {boolean} valid
+ */
+
+/*@jsdoc
+ * controllerWorldLocation is where the controller would be, in-world, with an added offset
+ *
+ * @example <caption>Get the controllerWorldPosition and print it to log.</caption>
+ *
+ * Script.include("/~/system/libraries/controllers.js");
+ *
+ * const controllerWorldLocation = getControllerWorldLocation(Controller.Standard.LeftHand, true);
+ *
+ * print(controllerWorldLocation);
+ *
+ *
+ * @name Controllers.getControllerWorldLocation
+ * @function
+ * @param {Controller.Standard} handController - Which hand controller? LeftHand or RightHand.
+ * @param {boolean} doOffset - true if returned position should be offset, so the grab position is in front of hand
+ * @returns {Controllers.controllerWorldLocation}
+ */
 const getControllerWorldLocation = function (handController, doOffset) {
     var orientation;
     var position;

--- a/scripts/system/libraries/controllers.js
+++ b/scripts/system/libraries/controllers.js
@@ -45,7 +45,7 @@ const getGrabPointSphereOffset = function(handController, ignoreSensorToWorldSca
     }
 };
 
-/*@jsdoc
+/**@jsdoc
  *
  * This is a javascript library and is not included by default. To use the method(s) below, you must first include the library.
  *
@@ -54,7 +54,7 @@ const getGrabPointSphereOffset = function(handController, ignoreSensorToWorldSca
  * @namespace Controllers
  */
 
-/*@jsdoc
+/**@jsdoc
  * @typedef {Object} Controllers.controllerWorldLocation
  * @property {Vec3} position - The position of the controller, relative to the world
  * @property {Vec3} translation - Deprecated: Use position instead.
@@ -63,7 +63,7 @@ const getGrabPointSphereOffset = function(handController, ignoreSensorToWorldSca
  * @property {boolean} valid
  */
 
-/*@jsdoc
+/**@jsdoc
  * controllerWorldLocation is where the controller would be, in-world, with an added offset
  *
  * @example <caption>Get the controllerWorldPosition and print it to log.</caption>

--- a/scripts/system/libraries/controllers.js
+++ b/scripts/system/libraries/controllers.js
@@ -47,7 +47,7 @@ const getGrabPointSphereOffset = function(handController, ignoreSensorToWorldSca
 
 /**@jsdoc
  *
- * This is a javascript library and is not included by default. To use the method(s) below, you must first include the library.
+ * This is a JavaScript library and is not included by default. To use the method(s) below, you must first include the library.
  *
  * @example <caption>Include this library in your script.</caption>
  * Script.include("/~/system/libraries/controllers.js");

--- a/tools/jsdoc/plugins/hifi.js
+++ b/tools/jsdoc/plugins/hifi.js
@@ -69,12 +69,13 @@ exports.handlers = {
             '../../libraries/ui/src/ui',
             '../../plugins/oculus/src',
             '../../plugins/openvr/src',
-            '../../scripts/modules',
-            '../../scripts/system/libraries'
+            '../../scripts/modules', // js
+            '../../scripts/system/libraries', // js
         ];
 
         // only files with this extension will be searched for jsdoc comments.
-        const exts = ['.h', '.h.in', '.cpp', '.cpp.in', '.js'];
+        const exts = ['.h', '.h.in', '.cpp', '.cpp.in']; // C++
+        const jsExts = ['.js']; // Javascript
 
         const fs = require('fs');
         dirList.forEach(function (dir) {
@@ -82,18 +83,27 @@ exports.handlers = {
             const files = fs.readdirSync(joinedDir);
             files.forEach(function (file) {
                 const path = pathTools.join(joinedDir, file);
-                if (fs.lstatSync(path).isFile() && endsWith(path, exts)) {
-                    // load entire file into a string
-                    const data = fs.readFileSync(path, "utf8");
+                let reg;
+                if (fs.lstatSync(path).isFile()) {
+                    if (endsWith(path, exts)) { // C++
+                        // this regex searches for blocks starting with /*@jsdoc and end with */
+                        reg = /(\/\*@jsdoc((.|[\r\n])*?)\*\/)/gm;
+                    } else if (endsWith(path, jsExts)) { // Javascript
+                        // this regex searches for blocks starting with /**@jsdoc and end with */
+                        reg = /(\/\*\*@jsdoc((.|[\r\n])*?)\*\/)/gm;
+                    }
 
-                    // this regex searches for blocks starting with /*@jsdoc and end with */
-                    const reg = /(\/\*@jsdoc(.|[\r\n])*?\*\/)/gm;
-                    const matches = data.match(reg);
-                    if (matches) {
-                        // add to source, but strip off c-comment asterisks
-                        e.source += matches.map(function (s) {
-                            return s.replace('/*@jsdoc', '/**');
-                        }).join('\n');
+                    if (reg) {
+                        // load entire file into a string
+                        const data = fs.readFileSync(path, "utf8");
+
+                        const matches = data.matchAll(reg);
+                        if (matches) {
+                            // add to source, but strip off c-comment asterisks
+                            e.source += [...matches].map(function (g) {
+                                return `/**${g[2]}*/`;
+                            }).join('\n');
+                        }
                     }
                 }
             });

--- a/tools/jsdoc/plugins/hifi.js
+++ b/tools/jsdoc/plugins/hifi.js
@@ -67,11 +67,13 @@ exports.handlers = {
             '../../libraries/ui/src',
             '../../libraries/ui/src/ui',
             '../../plugins/oculus/src',
-            '../../plugins/openvr/src'
+            '../../plugins/openvr/src',
+            '../../scripts/modules',
+            '../../scripts/system/libraries'
         ];
 
         // only files with this extension will be searched for jsdoc comments.
-        var exts = ['.h', '.h.in', '.cpp', '.cpp.in'];
+        var exts = ['.h', '.h.in', '.cpp', '.cpp.in', '.js'];
 
         var fs = require('fs');
         dirList.forEach(function (dir) {

--- a/tools/jsdoc/plugins/hifi.js
+++ b/tools/jsdoc/plugins/hifi.js
@@ -1,5 +1,6 @@
+"use strict"
 function endsWith(path, exts) {
-    var result = false;
+    let result = false;
     exts.forEach(function(ext) {
         if (path.endsWith(ext)) {
             result = true;
@@ -14,12 +15,12 @@ exports.handlers = {
     // We use this event to scan the C++ files for jsdoc comments
     // and reformat them into a form digestable by jsdoc.
     beforeParse: function(e) {
-        var pathTools = require('path');
-        var rootFolder = pathTools.dirname(e.filename);
+        const pathTools = require('path');
+        const rootFolder = pathTools.dirname(e.filename);
         console.log("Scanning the Overte source for JSDoc comments...");
 
         // directories to scan for jsdoc comments
-        var dirList = [
+        const dirList = [
             '../../assignment-client/src',
             '../../assignment-client/src/avatars',
             '../../assignment-client/src/entities',
@@ -73,21 +74,21 @@ exports.handlers = {
         ];
 
         // only files with this extension will be searched for jsdoc comments.
-        var exts = ['.h', '.h.in', '.cpp', '.cpp.in', '.js'];
+        const exts = ['.h', '.h.in', '.cpp', '.cpp.in', '.js'];
 
-        var fs = require('fs');
+        const fs = require('fs');
         dirList.forEach(function (dir) {
-            var joinedDir = pathTools.join(rootFolder, dir);
-            var files = fs.readdirSync(joinedDir);
+            const joinedDir = pathTools.join(rootFolder, dir);
+            const files = fs.readdirSync(joinedDir);
             files.forEach(function (file) {
-                var path = pathTools.join(joinedDir, file);
+                const path = pathTools.join(joinedDir, file);
                 if (fs.lstatSync(path).isFile() && endsWith(path, exts)) {
                     // load entire file into a string
-                    var data = fs.readFileSync(path, "utf8");
+                    const data = fs.readFileSync(path, "utf8");
 
                     // this regex searches for blocks starting with /*@jsdoc and end with */
-                    var reg = /(\/\*@jsdoc(.|[\r\n])*?\*\/)/gm;
-                    var matches = data.match(reg);
+                    const reg = /(\/\*@jsdoc(.|[\r\n])*?\*\/)/gm;
+                    const matches = data.match(reg);
                     if (matches) {
                         // add to source, but strip off c-comment asterisks
                         e.source += matches.map(function (s) {
@@ -105,7 +106,7 @@ exports.handlers = {
 
         // we only care about hifi custom tags on namespace and class doclets
         if (e.doclet.kind === "namespace" || e.doclet.kind === "class") {
-            var rows = [];
+            const rows = [];
             if (e.doclet.hifiInterface) {
                 rows.push("Interface Scripts");
             }
@@ -124,7 +125,7 @@ exports.handlers = {
 
             // Append an Available In: sentence at the beginning of the namespace description.
             if (rows.length > 0) {
-                var availableIn = "<p class='availableIn'><b>Supported Script Types:</b> " + rows.join(" &bull; ") + "</p>";
+                const availableIn = "<p class='availableIn'><b>Supported Script Types:</b> " + rows.join(" &bull; ") + "</p>";
 
                 e.doclet.description = availableIn + (e.doclet.description ? e.doclet.description : "");
             }

--- a/tools/jsdoc/plugins/hifiJSONExport.js
+++ b/tools/jsdoc/plugins/hifiJSONExport.js
@@ -1,11 +1,12 @@
+"use strict"
 exports.handlers = {
     processingComplete: function(e) {
         const pathTools = require('path');
-        var outputFolder;
-        var doclets = e.doclets.map(doclet => Object.assign({}, doclet));
+        let outputFolder;
+        const doclets = e.doclets.map(doclet => Object.assign({}, doclet));
 
-        var argv = process.argv;
-        for (var i = 0; i < argv.length; i++) {
+        const argv = process.argv;
+        for (let i = 0; i < argv.length; i++) {
             if (argv[i] === '-d') {
                 outputFolder = argv[i+1];
                 break;


### PR DESCRIPTION
Before this PR it seems no scripts libraries or modules were included in the apidocs. This is the first step to resolving this.

* JSDocs will now look in `scripts/modules` and `scripts/system/libraries`.
* JSDocs will look for `.js` files
* javascript files must use `/**@jsdoc` syntax, similar to `/*@jsdoc` as used in the c++ files, rather than `/**`, to start their comments
* `scripts/system/libraries/controllers.js` has been documented, with its own page in the API docs.

I made sure to document how to include the library at the top of the file, as it works differently to the other APIs.

Resolves #124 