### PR TITLE
Add a script API function to clear script cache

### DIFF
--- a/libraries/script-engine/src/ScriptManagerScriptingInterface.cpp
+++ b/libraries/script-engine/src/ScriptManagerScriptingInterface.cpp
@@ -10,8 +10,10 @@
 //  SPDX-License-Identifier: Apache-2.0
 //
 
-#include "ScriptManager.h"
 #include "ScriptManagerScriptingInterface.h"
+
+#include "ScriptCache.h"
+#include "ScriptManager.h"
 #include "ScriptEngines.h"
 #include "ScriptEngine.h"
 #include <QMetaType>
@@ -132,4 +134,9 @@ QString ScriptManagerScriptingInterface::btoa(const QByteArray &binary) {
 
 QByteArray ScriptManagerScriptingInterface::atob(const QString &base64) {
     return QByteArray::fromBase64(base64.toUtf8());
+}
+
+void ScriptManagerScriptingInterface::clearCache() {
+    qCInfo(scriptengine) << "clearScriptCache -- clearing caches";
+    DependencyManager::get<ScriptCache>()->clearCache();
 }

--- a/libraries/script-engine/src/ScriptManagerScriptingInterface.h
+++ b/libraries/script-engine/src/ScriptManagerScriptingInterface.h
@@ -563,7 +563,7 @@ public:
 
     /*@jsdoc
      * Create test object for garbage collector debugging.
-     * @function Script.createGarbageCollectorDebuggingObject()
+     * @function Script.createGarbageCollectorDebuggingObject
      * @Returns Test object.
      */
      Q_INVOKABLE ScriptValue createGarbageCollectorDebuggingObject();
@@ -635,6 +635,13 @@ public:
      * @returns {String} String with Base64-encoded binary data.
      */
      Q_INVOKABLE QString btoa(const QByteArray &binary);
+
+    /*@jsdoc
+     * Clears the script cache.
+     * This causes scripts to be downloaded again. Useful for script development.
+     * @function ScriptDiscoveryService.clearCache
+     */
+    Q_INVOKABLE void clearCache();
 
  signals:
 

--- a/libraries/script-engine/src/ScriptManagerScriptingInterface.h
+++ b/libraries/script-engine/src/ScriptManagerScriptingInterface.h
@@ -638,7 +638,7 @@ public:
 
     /*@jsdoc
      * Clears the script cache.
-     * This causes scripts to be downloaded again. Useful for script development.
+     * This causes scripts which had been stored in the cache to be downloaded again the next time they are loaded. Useful for script development.
      * @function ScriptDiscoveryService.clearCache
      */
     Q_INVOKABLE void clearCache();


### PR DESCRIPTION
It's a very useful functionality for script development, since reloading script doesn't reload dependencies added with Script.require().