### PR TITLE
Fix UB in HFMJoint usage.

### DIFF
--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -109,11 +109,11 @@ public:
     glm::quat inverseBindRotation;
     glm::mat4 bindTransform;
     QString name;
-    bool isSkeletonJoint;
-    bool bindTransformFoundInCluster;
+    bool isSkeletonJoint{false};
+    bool bindTransformFoundInCluster{false};
 
     // geometric offset is applied in local space but does NOT affect children.
-    bool hasGeometricOffset;
+    bool hasGeometricOffset{false};
     glm::vec3 geometricTranslation;
     glm::quat geometricRotation;
     glm::vec3 geometricScaling;

--- a/libraries/model-serializers/src/GLTFSerializer.cpp
+++ b/libraries/model-serializers/src/GLTFSerializer.cpp
@@ -271,7 +271,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
 
 
     // Build joints
-    HFMJoint joint;
+    HFMJoint joint{};
     joint.distanceToParent = 0;
     hfmModel.jointIndices["x"] = numNodes;
     QVector<glm::mat4> globalTransforms;


### PR DESCRIPTION
Class is created uninitialized, ubsan notices the problem with the bools.

Force initialization and pick some defaults for the bools.

Fixes #2178 