### PR TITLE
Fix flickering sky on OpenVR and FOV limit on OpenXR

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -411,7 +411,7 @@ glm::mat4 OpenVrDisplayPlugin::getCullingProjection(const glm::mat4& baseProject
     // FIXME: OpenVR gives us tan(angle), how can we clamp
     // this to within ~170° when multiplied by margin?
     // const float maxAngle = 0.9f * PI;
-    const float margin = 1.1f;
+    const float margin = 1.0f;
 
     std::array<float, 4> fovMax = {
         std::min(fovs[0][0], fovs[1][0]) * margin, // left

--- a/plugins/openxr/src/OpenXrDisplayPlugin.cpp
+++ b/plugins/openxr/src/OpenXrDisplayPlugin.cpp
@@ -86,7 +86,7 @@ glm::mat4 OpenXrDisplayPlugin::getCullingProjection(const glm::mat4& baseProject
 
     std::array<XrFovf, 2> fovs = { _views.value()[0].fov, _views.value()[1].fov };
 
-    const float maxAngle = 0.9f * PI;
+    const float maxAngle = 0.9f * PI / 2;
     const float margin = 1.1f;
 
     XrFovf fovMax;


### PR DESCRIPTION
The skybox flickering happens mostly on Anime avatars. Seems to be better or fixed on this branch.