### PR TITLE
Fix UB in settings system

### DIFF
--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -332,8 +332,8 @@ namespace Setting {
             _isDeprecated = true;
         }
 
-        T _value;
-        const T _defaultValue;
+        T _value{};
+        const T _defaultValue{};
         bool _isDeprecated{ false };
     };
 


### PR DESCRIPTION
Detected for booleans, but probably applies in other cases too.

```
/home/dale/git/overte/overte-master/libraries/shared/src/SettingHandle.h:295:58: runtime error: load of value 190, which is not a valid value for type 'bool'
    #0 0x0000005fe32e in Setting::Handle<bool>::set(bool const&) /home/dale/git/overte/overte-master/libraries/shared/src/SettingHandle.h:295
    #1 0x0000006815ce in Setting::Handle<bool>::setVariant(QVariant const&) /home/dale/git/overte/overte-master/libraries/shared/src/SettingHandle.h:343
    #2 0x7fabb05fe8d7 in operator() /home/dale/git/overte/overte-master/libraries/shared/src/SettingManager.cpp:139
    #3 0x7fabb05febc7 in withWriteLock<Setting::Manager::loadSetting(Setting::Interface*)::<lambda()> > /home/dale/git/overte/overte-master/libraries/shared/src/shared/ReadWriteLockable.h:64
    #4 0x7fabb05feec6 in Setting::Manager::loadSetting(Setting::Interface*) /home/dale/git/overte/overte-master/libraries/shared/src/SettingManager.cpp:135
    #5 0x7fabb05f4178 in Setting::Interface::load() /home/dale/git/overte/overte-master/libraries/shared/src/SettingInterface.cpp:128
    #6 0x7fabb05f4ac6 in Setting::Interface::init() /home/dale/git/overte/overte-master/libraries/shared/src/SettingInterface.cpp:94
    #7 0x7fabb05f5145 in Setting::Interface::maybeInit() const /home/dale/git/overte/overte-master/libraries/shared/src/SettingInterface.cpp:114
    #8 0x0000005b496b in Setting::Handle<bool>::get(bool const&) const /home/dale/git/overte/overte-master/libraries/shared/src/SettingHandle.h:251
    #9 0x0000005b4d9c in Setting::Handle<bool>::get() const /home/dale/git/overte/overte-master/libraries/shared/src/SettingHandle.h:241
    #10 0x7fabb2c3ea34 in operator() /home/dale/git/overte/overte-master/libraries/networking/src/DomainHandler.cpp:158
    #11 0x7fabb2c3ebaa in operator() /home/dale/git/overte/overte-master/libraries/shared/src/shared/ReadWriteLockable.h:116
    #12 0x7fabb2c3ed07 in withReadLock<ReadWriteLockable::resultWithReadLock<bool, DomainHandler::getInterstitialModeEnabled() const::<lambda()> >(DomainHandler::getInterstitialModeEnabled() const::<lambda()>&&) const::<lambda()> > /home/dale/git/overte/overte-master/libraries/shared/src/shared/ReadWriteLockable.h:109
    #13 0x7fabb2c3eee7 in resultWithReadLock<bool, DomainHandler::getInterstitialModeEnabled() const::<lambda()> > /home/dale/git/overte/overte-master/libraries/shared/src/shared/ReadWriteLockable.h:115
    #14 0x7fabb2c3f10a in DomainHandler::getInterstitialModeEnabled() const /home/dale/git/overte/overte-master/libraries/networking/src/DomainHandler.cpp:157
    #15 0x0000006d5f68 in Application::setIsInterstitialMode(bool) /home/dale/git/overte/overte-master/interface/src/Application.cpp:1053
    #16 0x000000946765 in Application::initializeUi() /home/dale/git/overte/overte-master/interface/src/Application_Graphics.cpp:431
    #17 0x000000a23cda in Application::initialize(QCommandLineParser const&) /home/dale/git/overte/overte-master/interface/src/Application_Setup.cpp:826
    #18 0x0000011b0fe1 in main /home/dale/git/overte/overte-master/interface/src/main.cpp:779
    #19 0x7fabe64105b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #20 0x7fabe6410667 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x3667) (BuildId: ff0267465bc3d76e21003b3bc5598fd5ee63e261)
    #21 0x00000040b304 in _start (/home/dale/git/overte/overte-master
```

The problem happens here:

```
        void set(const T& value) {
            maybeInit();

            // qCDebug(settings_handle) << "Setting" << this->getKey() << "to" << value;

            if ((!_isSet && (value != _defaultValue)) || _value != value) {
                _value = value;
                _isSet = true;
                save();
            }
            if (_isDeprecated) {
                deprecate();
            }
        }
```

In the `if ((!_isSet && (value != _defaultValue)) || _value != value) {` bit.

I verified the value is all read and interpreted correctly from the config, the problem isn't the incoming read value, but the contents of `_value`, which are uninitialized. 

Changing the declaration of `_value` ensures it's initialized properly.
