### PR TITLE
Warn on null pointer in callback in Font.cpp

### DIFF
--- a/libraries/render-utils/src/text/Font.cpp
+++ b/libraries/render-utils/src/text/Font.cpp
@@ -103,6 +103,11 @@ void Font::handleFontNetworkReply() {
 QThreadStorage<size_t> _readOffset;
 QThreadStorage<size_t> _readMax;
 int readHelper(void* dst, int length, void* data) {
+    if (!dst) {
+        qWarning() << "readHelper called with NULL pointer as first argument: dst = " << dst << "; length = " << length << "; data =" << data;
+        return 0;
+    }
+
     if (_readOffset.localData() + length > _readMax.localData()) {
         return -1;
     }


### PR DESCRIPTION
This was found by the address sanitizer, see below:

I added some debug info, which results in this pattern of calls:

```
[04/13 19:43:40] [INFO] [default] readHelper: dst 0x7b5463e5f770 ; len 112 data 0x7b54488a9818
[04/13 19:43:40] [INFO] [default] readHelper: dst 0x7b5463e5f800 ; len 192 data 0x7b54488a9818
[04/13 19:43:40] [INFO] [default] readHelper: dst 0x7d6519a60d00 ; len 4560 data 0x7b54488a9818
[04/13 19:43:40] [INFO] [default] readHelper: dst 0x0 ; len 0 data 0x7b54488a9818
```

Turns out passing a 0 as the first argument to memset isn't supposed to be done.

I'm not sure if this is a bug in the library or an indication of something special that should be reacted to in a special manner. Maybe an "end" indication. If that's it, then we should just remove the logged warning.

```
[04/13 19:43:40] [WARNING] [default] readHelper called with NULL pointer as first argument: dst =  0x0 ; length =  0 ; data = 0x7b54488a9818
[04/13 19:43:40] [DEBUG] [default] Font "https://files.thingvellir.net/Poppins-Medium.arfont" failed to decode.


#1  0x00007fffd8005151 in handleNonNullArg (Data=Data@entry=0x7fffe867e480, Opts=..., IsAttr=IsAttr@entry=true) at ../../../../libsanitizer/ubsan/ubsan_handlers.cpp:750
#2  0x00007fffd8008084 in __ubsan::__ubsan_handle_nonnull_arg (Data=Data@entry=0x7fffe867e480) at ../../../../libsanitizer/ubsan/ubsan_handlers.cpp:754
#3  0x00007fffe5e0474d in readHelper (dst=<optimized out>, length=length@entry=0, data=data@entry=0x7bfed518c818) at /home/dale/git/overte/overte-master/libraries/render-utils/src/text/Font.cpp:111
#4  0x00007fffe5e49de5 in artery_font::decode<&(readHelper(void*, int, void*)), float, artery_font::StdList, artery_font::StdList<unsigned char>, artery_font::StdString> (font=..., userData=<optimized out>)
    at /home/dale/git/overte/overte-master/libraries/render-utils/src/text/Font.cpp:123
#5  0x00007fffe5e0fb5b in Font::read (this=this@entry=0x7cdfa2374ad0, in=...) at /home/dale/git/overte/overte-master/libraries/render-utils/src/text/Font.cpp:123
#6  0x00007fffe5e15281 in Font::load (family=..., fontFile=...) at /home/dale/git/overte/overte-master/libraries/render-utils/src/text/Font.cpp:88
#7  0x00007fffe5e1696b in Font::load (family=...) at /home/dale/git/overte/overte-master/libraries/render-utils/src/text/Font.cpp:289
#8  0x00007fffe5d42ffd in TextRenderer3D::TextRenderer3D (this=0x7cefa05d7ae0, family=<optimized out>) at /home/dale/git/overte/overte-master/libraries/render-utils/src/TextRenderer3D.cpp:22
#9  0x00007fffe5d436ab in TextRenderer3D::getInstance (family=family@entry=0x7ffff1a636e0 "Roboto") at /home/dale/git/overte/overte-master/libraries/render-utils/src/TextRenderer3D.cpp:17
#10 0x00007ffff200ebf3 in render::entities::TextEntityRenderer::TextEntityRenderer (this=this@entry=0x7d8fa44b0680, entity=⚠️ warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<TextEntityItem*, TextEntityItem::factory(EntityItemID const&, EntityItemProperties const&)::{lambda(TextEntityItem*)#1}, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
⚠️ warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<TextEntityItem*, TextEntityItem::factory(EntityItemID const&, EntityItemProperties const&)::{lambda(TextEntityItem*)#1}, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr<EntityItem> (use count 6, weak count 3) = {...})
    at /home/dale/git/overte/overte-master/libraries/entities-renderer/src/RenderableTextEntityItem.cpp:32
#11 0x00007ffff1d4dac4 in make_renderer<render::entities::TextEntityRenderer> (entity=⚠️ warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<TextEntityItem*, TextEntityItem::factory(EntityItemID const&, EntityItemProperties const&)::{lambda(TextEntityItem*)#1}, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
⚠️ warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<TextEntityItem*, TextEntityItem::factory(EntityItemID const&, EntityItemProperties const&)::{lambda(TextEntityItem*)#1}, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
std::shared_ptr<EntityItem> (use count 6, weak count 3) = {...})
    at /home/dale/git/overte/overte-master/libraries/entities-renderer/src/RenderableEntityItem.cpp:136
#12 0x00007ffff1d00cf1 in render::entities::EntityRenderer::addToScene (renderer=..., entity=⚠️ warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<TextEntityItem*, TextEntityItem::factory(EntityItemID const&, EntityItemProperties const&)::{lambda(TextEntityItem*)#1}, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'
⚠️ warning: RTTI symbol not found for class 'std::_Sp_counted_deleter<TextEntityItem*, TextEntityItem::factory(EntityItemID const&, EntityItemProperties const&)::{lambda(TextEntityItem*)#1}, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>'

   std::shared_ptr<EntityItem> (use count 6, weak count 3) = {...}, scene=std::shared_ptr<render::Scene> (use count 5, weak count 0) = {...}, transaction=...)
    at /home/dale/git/overte/overte-master/libraries/entities-renderer/src/RenderableEntityItem.cpp:440
#13 0x00007ffff1bad627 in EntityTreeRenderer::addPendingEntities (this=this@entry=0x7d8fa1e65980, scene=std::shared_ptr<render::Scene> (use count 5, weak count 0) = {...}, transaction=...)
    at /home/dale/git/overte/overte-master/libraries/entities-renderer/src/EntityTreeRenderer.cpp:494
#14 0x00007ffff1bc51ff in EntityTreeRenderer::update (this=this@entry=0x7d8fa1e65980, simulate=simulate@entry=false) at /home/dale/git/overte/overte-master/libraries/entities-renderer/src/EntityTreeRenderer.cpp:634
#15 0x0000000000d53fbc in Application::update (this=this@entry=0x7bff9f604790, deltaTime=<optimized out>) at /home/dale/git/overte/overte-master/interface/src/Application.cpp:2306
#16 0x0000000000d5eaef in Application::idle (this=this@entry=0x7bff9f604790) at /home/dale/git/overte/overte-master/interface/src/Application.cpp:1875
#17 0x0000000000f54455 in Application::event (this=0x7bff9f604790, event=0x7c2fa1027420) at /home/dale/git/overte/overte-master/interface/src/Application_Events.cpp:103
#18 0x00007fffb1240ef7 in QApplicationPrivate::notify_helper (this=this@entry=0x7d2fa02a4740, receiver=receiver@entry=0x7bff9f604790, e=e@entry=0x7c2fa1027420) at kernel/qapplication.cpp:3640
#19 0x00007fffb12477c3 in QApplication::notify (this=this@entry=0x7bff9f604790, receiver=receiver@entry=0x7bff9f604790, e=e@entry=0x7c2fa1027420) at kernel/qapplication.cpp:3386
#20 0x0000000000f4c023 in Application::notify (this=0x7bff9f604790, object=<optimized out>, event=<optimized out>) at /home/dale/git/overte/overte-master/interface/src/Application_Events.cpp:61
#21 0x00007fffe8c1f778 in QCoreApplication::notifyInternal2 (receiver=0x7bff9f604790, event=0x7c2fa1027420) at kernel/qcoreapplication.cpp:1064
#22 0x00007fffe8c1f992 in QCoreApplication::sendEvent (receiver=<optimized out>, event=<optimized out>) at kernel/qcoreapplication.cpp:1462
#23 0x00007fffe8c22ca8 in QCoreApplicationPrivate::sendPostedEvents (receiver=0x0, event_type=event_type@entry=0, data=0x7cbfa0207f40) at kernel/qcoreapplication.cpp:1821
#24 0x00007fffe8c22f50 in QCoreApplication::sendPostedEvents (receiver=<optimized out>, event_type=0) at kernel/qcoreapplication.cpp:1680
--Type <RET> for more, q to quit, c to continue without paging--
#25 0x00007fffe8c754cf in postEventSourceDispatch (s=0x7cafa02d0360) at kernel/qeventdispatcher_glib.cpp:277
#26 0x00007fffe14eb323 in g_main_dispatch (context=0x7d0fa0282480) at ../glib/gmain.c:3565
#27 g_main_context_dispatch_unlocked (context=0x7d0fa0282480) at ../glib/gmain.c:4425
#28 0x00007fffe14f4278 in g_main_context_iterate_unlocked (context=context@entry=0x7d0fa0282480, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4490
#29 0x00007fffe14f4423 in g_main_context_iteration (context=0x7d0fa0282480, may_block=1) at ../glib/gmain.c:4556
#30 0x00007fffe8c74f67 in QEventDispatcherGlib::processEvents (this=0x7c2fa0907f00, flags=...) at kernel/qeventdispatcher_glib.cpp:423
#31 0x00007fffe8c1e0e2 in QEventLoop::exec (this=this@entry=0x7fffffff6fb0, flags=..., flags@entry=...) at ../../include/QtCore/../../src/corelib/global/qflags.h:69
#32 0x00007fffe8c264c4 in QCoreApplication::exec () at kernel/qcoreapplication.cpp:1375
#33 0x00007fffc7c61bad in QGuiApplication::exec () at kernel/qguiapplication.cpp:1863
#34 0x00007fffb1240e69 in QApplication::exec () at kernel/qapplication.cpp:2832
#35 0x00000000017e4876 in main (argc=<optimized out>, argv=<optimized out>) at /home/dale/git/overte/overte-master/interface/src/main.cpp:850

```

@HifiExperiments I think you should have a better idea of how this is supposed to work, your feedback would be great.
