### PR TITLE
Add missing virtual destructor in ScriptUser

### DIFF
--- a/libraries/script-engine/src/ScriptCache.h
+++ b/libraries/script-engine/src/ScriptCache.h
@@ -24,6 +24,7 @@ using contentAvailableCallback = std::function<void(const QString& scriptOrURL, 
 
 class ScriptUser {
 public:
+    virtual ~ScriptUser() = default;
     virtual void scriptContentsAvailable(const QUrl& url, const QString& scriptContents) = 0;
     virtual void errorInLoadingScript(const QUrl& url) = 0;
 };


### PR DESCRIPTION
Fixes warning from clang tidy. Lack of virtual destructor causes trouble when derived object is destroyed by the pointer to base object.