### PR TITLE
Add assert to cover edge case in getSrcAndDst in CubeMap.cpp

### DIFF
--- a/libraries/image/src/image/CubeMap.cpp
+++ b/libraries/image/src/image/CubeMap.cpp
@@ -185,7 +185,16 @@ private:
         } else if (value >= dim) {
             src = dim;
             dst = dim + 1;
+        } else {
+            // TODO:
+            // This branch should never happen.
+            // If it does, we're unsure of the correct return values.
+            //
+            // If the assert is hit, this code should be revisited to work out what should
+            // be the proper result in this case.
+            assert(0);
         }
+
         return std::make_pair(src, dst);
     }
 


### PR DESCRIPTION
Adds an assert to check for an unhandled possibility.

So far in testing this has not been hit.