### PR TITLE
Fix two cases of negative timer intervals.

### DIFF
--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -1281,7 +1281,20 @@ QTimer* ScriptManager::setupTimerWithInterval(const ScriptValue& function, int i
     CallbackData timerData = { function, currentEntityIdentifier, currentSandboxURL };
     _timerFunctionMap.insert(newTimer, timerData);
 
-    newTimer->start(intervalMS);
+    if (intervalMS < 0) {
+        int lineNumber = -1;
+        QString fileName = getFilename();
+        auto context = _engine->currentContext();
+        if (context) {
+            lineNumber = context->currentLineNumber();
+            fileName = context->currentFileName();
+        }
+
+        scriptWarningMessage("Script.setInterval() was passed negative value " + QString::number(intervalMS) + ". Ignored, timer not started. Parent script:" + getFilename(), fileName, lineNumber);
+    } else {
+        newTimer->start(intervalMS);
+    }
+
     return newTimer;
 }
 

--- a/libraries/shared/src/SharedUtil.cpp
+++ b/libraries/shared/src/SharedUtil.cpp
@@ -782,7 +782,7 @@ bool similarStrings(const QString& stringA, const QString& stringB) {
 void disableQtBearerPoll() {
     // To disable the Qt constant wireless scanning, set the env for polling interval to -1
     // The constant polling causes ping spikes on windows every 10 seconds or so that affect the audio
-    const QByteArray DISABLE_BEARER_POLL_TIMEOUT = QString::number(-1).toLocal8Bit();
+    const QByteArray DISABLE_BEARER_POLL_TIMEOUT = QString::number(std::numeric_limits<int>::max()).toLocal8Bit();
     qputenv("QT_BEARER_POLL_TIMEOUT", DISABLE_BEARER_POLL_TIMEOUT);
 }
 


### PR DESCRIPTION
This fixes issue #2159:

QObject::startTimer: Timers cannot have negative intervals

1. Add a warning to the scripting engine, because you can create timers with Script.setInterval.
2. Fix a warning caused by a workaround in SharedUtil.

The second warning comes from `QNetworkConfigurationManagerPrivate::startPolling`, and is caused by this:

```
const QByteArray DISABLE_BEARER_POLL_TIMEOUT = QString::number(-1).toLocal8Bit();
qputenv("QT_BEARER_POLL_TIMEOUT", DISABLE_BEARER_POLL_TIMEOUT);
```

It's a workaround for an issue causing latency over wifi for some reason.