### PR TITLE
Correct spotlight attenuation angle calculation

### DIFF
--- a/libraries/render-utils/src/LightLocal.slh
+++ b/libraries/render-utils/src/LightLocal.slh
@@ -117,6 +117,14 @@ vec4 evalLocalLighting(ivec3 cluster, int numLights, vec3 fragWorldPos, SurfaceD
 
         updateSurfaceDataWithLight(surface, fragLightDir);
 
+        float spotAngle = lightVolume_getSpotAngleCos(light.volume);
+        float spotExponent = lightIrradiance_getFalloffSpot(light.irradiance);
+        // TODO: expose configurable inner radius, this fixed scale just takes the sharp edges away
+        // FIXME: the exponent thing is a bit weird and tricky to replicate, it applied an exponent
+        // over a 180° spotlight that was clipped against the outer radius
+        float spotEpsilon = spotAngle - pow(spotAngle * 0.98, spotExponent);
+        cosSpotAngle = clamp((cosSpotAngle - spotAngle) / max(spotEpsilon, 0.0001), 0.0, 1.0);
+
         // Eval attenuation
         float radialAttenuation = lightIrradiance_evalLightAttenuation(light.irradiance, fragLightDistance);
         float angularAttenuation = lightIrradiance_evalLightSpotAttenuation(light.irradiance, cosSpotAngle);


### PR DESCRIPTION
The part of #1481 that doesn't need a new light property

### Master
Aliased and difficult to tune since spotlights were calculated as 180° flat lights with a hard angular cutoff

| 45° Exp. 1 | 45° Exp. 2 | 60° Exp. 6
| --- | --- | ---
| <img width="1280" height="941" alt="overte-snap-by-ada-tv-on-2026-05-02_03-56-55" src="https://github.com/user-attachments/assets/101baa45-492b-4669-8257-106799dd8b6a" /> | <img width="1280" height="941" alt="overte-snap-by-ada-tv-on-2026-05-02_03-57-32" src="https://github.com/user-attachments/assets/014ccfd0-1fcf-48d8-a253-6443790088aa" /> | <img width="1280" height="941" alt="overte-snap-by-ada-tv-on-2026-05-02_03-58-05" src="https://github.com/user-attachments/assets/8ccd882b-c07f-439b-9376-2ddea7c7d611" />

### This PR
Smooth and easier to tune, spotlight falloff angle is calculated correctly

Inner angle is currently hardcoded to 98% of the outer angle

Tried my best to match the existing exponent behavior, though the way it works is a bit weird and there are cases where the spotlight just completely disappears (high exponents with low angles)

| 45° Exp. 1 | 45° Exp. 2 | 60° Exp. 6
| --- | --- | ---
| <img width="1280" height="941" alt="overte-snap-by--on-2026-05-02_03-56-58" src="https://github.com/user-attachments/assets/3452c75c-3460-4353-b25b-479a112a1560" /> | <img width="1280" height="941" alt="overte-snap-by--on-2026-05-02_03-57-33" src="https://github.com/user-attachments/assets/50471d8d-e9b3-4d57-afca-fc7f11940e48" /> | <img width="1280" height="941" alt="overte-snap-by--on-2026-05-02_03-58-08" src="https://github.com/user-attachments/assets/abfe8c9c-f658-44bc-9b26-6305ca69b7b1" />
