### PR TITLE
Fix entity script destruction

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -109,9 +109,15 @@ void EntityScriptServer::handleReloadEntityServerScriptPacket(QSharedPointer<Rec
     if (senderNode->getCanRez() || senderNode->getCanRezTmp()) {
         auto entityID = QUuid::fromRfc4122(message->read(NUM_BYTES_RFC4122_UUID));
 
-        if (_entityViewer.getTree() && !_shuttingDown) {
+        if (!_entityViewer.getTree() || _shuttingDown) { return; }
+
+        EntityItemPointer entity = _entityViewer.getTree()->findEntityByEntityItemID(entityID);
+
+        if (entity) {
             qCDebug(entity_script_server) << "Reloading: " << entityID;
-            checkAndCallPreload(entityID, true);
+
+            auto script = entity->getServerScripts();
+            checkAndCallPreload(entityID, script, script);
         }
     }
 }

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -577,7 +577,10 @@ void EntityScriptServer::shutdownScriptEngine() {
 }
 
 void EntityScriptServer::addingEntity(const EntityItemID& entityID) {
-    checkAndCallPreload(entityID);
+    EntityItemPointer entity = _entityViewer.getTree()->findEntityByEntityItemID(entityID);
+    if (entity) {
+        checkAndCallPreload(entityID, "", entity->getServerScripts());
+    }
 }
 
 void EntityScriptServer::deletingEntity(const EntityItemID& entityID) {
@@ -587,13 +590,13 @@ void EntityScriptServer::deletingEntity(const EntityItemID& entityID) {
     }
 }
 
-void EntityScriptServer::entityServerScriptChanging(const EntityItemID& entityID, bool reload) {
+void EntityScriptServer::entityServerScriptChanging(const EntityItemID& entityID, const QString& oldScriptURL, const QString& newScriptURL) {
     if (_entityViewer.getTree() && !_shuttingDown) {
-        checkAndCallPreload(entityID, reload);
+        checkAndCallPreload(entityID, oldScriptURL, newScriptURL);
     }
 }
 
-void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, bool forceRedownload) {
+void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, const QString& oldScriptURL, const QString& newScriptURL) {
     if (_entityViewer.getTree() && !_shuttingDown && _entitiesScriptManager) {
 
         EntityItemPointer entity = _entityViewer.getTree()->findEntityByEntityItemID(entityID);
@@ -601,20 +604,21 @@ void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, bool 
             return;
         }
 
-        QString serverScripts = entity->getServerScripts();
         EntityScriptDetails details;
-        bool isRunning = _entitiesScriptManager->getEntityScriptDetails(entityID, serverScripts, details);
-        if (forceRedownload || !isRunning || details.scriptText != serverScripts) {
-            // TODO: Check if this is running on script engine thread, otherwise lambda capturing script engine pointer is needed
-            if (isRunning) {
-                _entitiesScriptManager->unloadEntityScript(entityID, serverScripts, true);
-            }
+        bool isRunning = _entitiesScriptManager->getEntityScriptDetails(entityID, oldScriptURL, details);
+        bool reload = oldScriptURL == newScriptURL;
 
-            QString scriptUrl = entity->getServerScripts();
-            if (!scriptUrl.isEmpty()) {
-                scriptUrl = DependencyManager::get<ResourceManager>()->normalizeURL(scriptUrl);
-                _entitiesScriptManager->loadEntityScript(entityID, scriptUrl, forceRedownload);
-            }
+        // TODO: Check if this is running on script engine thread, otherwise lambda capturing script engine pointer is needed
+        if (isRunning) {
+            _entitiesScriptManager->unloadEntityScript(entityID, oldScriptURL, true);
+        }
+
+        if (!newScriptURL.isEmpty()) {
+            _entitiesScriptManager->loadEntityScript(
+                entityID,
+                DependencyManager::get<ResourceManager>()->normalizeURL(newScriptURL),
+                reload
+            );
         }
     }
 }

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -96,8 +96,8 @@ private:
 
     void addingEntity(const EntityItemID& entityID);
     void deletingEntity(const EntityItemID& entityID);
-    void entityServerScriptChanging(const EntityItemID& entityID, bool reload);
-    void checkAndCallPreload(const EntityItemID& entityID, bool forceRedownload = false);
+    void entityServerScriptChanging(const EntityItemID& entityID, const QString& oldScriptURL, const QString& newScriptURL);
+    void checkAndCallPreload(const EntityItemID& entityID, const QString& oldScriptURL, const QString& newScriptURL);
 
     void cleanupOldKilledListeners();
 

--- a/interface/src/Application_Setup.cpp
+++ b/interface/src/Application_Setup.cpp
@@ -1685,7 +1685,7 @@ void Application::setupSignalsAndOperators() {
         });
 
         ScriptEntityItem::setLoadOrReloadScriptOperator([](const EntityItemID& entityID, const QString& oldScriptURL, const QString& newScriptURL) -> bool {
-            return DependencyManager::get<EntityTreeRenderer>()->checkAndCallPreload(entityID, true, true, oldScriptURL, newScriptURL);
+            return DependencyManager::get<EntityTreeRenderer>()->checkAndCallPreload(entityID, oldScriptURL, newScriptURL);
         });
         ScriptEntityItem::setUnloadScriptOperator([](const EntityItemID& entityID, const QString& scriptURL) -> void {
             DependencyManager::get<EntityTreeRenderer>()->unloadEntityScript(entityID, scriptURL);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1149,55 +1149,51 @@ void EntityTreeRenderer::deletingEntity(const EntityItemID& entityID) {
 }
 
 void EntityTreeRenderer::addingEntity(const EntityItemID& entityID) {
-    checkAndCallPreload(entityID);
     auto entity = std::static_pointer_cast<EntityTree>(_tree)->findEntityByID(entityID);
     if (entity) {
         _entitiesToAdd.insert({ entity->getEntityItemID(),  entity });
+        checkAndCallPreload(entityID, "", entity->getScript());
     }
 }
 
-void EntityTreeRenderer::entityScriptChanging(const EntityItemID& entityID, bool reload) {
-    checkAndCallPreload(entityID, reload, true);
+void EntityTreeRenderer::entityScriptChanging(const EntityItemID& entityID, const QString& oldScriptURL, const QString& newScriptURL) {
+    checkAndCallPreload(entityID, oldScriptURL, newScriptURL);
     // Force "re-checking" entities so that the logic inside `checkEnterLeaveEntities()` is run.
     // This will ensure that the `enterEntity()` signal is emitted on clients whose avatars
     // are inside an entity when the script is reloaded.
     forceRecheckEntities();
 }
 
-bool EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, bool reload, bool unloadFirst,
-                                             const QString& oldOverrideURL, const QString& newOverrideURL) {
+bool EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID,
+                                             const QString& oldScriptURL,
+                                             const QString& newScriptURL) {
     if (_tree && !_shuttingDown) {
         EntityItemPointer entity = getTree()->findEntityByEntityItemID(entityID);
         if (!entity) {
             return false;
         }
+
         auto& scriptEngine = (entity->isLocalEntity() || entity->isMyAvatarEntity()) ? _persistentEntitiesScriptManager : _nonPersistentEntitiesScriptManager;
         if (!scriptEngine) {
             return false;
         }
 
-        bool shouldLoad = !newOverrideURL.isEmpty() ? (newOverrideURL != oldOverrideURL) : entity->shouldPreloadScript();
-        QString scriptUrl = !oldOverrideURL.isEmpty() ? oldOverrideURL : entity->getScript();
-        if ((shouldLoad && unloadFirst) || scriptUrl.isEmpty()) {
-            QString loadedScript = !oldOverrideURL.isEmpty() ? oldOverrideURL : entity->getLoadedScript();
+        bool reload = oldScriptURL == newScriptURL;
+
+        if (!oldScriptURL.isEmpty()) {
             if (_currentEntitiesInside.contains(entityID)) {
-                scriptEngine->callEntityScriptMethodForScript(entityID, loadedScript, "leaveEntity");
+                scriptEngine->callEntityScriptMethodForScript(entityID, oldScriptURL, "leaveEntity");
             }
-            QMetaObject::invokeMethod(scriptEngine.get(), [scriptEngine, entityID, loadedScript]{
-                scriptEngine->unloadEntityScript(entityID, loadedScript, true);
+            QMetaObject::invokeMethod(scriptEngine.get(), [scriptEngine, entityID, oldScriptURL]{
+                scriptEngine->unloadEntityScript(entityID, oldScriptURL, true);
             });
-            if (!oldOverrideURL.isEmpty()) {
-                entity->scriptHasUnloaded();
-            }
+            entity->scriptHasUnloaded();
         }
-        if (shouldLoad) {
-            if (!newOverrideURL.isEmpty()) {
-                entity->setScriptHasFinishedPreload(false);
-            }
-            scriptEngine->loadEntityScript(entityID, resolveScriptURL(!newOverrideURL.isEmpty() ? newOverrideURL : scriptUrl), reload);
-            if (!newOverrideURL.isEmpty()) {
-                entity->scriptHasPreloaded();
-            }
+
+        if (!newScriptURL.isEmpty()) {
+            entity->setScriptHasFinishedPreload(false);
+            scriptEngine->loadEntityScript(entityID, resolveScriptURL(newScriptURL), reload);
+            entity->scriptHasPreloaded();
         }
 
         return true;

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -150,10 +150,8 @@ public:
     bool layeredZonesHaveFade(const TransitionType type) const { return _layeredZones.hasFade(type); }
 
     bool checkAndCallPreload(const EntityItemID& entityID,
-                             bool reload = false,
-                             bool unloadFirst = false,
-                             const QString& oldOverrideURL = "",
-                             const QString& newOverrideURL = "");
+                             const QString& oldScriptURL = "",
+                             const QString& newScriptURL = "");
     void unloadEntityScript(const EntityItemID& entityID, const QString& scriptURL);
     void updateScriptUserData(const EntityItemID& entityID, const QString& scriptURL, const QString& userData);
 
@@ -165,7 +163,7 @@ signals:
 public slots:
     void addingEntity(const EntityItemID& entityID);
     void deletingEntity(const EntityItemID& entityID);
-    void entityScriptChanging(const EntityItemID& entityID, const bool reload);
+    void entityScriptChanging(const EntityItemID& entityID, const QString& oldScriptURL, const QString& newScriptURL);
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
     void updateEntityRenderStatus(bool shouldRenderEntities);
     void updateZone(const EntityItemID& id);

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -230,10 +230,10 @@ int EntityTree::readEntityDataFromBuffer(const unsigned char* data, int bytesLef
                     // If the script value has changed on us, or it's timestamp has changed to force
                     // a reload then we want to send out a script changing signal...
                     if (reload || entityScriptBefore != entityScriptAfter) {
-                        emitEntityScriptChanging(entityItemID, reload); // the entity script has changed
+                        emitEntityScriptChanging(entityItemID, entityScriptBefore, entityScriptAfter);
                     }
                     if (reload || entityServerScriptsBefore != entityServerScriptsAfter) {
-                        emitEntityServerScriptChanging(entityItemID, reload); // the entity server script has changed
+                        emitEntityServerScriptChanging(entityItemID, entityServerScriptsBefore, entityServerScriptsAfter);
                     }
 
                     QUuid parentIDAfter = entity->getParentID();
@@ -518,7 +518,7 @@ bool EntityTree::updateEntity(EntityItemPointer entity, const EntityItemProperti
         quint64 entityScriptTimestampAfter = entity->getScriptTimestamp();
         bool reload = entityScriptTimestampBefore != entityScriptTimestampAfter;
         if (entityScriptBefore != entityScriptAfter || reload) {
-            emitEntityScriptChanging(entity->getEntityItemID(), reload); // the entity script has changed
+            emitEntityScriptChanging(entity->getEntityItemID(), entityScriptBefore, entityScriptAfter);
         }
     }
 
@@ -578,12 +578,12 @@ EntityItemPointer EntityTree::addEntity(const EntityItemID& entityID, const Enti
     return result;
 }
 
-void EntityTree::emitEntityScriptChanging(const EntityItemID& entityItemID, bool reload) {
-    emit entityScriptChanging(entityItemID, reload);
+void EntityTree::emitEntityScriptChanging(const EntityItemID& entityItemID, const QString& oldScriptURL, const QString& newScriptURL) {
+    emit entityScriptChanging(entityItemID, oldScriptURL, newScriptURL);
 }
 
-void EntityTree::emitEntityServerScriptChanging(const EntityItemID& entityItemID, bool reload) {
-    emit entityServerScriptChanging(entityItemID, reload);
+void EntityTree::emitEntityServerScriptChanging(const EntityItemID& entityItemID, const QString& oldScriptURL, const QString& newScriptURL) {
+    emit entityServerScriptChanging(entityItemID, oldScriptURL, newScriptURL);
 }
 
 void EntityTree::notifyNewCollisionSoundURL(const QString& newURL, const EntityItemID& entityID) {

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -181,8 +181,8 @@ public:
 
     void entityChanged(EntityItemPointer entity);
 
-    void emitEntityScriptChanging(const EntityItemID& entityItemID, bool reload);
-    void emitEntityServerScriptChanging(const EntityItemID& entityItemID, bool reload);
+    void emitEntityScriptChanging(const EntityItemID& entityItemID, const QString& oldScriptURL, const QString& newScriptURL);
+    void emitEntityServerScriptChanging(const EntityItemID& entityItemID, const QString& oldScriptURL, const QString& newScriptURL);
 
     void setSimulation(EntitySimulationPointer simulation);
     EntitySimulationPointer getSimulation() const { return _simulation; }
@@ -287,8 +287,8 @@ signals:
     void addingEntity(const EntityItemID& entityID);
     void addingEntityPointer(EntityItem* entityID);
     void editingEntityPointer(const EntityItemPointer& entityID);
-    void entityScriptChanging(const EntityItemID& entityItemID, const bool reload);
-    void entityServerScriptChanging(const EntityItemID& entityItemID, const bool reload);
+    void entityScriptChanging(const EntityItemID& entityItemID, const QString& oldScriptURL, const QString& newScriptURL);
+    void entityServerScriptChanging(const EntityItemID& entityItemID, const QString& oldScriptURL, const QString& newScriptURL);
     void newCollisionSoundURL(const QUrl& url, const EntityItemID& entityID);
     void clearingEntities();
     void killChallengeOwnershipTimeoutTimer(const EntityItemID& certID);

--- a/libraries/script-engine/src/ScriptManager.cpp
+++ b/libraries/script-engine/src/ScriptManager.cpp
@@ -2658,11 +2658,10 @@ void ScriptManager::refreshFileScript(const EntityItemID& entityID, const QStrin
         return;
     }
 
-    static bool recurseGuard = false;
-    if (recurseGuard) {
+    if (_refreshRecurseGuard) {
         return;
     }
-    recurseGuard = true;
+    _refreshRecurseGuard = true;
 
     EntityScriptDetails details;
     {
@@ -2675,10 +2674,11 @@ void ScriptManager::refreshFileScript(const EntityItemID& entityID, const QStrin
         auto lastModified = QFileInfo(filePath).lastModified().toMSecsSinceEpoch();
         if (lastModified > details.lastModified) {
             scriptInfoMessage("Reloading modified script " + details.scriptText, filePath, -1);
+            unloadEntityScript(entityID, details.scriptText, true);
             loadEntityScript(entityID, details.scriptText, true);
         }
     }
-    recurseGuard = false;
+    _refreshRecurseGuard = false;
 }
 
 // Execute operation in the appropriate context for (the possibly empty) entityID.

--- a/libraries/script-engine/src/ScriptManager.h
+++ b/libraries/script-engine/src/ScriptManager.h
@@ -1696,6 +1696,7 @@ protected:
     std::shared_ptr<ConsoleScriptingInterface> _consoleScriptingInterface;
     std::atomic<bool> _isUserLoaded { false };
     bool _isReloading { false };
+    bool _refreshRecurseGuard { false };
 
     std::atomic<bool> _quitWhenFinished;
 


### PR DESCRIPTION
* Unload scripts that are auto-refreshing before restarting them. (Fixes #1697)
* Refactors `entityScriptChanging` to account for old and new URLs, was previously always setting them both to `""` and failing. (Fixes #2187)
* Cleaned up `EntityTreeRenderer::checkAndCallPreload` to be less confusing lol