### PR TITLE
Fix race condition when updating joint data

### DIFF
--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -389,6 +389,7 @@ void OtherAvatar::simulate(float deltaTime, bool inView) {
             if (_hasNewJointData) {
                 quint64 currentTime = usecTimestampNow();
 
+                QReadLocker readLock(&_jointDataLock);
                 Q_ASSERT(_hasNewJointDataVec.size() == static_cast<size_t>(_jointData.size()));
                 // Reset joint history if joint count changed.
                 if (_jointHistory.size() != static_cast<size_t>(_jointData.size())) {

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1599,7 +1599,7 @@ protected:
     // key state
     KeyState _keyState;
 
-    bool _hasNewJointData { true }; // set in AvatarData, cleared in Avatar
+    std::atomic<bool> _hasNewJointData { true }; // set in AvatarData, cleared in Avatar
 
     /// Per-joint variable signalizing availability of the new transforms.
     /// Set in AvatarData, cleared in OtherAvatar.


### PR DESCRIPTION
Joint data grabs a write lock [here](https://github.com/overte-org/overte/blob/ae5703220e7b39e9cb274d04e2eaf25ff48e6087/libraries/avatars/src/AvatarData.cpp#L1366) when processing joint data, but there was no corresponding read lock when joints were updated.