### PR TITLE
Fix crash when shader cache gets too large

### DIFF
--- a/libraries/gl/src/gl/GLShaders.cpp
+++ b/libraries/gl/src/gl/GLShaders.cpp
@@ -439,7 +439,14 @@ static const char* SHADER_JSON_DATA_KEY = "data";
 void gl::loadShaderCache(ShaderCache& cache) {
 #if !defined(DISABLE_QML)
     QString shaderCacheFile = getShaderCacheFile();
-    if (QFileInfo(shaderCacheFile).exists()) {
+    // QT6TODO: check if QT6 strings handle larger sizes correctly, if so we can remove this limit once Overte is running on Qt6.
+    // Qt cannot handle strings bigger than 2 GB.
+    // In such case it's best to delete file so that new shader cache can be written.
+    auto shaderFileInfo = QFileInfo(shaderCacheFile);
+    if (!shaderFileInfo.exists()) {
+        return;
+    }
+    if (shaderFileInfo.size() <= INT32_MAX / 2 - 1) {
         QString json = FileUtils::readFile(shaderCacheFile);
         nlohmann::json root;
         try {
@@ -487,6 +494,10 @@ void gl::loadShaderCache(ShaderCache& cache) {
             cachedShader.format = (GLenum)programObject[SHADER_JSON_TYPE_KEY].get<int>();
             cachedShader.source = programObject[SHADER_JSON_SOURCE_KEY].get<std::string>();
         }
+    } else {
+        qWarning() << "Shader cache is too large and cannot be read to a string. Clearing cache.";
+        auto shaderFile = QFile(shaderCacheFile);
+        shaderFile.remove();
     }
 #endif
 }

--- a/libraries/gl/src/gl/GLShaders.cpp
+++ b/libraries/gl/src/gl/GLShaders.cpp
@@ -436,18 +436,18 @@ static const char* SHADER_JSON_TYPE_KEY = "type";
 static const char* SHADER_JSON_SOURCE_KEY = "source";
 static const char* SHADER_JSON_DATA_KEY = "data";
 
+// Currently shader cache size limit is 1 GB.
+constexpr qsizetype MAX_SHADER_CACHE_SIZE = INT32_MAX / 2 - 1;
+
 void gl::loadShaderCache(ShaderCache& cache) {
 #if !defined(DISABLE_QML)
     QString shaderCacheFile = getShaderCacheFile();
-    // QT6TODO: check if QT6 strings handle larger sizes correctly, if so we can remove this limit once Overte is running on Qt6.
-    // Qt cannot handle strings bigger than 2 GB.
-    // In such case it's best to delete file so that new shader cache can be written.
     auto shaderFileInfo = QFileInfo(shaderCacheFile);
     if (!shaderFileInfo.exists()) {
         return;
     }
-    if (shaderFileInfo.size() <= INT32_MAX / 2 - 1) {
-        QString json = FileUtils::readFile(shaderCacheFile);
+    // Shader cache will slowly get bigger, so we need to keep it to some reasonable size.
+    if (shaderFileInfo.size() <= MAX_SHADER_CACHE_SIZE) {
         nlohmann::json root;
         try {
             std::ifstream i(shaderCacheFile.toStdString());

--- a/libraries/shared/src/shared/FileUtils.cpp
+++ b/libraries/shared/src/shared/FileUtils.cpp
@@ -63,7 +63,15 @@ QString FileUtils::readFile(const QString& filename) {
     QFile file(filename);
     file.open(QFile::Text | QFile::ReadOnly);
     QString result;
-    result.append(QTextStream(&file).readAll());
+    // QT6TODO: check if QT6 strings handle larger sizes correctly, if so we can remove this limit once Overte is running on Qt6.
+    // Qt cannot handle strings bigger than 2 GB.
+    // Since QString is UTF-16, this means that reading a file bigger than 1 GB will cause a crash.
+    if (file.size() <= INT32_MAX / 2 - 1) {
+        result.append(QTextStream(&file).readAll());
+    } else {
+        qWarning() << "File is too large and cannot be read to a string";
+        Q_ASSERT(false);
+    }
     return result;
 }
 


### PR DESCRIPTION
Fixes https://github.com/overte-org/overte/issues/1966

Shader cache for a fresh build takes about 160 MB, but tends to grow with time. When it exceeds 1 GB, Overte crashes on every launch and deleting the shader cache which is in a hidden directory is the only fix.

In this PR cache is deleted automatically when it reaches 1 GB.

I also adder assert to the function that reads file into `QString`.
