### PR TITLE
Do warnings as errors always on Linux, not just on gcc 11

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -157,7 +157,7 @@ class Overte(ConanFile):
 
         # Enabling warnings-as-errors by default on our Linux target and on Windows.
         # Our current Linux development target is Ubuntu 22.04, which uses GCC 11.2.
-        if self.settings.compiler == "gcc" and self.settings.compiler.version == "11":
+        if self.settings.compiler == "gcc":
             tc.cache_variables.update({
                 "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
             })


### PR DESCRIPTION
I don't see the reason to restrict warnings as errors to GCC 11 specifically.

New compilers catch more mistakes. The point of warnings as errors is not to add more bad stuff to start with, and to fix errors that were hiding until the compiler got better at catching them.

After PR #2184 we should be back to a fully clean build on GCC 15.2.1.