### PR TITLE
Fix PacketReceiver.h:141:65: warning: ‘SR.7317’ may be used uninitialized

### DIFF
--- a/libraries/networking/src/PacketReceiver.h
+++ b/libraries/networking/src/PacketReceiver.h
@@ -62,7 +62,7 @@ public:
 
 public:
     using PacketTypeList = std::vector<PacketType>;
-    
+
     PacketReceiver(QObject* parent = 0);
     PacketReceiver(const PacketReceiver&) = delete;
 
@@ -76,11 +76,11 @@ public:
     bool registerListener(PacketType type, const ListenerReferencePointer& listener, bool deliverPending = false);
     bool registerListenerForTypes(PacketTypeList types, const ListenerReferencePointer& listener);
     void unregisterListener(QObject* listener);
-    
+
     void handleVerifiedPacket(std::unique_ptr<udt::Packet> packet);
     void handleVerifiedMessagePacket(std::unique_ptr<udt::Packet> message);
     void handleMessageFailure(SockAddr from, udt::Packet::MessageNumber messageNumber);
-    
+
 private:
     template <class T>
     class UnsourcedListenerReference : public ListenerReference {
@@ -131,19 +131,21 @@ private:
     QSet<QObject*> _directlyConnectedObjects;
 
     std::unordered_map<std::pair<SockAddr, udt::Packet::MessageNumber>, QSharedPointer<ReceivedMessage>> _pendingMessages;
-    
+
     friend class EntityEditPacketSender;
     friend class OctreePacketProcessor;
 };
 
 template <class T>
 PacketReceiver::ListenerReferencePointer PacketReceiver::makeUnsourcedListenerReference(T* target, void (T::* slot)(QSharedPointer<ReceivedMessage>)) {
-    return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
+    auto ptr = QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
+    return ptr;
 }
 
 template <class T>
 PacketReceiver::ListenerReferencePointer PacketReceiver::makeSourcedListenerReference(T* target, void (T::* slot)(QSharedPointer<ReceivedMessage>, QSharedPointer<Node>)) {
-    return QSharedPointer<SourcedListenerReference<T>>::create(target, slot);
+    auto ptr = QSharedPointer<SourcedListenerReference<T>>::create(target, slot);
+    return ptr;
 }
 
 template <class T>


### PR DESCRIPTION
This is a weird one, it only occurs in release builds, and seems a spurious warning. When it happens there's quite a lot of them.

It also goes away when building with `-fno-tree-sra` suggesting this is some sort of optimizer bug.


```
[148/973] Building CXX object libraries/octree/CMakeFiles/octree.dir/src/OctreePersistThread.cpp.o
In file included from /home/dale/git/overte/overte-master/libraries/networking/src/LimitedNodeList.h:45,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/NodeList.h:37,
                 from /home/dale/git/overte/overte-master/libraries/octree/src/OctreeSceneStats.h:17,
                 from /home/dale/git/overte/overte-master/libraries/octree/src/Octree.h:30,
                 from /home/dale/git/overte/overte-master/libraries/octree/src/OctreePersistThread.h:20,
                 from /home/dale/git/overte/overte-master/libraries/octree/src/OctreePersistThread.cpp:12:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h: In member function ‘void OctreePersistThread::start()’:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h:141:65: warning: ‘SR.1391’ may be used uninitialized [-Wmaybe-uninitialized]
  141 |     return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
[362/834] Building CXX object domain-server/CMakeFiles/domain-server.dir/src/DomainServer.cpp.o
In file included from /home/dale/git/overte/overte-master/libraries/networking/src/LimitedNodeList.h:45,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/NodeList.h:37,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/Assignment.h:20,
                 from /home/dale/git/overte/overte-master/domain-server/src/DomainServer.h:27,
                 from /home/dale/git/overte/overte-master/domain-server/src/DomainServer.cpp:14:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h: In member function ‘void DomainServer::setupNodeListAndAssignments()’:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h:141:65: warning: ‘SR.9462’ may be used uninitialized [-Wmaybe-uninitialized]
  141 |     return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
[528/810] Building CXX object assignment-client/CMakeFiles/assignment-client.dir/src/AssignmentClientMonitor.cpp.o
In file included from /home/dale/git/overte/overte-master/libraries/networking/src/LimitedNodeList.h:45,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/NodeList.h:37,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/Assignment.h:20,
                 from /home/dale/git/overte/overte-master/assignment-client/src/AssignmentClientMonitor.h:23,
                 from /home/dale/git/overte/overte-master/assignment-client/src/AssignmentClientMonitor.cpp:13:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h: In constructor ‘AssignmentClientMonitor::AssignmentClientMonitor(unsigned int, unsigned int, unsigned int, Assignment::Type, QString, quint16, quint16, QString, quint16, quint16, QString, bool, QString)’:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h:141:65: warning: ‘SR.2022’ may be used uninitialized [-Wmaybe-uninitialized]
  141 |     return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
[529/810] Building CXX object assignment-client/CMakeFiles/assignment-client.dir/src/AssignmentClient.cpp.o
In file included from /home/dale/git/overte/overte-master/libraries/networking/src/LimitedNodeList.h:45,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/NodeList.h:37,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/Assignment.h:20,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/ThreadedAssignment.h:19,
                 from /home/dale/git/overte/overte-master/assignment-client/src/AssignmentClient.h:22,
                 from /home/dale/git/overte/overte-master/assignment-client/src/AssignmentClient.cpp:13:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h: In constructor ‘AssignmentClient::AssignmentClient(Assignment::Type, QString, quint16, QString, quint16, quint16, bool)’:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h:141:65: warning: ‘SR.2242’ may be used uninitialized [-Wmaybe-uninitialized]
  141 |     return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
[546/809] Building CXX object assignment-client/CMakeFiles/assignment-client.dir/src/avatars/AvatarMixer.cpp.o
In file included from /home/dale/git/overte/overte-master/libraries/networking/src/LimitedNodeList.h:45,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/NodeList.h:37,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/Assignment.h:20,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/ThreadedAssignment.h:19,
                 from /home/dale/git/overte/overte-master/assignment-client/src/avatars/AvatarMixer.h:25,
                 from /home/dale/git/overte/overte-master/assignment-client/src/avatars/AvatarMixer.cpp:13:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h: In constructor ‘AvatarMixer::AvatarMixer(ReceivedMessage&)��:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h:141:65: warning: ‘SR.5714’ may be used uninitialized [-Wmaybe-uninitialized]
  141 |     return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
[547/809] Building CXX object assignment-client/CMakeFiles/assignment-client.dir/src/audio/AudioMixer.cpp.o
In file included from /home/dale/git/overte/overte-master/libraries/networking/src/LimitedNodeList.h:45,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/NodeList.h:37,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/Assignment.h:20,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/ThreadedAssignment.h:19,
                 from /home/dale/git/overte/overte-master/assignment-client/src/audio/AudioMixer.h:20,
                 from /home/dale/git/overte/overte-master/assignment-client/src/audio/AudioMixer.cpp:12:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h: In constructor ‘AudioMixer::AudioMixer(ReceivedMessage&)’:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h:141:65: warning: ‘SR.5670’ may be used uninitialized [-Wmaybe-uninitialized]
  141 |     return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
[549/809] Building CXX object assignment-client/CMakeFiles/assignment-client.dir/src/Agent.cpp.o
In file included from /home/dale/git/overte/overte-master/libraries/networking/src/LimitedNodeList.h:45,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/NodeList.h:37,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/PacketSender.h:20,
                 from /home/dale/git/overte/overte-master/libraries/octree/src/OctreeEditPacketSender.h:17,
                 from /home/dale/git/overte/overte-master/libraries/entities/src/EntityEditPacketSender.h:17,
                 from /home/dale/git/overte/overte-master/assignment-client/src/Agent.h:27,
                 from /home/dale/git/overte/overte-master/assignment-client/src/Agent.cpp:14:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h: In constructor ‘Agent::Agent(ReceivedMessage&)’:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h:141:65: warning: ‘SR.7317’ may be used uninitialized [-Wmaybe-uninitialized]
  141 |     return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
[551/809] Building CXX object assignment-client/CMakeFiles/assignment-client.dir/src/scripts/EntityScriptServer.cpp.o
In file included from /home/dale/git/overte/overte-master/libraries/networking/src/LimitedNodeList.h:45,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/NodeList.h:37,
                 from /home/dale/git/overte/overte-master/libraries/networking/src/PacketSender.h:20,
                 from /home/dale/git/overte/overte-master/libraries/octree/src/OctreeEditPacketSender.h:17,
                 from /home/dale/git/overte/overte-master/libraries/entities/src/EntityEditPacketSender.h:17,
                 from /home/dale/git/overte/overte-master/assignment-client/src/scripts/EntityScriptServer.h:25,
                 from /home/dale/git/overte/overte-master/assignment-client/src/scripts/EntityScriptServer.cpp:14:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h: In constructor ‘EntityScriptServer::EntityScriptServer(ReceivedMessage&)’:
/home/dale/git/overte/overte-master/libraries/networking/src/PacketReceiver.h:141:65: warning: ‘SR.6344’ may be used uninitialized [-Wmaybe-uninitialized]
  141 |     return QSharedPointer<UnsourcedListenerReference<T>>::create(target, slot);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```