### PR TITLE
fix opengl 4.1 backend

### DIFF
--- a/libraries/entities-renderer/src/paintStroke.slh
+++ b/libraries/entities-renderer/src/paintStroke.slh
@@ -19,7 +19,11 @@
 // Hack comment to absorb the extra '//' scribe prepends
 
 #if !defined(GPU_SSBO_TRANSFORM_OBJECT)
+#ifdef GPU_GLES_310
 LAYOUT(binding=GPU_RESOURCE_BUFFER_SLOT0_TEXTURE) uniform samplerBuffer polylineVerticesBuffer;
+#else
+RESOURCE_BUFFER(GPU_RESOURCE_BUFFER_SLOT0_TEXTURE, polylineVerticesBuffer);
+#endif
 PolylineVertex getPolylineVertex(int i) {
     int offset = 4 * i;
     PolylineVertex vertex;

--- a/libraries/gpu/src/gpu/Transform.slh
+++ b/libraries/gpu/src/gpu/Transform.slh
@@ -132,7 +132,12 @@ TransformObject getTransformObject() {
     return transformObject;
 }
 #else
+
+#ifdef GPU_GLES_310
 LAYOUT(binding=GPU_TEXTURE_TRANSFORM_OBJECT) uniform samplerBuffer transformObjectBuffer;
+#else
+RESOURCE_BUFFER(GPU_TEXTURE_TRANSFORM_OBJECT, transformObjectBuffer);
+#endif
 
 TransformObject getTransformObject() {
 #ifdef GPU_VERTEX_SHADER

--- a/libraries/render-utils/src/Blendshape.slh
+++ b/libraries/render-utils/src/Blendshape.slh
@@ -11,7 +11,11 @@
 <@func declareBlendshape(USE_NORMAL, USE_TANGENT)@>
 
 #if !defined(GPU_SSBO_TRANSFORM_OBJECT)
+#ifdef GPU_GLES_310
 LAYOUT(binding=GPU_RESOURCE_BUFFER_SLOT0_TEXTURE) uniform samplerBuffer blendshapeOffsetsBuffer;
+#else
+RESOURCE_BUFFER(GPU_RESOURCE_BUFFER_SLOT0_TEXTURE, blendshapeOffsetsBuffer);
+#endif
 uvec4 getPackedBlendshapeOffset(int i) {
     return floatBitsToUint(texelFetch(blendshapeOffsetsBuffer, i));
 }

--- a/libraries/render-utils/src/Highlight_aabox.slv
+++ b/libraries/render-utils/src/Highlight_aabox.slv
@@ -22,7 +22,11 @@ struct ItemBound {
 };
 
 #if !defined(GPU_SSBO_TRANSFORM_OBJECT)
+#ifdef GPU_GLES_310
 LAYOUT(binding=GPU_RESOURCE_BUFFER_SLOT0_TEXTURE) uniform samplerBuffer ssbo0Buffer;
+#else
+RESOURCE_BUFFER(GPU_RESOURCE_BUFFER_SLOT0_TEXTURE, ssbo0Buffer);
+#endif
 ItemBound getItemBound(int i) {
     int offset = 2 * i;
     ItemBound bound;

--- a/libraries/render-utils/src/WorkloadResource.slh
+++ b/libraries/render-utils/src/WorkloadResource.slh
@@ -26,7 +26,11 @@ struct WorkloadProxy {
 };
 
 #if !defined(GPU_SSBO_TRANSFORM_OBJECT)
+#ifdef GPU_GLES_310
 LAYOUT(binding=GPU_RESOURCE_BUFFER_SLOT0_TEXTURE) uniform samplerBuffer workloadProxiesBuffer;
+#else
+RESOURCE_BUFFER(GPU_RESOURCE_BUFFER_SLOT0_TEXTURE, workloadProxiesBuffer);
+#endif
 WorkloadProxy getWorkloadProxy(int i) {
     int offset = 2 * i;
     WorkloadProxy proxy;
@@ -58,7 +62,11 @@ struct WorkloadView {
 };
 
 #if !defined(GPU_SSBO_TRANSFORM_OBJECT)
+#ifdef GPU_GLES_310
 LAYOUT(binding=GPU_RESOURCE_BUFFER_SLOT1_TEXTURE) uniform samplerBuffer workloadViewsBuffer;
+#else
+RESOURCE_BUFFER(GPU_RESOURCE_BUFFER_SLOT1_TEXTURE, workloadViewsBuffer);
+#endif
 WorkloadView getWorkloadView(int i) {
     int offset = 8 * i;
     WorkloadView view;

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -66,7 +66,7 @@
         vec4 scale;
     };
 
-    LAYOUT(binding=GRAPHICS_BUFFER_TRIPLANAR_SCALE) uniform triplanarParamsBuffer {
+    UNIFORM_BUFFER(GRAPHICS_BUFFER_TRIPLANAR_SCALE, triplanarParamsBuffer) {
         TriplanarParams triplanarParams;
     };
 <@endif@>

--- a/libraries/render/src/render/drawItemBounds.slv
+++ b/libraries/render/src/render/drawItemBounds.slv
@@ -35,7 +35,11 @@ struct ItemBound {
 };
 
 #if !defined(GPU_SSBO_TRANSFORM_OBJECT)
+#ifdef GPU_GLES_310
 LAYOUT(binding=GPU_RESOURCE_BUFFER_SLOT0_TEXTURE) uniform samplerBuffer ssbo0Buffer;
+#else
+RESOURCE_BUFFER(GPU_RESOURCE_BUFFER_SLOT0_TEXTURE, ssbo0Buffer);
+#endif
 ItemBound getItemBound(int i) {
     int offset = 2 * i;
     ItemBound bound;

--- a/libraries/shaders/headers/310es/header.glsl
+++ b/libraries/shaders/headers/310es/header.glsl
@@ -11,8 +11,8 @@
 #else
     #define UNIFORM_BUFFER(SLOT, NAME) layout(std140, binding=SLOT) uniform NAME
     #define TEXTURE(SLOT, TYPE, NAME) layout(binding=SLOT) uniform TYPE NAME
-    #define RESOURCE_BUFFER(SLOT, NAME) layout(binding=SLOT) buffer NAME
-    #define RESOURCE_BUFFER_STD140(SLOT, NAME) layout(std140, binding=SLOT) buffer NAME
+    #define RESOURCE_BUFFER(SLOT, NAME) layout(binding=SLOT) uniform samplerBuffer NAME
+    #define RESOURCE_BUFFER_STD140(SLOT, NAME) layout(std140, binding=SLOT) uniform samplerBuffer NAME
 #endif
 #extension GL_EXT_texture_buffer : enable
 #if defined(HAVE_EXT_clip_cull_distance) && !defined(VULKAN)

--- a/libraries/shaders/headers/410/header.glsl
+++ b/libraries/shaders/headers/410/header.glsl
@@ -10,8 +10,8 @@
     #define RESOURCE_BUFFER_STD140(SLOT, NAME) layout(std140, binding=SLOT) uniform samplerBuffer NAME
 #else
     #define UNIFORM_BUFFER(SLOT, NAME) layout(std140) uniform NAME
-    #define TEXTURE(SLOT, TYPE, NAME) layout(binding=SLOT) uniform TYPE NAME
-    #define RESOURCE_BUFFER(SLOT, NAME) layout(binding=SLOT) uniform samplerBuffer NAME
+    #define TEXTURE(SLOT, TYPE, NAME) uniform TYPE NAME
+    #define RESOURCE_BUFFER(SLOT, NAME) uniform samplerBuffer NAME
     #define RESOURCE_BUFFER_STD140(SLOT, NAME) layout(std140) uniform samplerBuffer NAME
 #endif
 


### PR DESCRIPTION
fix #1570

da01b4c8dd169d6eff8215ebfcbd465fe60b9e65 added these to the non-Vulkan path, but bindings were added in 4.2.