### PR TITLE
Fix build under OVERTE_MEMORY_DEBUGGING

### DIFF
--- a/libraries/gpu/src/gpu/Renderpass.cpp
+++ b/libraries/gpu/src/gpu/Renderpass.cpp
@@ -12,6 +12,10 @@
 
 using namespace gpu;
 
+Renderpass::Renderpass() = default;
+
+Renderpass::~Renderpass() = default;
+
 Attachment::Attachment() {
 }
 


### PR DESCRIPTION
```
[100%] Linking CXX executable interface
/usr/bin/ld: ../libraries/gpu/libgpu.so: undefined reference to `typeinfo for gpu::Renderpass'
```

The class declares a constructor and virtual destructor but doesn't define them. This breaks the build, but only on memory debugging settings for some reason.
