### PR TITLE
Fix UB in OffscreenQmlSurface::eventFilter

### DIFF
--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -248,7 +248,7 @@ void OffscreenQmlSurface::initializeEngine(QQmlEngine* engine) {
     fileSelector->setExtraSelectors(FileUtils::getFileSelectors());
 
     static std::once_flag once;
-    std::call_once(once, [] { 
+    std::call_once(once, [] {
         qRegisterMetaType<TabletProxy*>();
         qRegisterMetaType<TabletButtonProxy*>();
         qmlRegisterType<SoundEffect>("Hifi", 1, 0, "SoundEffect");
@@ -408,7 +408,7 @@ bool OffscreenQmlSurface::eventFilter(QObject* originalDestination, QEvent* even
 
     if (event->type() == QEvent::Resize) {
         QResizeEvent* resizeEvent = static_cast<QResizeEvent*>(event);
-        QWidget* widget = static_cast<QWidget*>(originalDestination);
+        QWidget* widget = dynamic_cast<QWidget*>(originalDestination);
         if (widget) {
             this->resize(resizeEvent->size());
         }
@@ -832,7 +832,7 @@ void OffscreenQmlSurface::loadFromQml(const QUrl& qmlSource, QQuickItem* parent,
     };
 
     if (hifi::scripting::isLocalAccessSafeThread()) {
-        // If this is a 
+        // If this is a
         auto contextCallback = [callback](QQmlContext* context) {
             ContextAwareProfile::restrictContext(context, false);
 #if !defined(Q_OS_ANDROID)


### PR DESCRIPTION
The sender of the event isn't always a QWidget. Seems to happen specifically on Vulkan.

```
/home/dale/git/overte/overte-master/libraries/ui/src/ui/OffscreenQmlSurface.cpp:411:27: runtime error: downcast of address 0x7d2f9ecacc40 which does not point to an object of type 'QWidget'
0x7d2f9ecacc40: note: object is of type 'VKWindow'
 00 00 00 00  98 b3 66 f4 ff 7f 00 00  40 3b c2 9e 1f 7d 00 00  c8 b4 66 f4 ff 7f 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'VKWindow'
```

Backtrace:

```
#0  __ubsan::ScopedReport::~ScopedReport (this=this@entry=0x7fffffff65a0) at ../../../../libsanitizer/ubsan/ubsan_diag.cpp:394
#1  0x00007fffd4008ab5 in HandleDynamicTypeCacheMiss (Data=Data@entry=0x7fffc6390cc0, Pointer=Pointer@entry=137643481025600, Hash=<optimized out>, Opts=...) at ../../../../libsanitizer/ubsan/ubsan_handlers_cxx.cpp:81
#2  0x00007fffd4008e2f in __ubsan::__ubsan_handle_dynamic_type_cache_miss (Data=Data@entry=0x7fffc6390cc0, Pointer=Pointer@entry=137643481025600, Hash=<optimized out>) at ../../../../libsanitizer/ubsan/ubsan_handlers_cxx.cpp:87
#3  0x00007fffc5dc1f54 in OffscreenQmlSurface::eventFilter (this=this@entry=0x7d1f9ee22740, originalDestination=originalDestination@entry=0x7d2f9ecacc40, event=event@entry=0x7fffffff6c90)
    at /home/dale/git/overte/overte-master/libraries/ui/src/ui/OffscreenQmlSurface.cpp:411
#4  0x00007fffc5d13d94 in OffscreenUi::eventFilter (this=0x7d1f9ee22740, originalDestination=<optimized out>, event=0x7fffffff6c90) at /home/dale/git/overte/overte-master/libraries/ui/src/OffscreenUi.cpp:1130
#5  0x00007fffe761f525 in QCoreApplicationPrivate::sendThroughObjectEventFilters (receiver=receiver@entry=0x7d2f9ecacc40, event=event@entry=0x7fffffff6c90) at kernel/qcoreapplication.cpp:1190
#6  0x00007fffafc40ee7 in QApplicationPrivate::notify_helper (this=this@entry=0x7d2f9eca5540, receiver=receiver@entry=0x7d2f9ecacc40, e=e@entry=0x7fffffff6c90) at kernel/qapplication.cpp:3634
#7  0x00007fffafc477c3 in QApplication::notify (this=this@entry=0x7bff9e0047a0, receiver=receiver@entry=0x7d2f9ecacc40, e=e@entry=0x7fffffff6c90) at kernel/qapplication.cpp:3386
#8  0x0000000000f54163 in Application::notify (this=0x7bff9e0047a0, object=<optimized out>, event=<optimized out>) at /home/dale/git/overte/overte-master/interface/src/Application_Events.cpp:61
#9  0x00007fffe761f778 in QCoreApplication::notifyInternal2 (receiver=0x7d2f9ecacc40, event=0x7fffffff6c90) at kernel/qcoreapplication.cpp:1064
#10 0x00007fffe761f9b2 in QCoreApplication::sendSpontaneousEvent (receiver=<optimized out>, event=<optimized out>) at kernel/qcoreapplication.cpp:1474
#11 0x00007fffc666ab22 in QGuiApplicationPrivate::processGeometryChangeEvent (e=<optimized out>) at kernel/qguiapplication.cpp:2603
#12 0x00007fffc664a9ec in QWindowSystemInterface::sendWindowSystemEvents (flags=flags@entry=...) at kernel/qwindowsysteminterface.cpp:1169
#13 0x00007bff86fdc1b6 in xcbSourceDispatch (source=<optimized out>) at qxcbeventdispatcher.cpp:105
#14 0x00007fffdf4eb323 in g_main_dispatch (context=0x7d0f9ec82d40) at ../glib/gmain.c:3565
#15 g_main_context_dispatch_unlocked (context=0x7d0f9ec82d40) at ../glib/gmain.c:4425
#16 0x00007fffdf4f4278 in g_main_context_iterate_unlocked (context=context@entry=0x7d0f9ec82d40, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4490
#17 0x00007fffdf4f4423 in g_main_context_iteration (context=0x7d0f9ec82d40, may_block=1) at ../glib/gmain.c:4556
#18 0x00007fffe7674f67 in QEventDispatcherGlib::processEvents (this=0x7c6f9ee5b6c0, flags=...) at kernel/qeventdispatcher_glib.cpp:423
#19 0x00007fffe761e0e2 in QEventLoop::exec (this=this@entry=0x7fffffff6f80, flags=..., flags@entry=...) at ../../include/QtCore/../../src/corelib/global/qflags.h:69
#20 0x00007fffe76264c4 in QCoreApplication::exec () at kernel/qcoreapplication.cpp:1375
#21 0x00007fffc6661bad in QGuiApplication::exec () at kernel/qguiapplication.cpp:1863
#22 0x00007fffafc40e69 in QApplication::exec () at kernel/qapplication.cpp:2832
#23 0x00000000017fe45a in main (argc=<optimized out>, argv=<optimized out>) at /home/dale/git/overte/overte-master/interface/src/main.cpp:850
(gdb) frame 3
#3  0x00007fffc5dc1f54 in OffscreenQmlSurface::eventFilter (this=this@entry=0x7d1f9ee22740, originalDestination=originalDestination@entry=0x7d2f9ecacc40, event=event@entry=0x7fffffff6c90)
    at /home/dale/git/overte/overte-master/libraries/ui/src/ui/OffscreenQmlSurface.cpp:411
411	       QWidget* widget = static_cast<QWidget*>(originalDestination);
```