### PR TITLE
Ensure initialization in makeBuffer, fixes maybe-uninitialized warning

### DIFF
--- a/libraries/gpu/src/gpu/Buffer.h
+++ b/libraries/gpu/src/gpu/Buffer.h
@@ -438,7 +438,7 @@ class StructBuffer : public gpu::BufferView {
 public:
     template <class U>
     static BufferPointer makeBuffer(uint32_t usage = gpu::Buffer::UniformBuffer) {
-        U t;
+        U t{};
         return std::make_shared<gpu::Buffer>(usage, sizeof(U), (const gpu::Byte*)&t, sizeof(U));
     }
     ~StructBuffer(){};


### PR DESCRIPTION
Fixes this:

```
[1750/2447] Building CXX object libraries/render-utils/CMakeFiles/render-utils.dir/src/DebugDeferredBuffer.cpp.o
In file included from /usr/include/c++/15/bits/stl_iterator.h:78,
                 from /usr/include/c++/15/bits/stl_algobase.h:67,
                 from /usr/include/c++/15/algorithm:62,
                 from /usr/include/qt5/QtCore/qglobal.h:142,
                 from /usr/include/qt5/QtCore/qiodevice.h:43,
                 from /usr/include/qt5/QtCore/qfiledevice.h:43,
                 from /usr/include/qt5/QtCore/qfile.h:44,
                 from /usr/include/qt5/QtCore/qfileinfo.h:43,
                 from /usr/include/qt5/QtCore/QFileInfo:1,
                 from /home/dale/git/overte/overte-master/libraries/render-utils/src/DebugDeferredBuffer.h:16,
                 from /home/dale/git/overte/overte-master/libraries/render-utils/src/DebugDeferredBuffer.cpp:13:
In function ‘constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = gpu::Buffer; _Args = {unsigned int&, long unsigned int, const unsigned char*, long unsigned int}]’,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = gpu::Buffer; _Args = {unsigned int&, long unsigned int, const unsigned char*, long unsigned int}]’ at /usr/include/c++/15/bits/alloc_traits.h:805:19,
    inlined from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {unsigned int&, long unsigned int, const unsigned char*, long unsigned int}; _Tp = gpu::Buffer; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/15/bits/shared_ptr_base.h:606:39,
    inlined from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = gpu::Buffer; _Alloc = std::allocator<void>; _Args = {unsigned int&, long unsigned int, const unsigned char*, long unsigned int}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/15/bits/shared_ptr_base.h:969:16,
    inlined from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {unsigned int&, long unsigned int, const unsigned char*, long unsigned int}; _Tp = gpu::Buffer; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/15/bits/shared_ptr_base.h:1719:14,
    inlined from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {unsigned int&, long unsigned int, const unsigned char*, long unsigned int}; _Tp = gpu::Buffer]’ at /usr/include/c++/15/bits/shared_ptr.h:463:59,
    inlined from ‘std::shared_ptr<std::_NonArray<_Tp> > std::make_shared(_Args&& ...) [with _Tp = gpu::Buffer; _Args = {unsigned int&, long unsigned int, const unsigned char*, long unsigned int}]’ at /usr/include/c++/15/bits/shared_ptr.h:1008:39,
    inlined from ‘static gpu::BufferPointer gpu::StructBuffer<T>::makeBuffer(uint32_t) [with U = DebugDeferredBuffer::DebugParameters; T = DebugDeferredBuffer::DebugParameters]’ at /home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Buffer.h:442:95,
    inlined from ‘gpu::StructBuffer<T>::StructBuffer() [with T = DebugDeferredBuffer::DebugParameters]’ at /home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Buffer.h:445:51,
    inlined from ‘DebugDeferredBuffer::DebugDeferredBuffer(uint)’ at /home/dale/git/overte/overte-master/libraries/render-utils/src/DebugDeferredBuffer.cpp:272:92:
/usr/include/c++/15/bits/stl_construct.h:133:7: warning: ‘t’ may be used uninitialized [-Wmaybe-uninitialized]
  133 |       ::new(static_cast<void*>(__p)) _Tp(std::forward<_Args>(__args)...);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Resource.h:47,
                 from /home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Texture.h:25,
                 from /home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Framebuffer.h:14,
                 from /home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Batch.h:22,
                 from /home/dale/git/overte/overte-master/libraries/render/src/render/Engine.h:18,
                 from /home/dale/git/overte/overte-master/libraries/render/src/render/DrawTask.h:16,
                 from /home/dale/git/overte/overte-master/libraries/render-utils/src/DebugDeferredBuffer.h:18:
/home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Buffer.h: In constructor ‘DebugDeferredBuffer::DebugDeferredBuffer(uint)’:
/home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Buffer.h:77:5: note: by argument 4 of type ‘const gpu::Byte*’ {aka ‘const unsigned char*’} to ‘gpu::Buffer::Buffer(uint32_t, gpu::Resource::Size, const gpu::Byte*, gpu::Resource::Size)’ declared here
   77 |     Buffer(uint32_t usage, Size size, const Byte* bytes, Size pageSize = PageManager::DEFAULT_PAGE_SIZE);
      |     ^~~~~~
/home/dale/git/overte/overte-master/libraries/gpu/src/gpu/Buffer.h:441:11: note: ‘t’ declared here
  441 |         U t;
      |           ^
[1855/2447] Automatic MOC for target display-plugins
```