### PR TITLE
Fix "maybe uninitialized" warning

### DIFF
--- a/libraries/image/src/image/CubeMap.cpp
+++ b/libraries/image/src/image/CubeMap.cpp
@@ -76,7 +76,7 @@ struct CubeFaceMip {
 class CubeMap::ConstMip : public CubeFaceMip {
 public:
 
-    ConstMip(gpu::uint16 level, const CubeMap* cubemap) : 
+    ConstMip(gpu::uint16 level, const CubeMap* cubemap) :
         CubeFaceMip(level, cubemap), _faces(cubemap->_mips[level]) {
     }
 
@@ -176,8 +176,8 @@ private:
     }
 
     static std::pair<int, int> getSrcAndDst(int dim, int value) {
-        int src;
-        int dst;
+        int src = 0;
+        int dst = 0;
 
         if (value < 0) {
             src = 1;


### PR DESCRIPTION
Fixes this warning:

```
[ 50%] Building CXX object libraries/gpu-gl-common/CMakeFiles/gpu-gl-common.dir/src/gpu/gl/GLShader.cpp.o
In file included from /usr/include/c++/15/bits/stl_algobase.h:64,
                 from /usr/include/c++/15/algorithm:62,
                 from /home/dale/git/overte/overte-master-orig/libraries/gpu/src/gpu/Texture.h:14,
                 from /home/dale/git/overte/overte-master-orig/libraries/image/src/image/CubeMap.h:15,
                 from /home/dale/git/overte/overte-master-orig/libraries/image/src/image/CubeMap.cpp:11:
In constructor ‘constexpr std::pair<_T1, _T2>::pair(_U1&&, _U2&&) [with _U1 = int&; _U2 = int&; _T1 = int; _T2 = int]’,
    inlined from ‘constexpr std::pair<typename std::__strip_reference_wrapper<typename std::decay<_Tp>::type>::__type, typename std::__strip_reference_wrapper<typename std::decay<_Tp2>::type>::__type> std::make_pair(_T1&&, _T2&&) [with _T1 = int&; _T2 = int&]’ at /usr/include/c++/15/bits/stl_pair.h:1169:14,
    inlined from ‘static std::pair<int, int> image::CubeMap::Mip::getSrcAndDst(int, int)’ at /home/dale/git/overte/overte-master-orig/libraries/image/src/image/CubeMap.cpp:189:30:
/usr/include/c++/15/bits/stl_pair.h:464:11: warning: ‘src’ may be used uninitialized [-Wmaybe-uninitialized]
  464 |         : first(std::forward<_U1>(__x)), second(std::forward<_U2>(__y))
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/dale/git/overte/overte-master-orig/libraries/image/src/image/CubeMap.cpp: In static member function ‘static std::pair<int, int> image::CubeMap::Mip::getSrcAndDst(int, int)’:
/home/dale/git/overte/overte-master-orig/libraries/image/src/image/CubeMap.cpp:179:13: note: ‘src’ was declared here
  179 |         int src;
      |             ^~~
In constructor ‘constexpr std::pair<_T1, _T2>::pair(_U1&&, _U2&&) [with _U1 = int&; _U2 = int&; _T1 = int; _T2 = int]’,
    inlined from ‘constexpr std::pair<typename std::__strip_reference_wrapper<typename std::decay<_Tp>::type>::__type, typename std::__strip_reference_wrapper<typename std::decay<_Tp2>::type>::__type> std::make_pair(_T1&&, _T2&&) [with _T1 = int&; _T2 = int&]’ at /usr/include/c++/15/bits/stl_pair.h:1169:14,
    inlined from ‘static std::pair<int, int> image::CubeMap::Mip::getSrcAndDst(int, int)’ at /home/dale/git/overte/overte-master-orig/libraries/image/src/image/CubeMap.cpp:189:30:
/usr/include/c++/15/bits/stl_pair.h:464:42: warning: ‘dst’ may be used uninitialized [-Wmaybe-uninitialized]
  464 |         : first(std::forward<_U1>(__x)), second(std::forward<_U2>(__y))
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/dale/git/overte/overte-master-orig/libraries/image/src/image/CubeMap.cpp: In static member function ‘static std::pair<int, int> image::CubeMap::Mip::getSrcAndDst(int, int)’:
/home/dale/git/overte/overte-master-orig/libraries/image/src/image/CubeMap.cpp:180:13: note: ‘dst’ was declared here
  180 |         int dst;
      |             ^~~
```


Note that this might hide a bug, the code is:

```

    static std::pair<int, int> getSrcAndDst(int dim, int value) {
        int src;
        int dst;

        if (value < 0) {
            src = 1;
            dst = 0;
        } else if (value >= dim) {
            src = dim;
            dst = dim + 1;
        }
        return std::make_pair(src, dst);
    }

```

The problem is that the `if` doesn't cover all possibilities.