### PR TITLE
Fix octree stats ub

### DIFF
--- a/interface/src/Application_Setup.cpp
+++ b/interface/src/Application_Setup.cpp
@@ -416,7 +416,7 @@ bool setupEssentials(const QCommandLineParser& parser, bool runningMarkerExisted
 
     DependencyManager::set<EntityScriptServerLogClient>();
 
-    DependencyManager::set<OctreeStatsProvider>(nullptr, qApp->getOcteeSceneStats());
+    DependencyManager::set<OctreeStatsProvider>(nullptr);
     DependencyManager::set<AvatarBookmarks>();
     DependencyManager::set<LocationBookmarks>();
     DependencyManager::set<Snapshot>();

--- a/interface/src/ui/OctreeStatsProvider.cpp
+++ b/interface/src/ui/OctreeStatsProvider.cpp
@@ -15,9 +15,8 @@
 #include "Menu.h"
 #include "octree/OctreePacketProcessor.h"
 
-OctreeStatsProvider::OctreeStatsProvider(QObject* parent, NodeToOctreeSceneStats* model) :
+OctreeStatsProvider::OctreeStatsProvider(QObject* parent) :
     QObject(parent),
-    _model(model),
     _statCount(0),
     _averageUpdatesPerSecond(SAMPLES_PER_SECOND)
 {
@@ -70,7 +69,7 @@ void OctreeStatsProvider::updateOctreeStatsData() {
 
     // Do this ever paint event... even if we don't update
     auto totalTrackedEdits = entitiesTree->getTotalTrackedEdits();
-    
+
     const quint64 SAMPLING_WINDOW = USECS_PER_SECOND / SAMPLES_PER_SECOND;
     quint64 now = usecTimestampNow();
     quint64 sinceLastWindow = now - _lastWindowAt;
@@ -152,7 +151,7 @@ void OctreeStatsProvider::updateOctreeStatsData() {
     }
 
     emit sendingModeChanged(m_sendingMode);
-    
+
     // Server Elements
     m_serverElements = QString("Total: %1 / Internal: %2 / Leaves: %3").
             arg(totalNodes).arg(totalInternal).arg(totalLeaves);
@@ -210,7 +209,7 @@ void OctreeStatsProvider::updateOctreeStatsData() {
             .arg(outboundQueuedPPS, 5, 'f', FLOATING_POINT_PRECISION)
             .arg(outboundSentPPS, 5, 'f', FLOATING_POINT_PRECISION);
     emit outboundEditPacketsChanged(m_outboundEditPackets);
-    
+
     // Entity Edits update time
     auto averageEditDelta = entitiesTree->getAverageEditDeltas();
     auto maxEditDelta = entitiesTree->getMaxEditDelta();
@@ -222,7 +221,7 @@ void OctreeStatsProvider::updateOctreeStatsData() {
 
     // Entity Edits
     auto bytesPerEdit = entitiesTree->getAverageEditBytes();
-    
+
     auto updatesPerSecond = _averageUpdatesPerSecond.getAverage();
     if (updatesPerSecond < 1) {
         updatesPerSecond = 0; // we don't really care about small updates per second so suppress those

--- a/interface/src/ui/OctreeStatsProvider.h
+++ b/interface/src/ui/OctreeStatsProvider.h
@@ -38,7 +38,7 @@ class OctreeStatsProvider : public QObject, public Dependency {
     Q_PROPERTY(QStringList servers READ servers NOTIFY serversChanged)
 
 public:
-    OctreeStatsProvider(QObject* parent, NodeToOctreeSceneStats* model);
+    OctreeStatsProvider(QObject* parent);
     ~OctreeStatsProvider();
 
     int serversNum() const;
@@ -120,9 +120,8 @@ protected:
     void showOctreeServersOfType(NodeType_t serverType);
 
 private:
-    NodeToOctreeSceneStats* _model;
     int _statCount;
-    
+
     const int SAMPLES_PER_SECOND = 10;
     SimpleMovingAverage _averageUpdatesPerSecond;
     quint64 _lastWindowAt = usecTimestampNow();

--- a/libraries/gpu/src/gpu/Renderpass.cpp
+++ b/libraries/gpu/src/gpu/Renderpass.cpp
@@ -12,6 +12,10 @@
 
 using namespace gpu;
 
+Renderpass::Renderpass() = default;
+
+Renderpass::~Renderpass() = default;
+
 Attachment::Attachment() {
 }
 


### PR DESCRIPTION
Under OVERTE_MEMORY_DEBUGGING, this happens very early on:

```
[04/11 17:49:01] [DEBUG] [hifi.controllers] 	Input  27 1 "101bff00" :  "CONTEXT_MENU"
[04/11 17:49:01] [DEBUG] [hifi.controllers] 	Input  28 1 "101cff00" :  "TOGGLE_MUTE"
[04/11 17:49:01] [DEBUG] [hifi.controllers] 	Input  125 1 "107dff00" :  "SPRINT"
[04/11 17:49:01] [DEBUG] [hifi.networking] Registering a packet listener for packet list type 76 (EntityScriptGetStatusReply)
[04/11 17:49:01] [DEBUG] [hifi.networking] Registering a packet listener for packet list type 79 (EntityServerScriptLog)
/home/dale/git/overte/overte-master/interface/src/Application.h:329:96: runtime error: member call on null pointer of type 'struct element_type'
/home/dale/git/overte/overte-master/interface/src/Application.h:329:96: runtime error: member access within null pointer of type 'struct element_type'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==1636715==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x0000008d408a bp 0x7ffce75936e0 sp 0x7ffce75936d0 T0)
==1636715==The signal is caused by a READ memory access.
==1636715==Hint: address points to the zero page.
    #0 0x0000008d408a in Application::getOcteeSceneStats() /home/dale/git/overte/overte-master/interface/src/Application.h:329
    #1 0x000000a0e356 in setupEssentials(QCommandLineParser const&, bool) /home/dale/git/overte/overte-master/interface/src/Application_Setup.cpp:419
    #2 0x000000a185cf in Application::initialize(QCommandLineParser const&) /home/dale/git/overte/overte-master/interface/src/Application_Setup.cpp:458
    #3 0x0000011b1261 in main /home/dale/git/overte/overte-master/interface/src/main.cpp:779
    #4 0x7fe9418105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #5 0x7fe941810667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #6 0x00000040b304 in _start (/home/dale/git/overte/overte-master/build/interface/interface+0x40b304) (BuildId: 6455036e8325170958ba58eb35a200a12595b730)

==1636715==Register values:
rax = 0x0000000000000000  rbx = 0x0000000000000000  rcx = 0x00007fe937e1526b  rdx = 0x0000000000000000  
rdi = 0x00000000008d41b4  rsi = 0x00007ffce75936c0  rbp = 0x00007ffce75936e0  rsp = 0x00007ffce75936d0  
 r8 = 0x00007ffce7593138   r9 = 0x00000000000000b9  r10 = 0x00000000ffffffff  r11 = 0x0000000000000202  
r12 = 0x00007be8ff4055b0  r13 = 0x00007be8ff400110  r14 = 0x00007be8ff404790  r15 = 0x00007be8ff20e300  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/dale/git/overte/overte-master/interface/src/Application.h:329 in Application::getOcteeSceneStats()
==1636715==ABORTING
```

`DependencyManager::set<OctreeStatsProvider>(nullptr, qApp->getOcteeSceneStats())` is UB because `qApp->getOcteeSceneStats()` uses `_octreeProcessor`, which isn't initialized yet.

However it turns out this argument isn't actually used for anything, so we can get rid of it and not have any initialization order requirements here.
