### PR TITLE
Work around OpenXR-loader permission issues on the CI pipeline.

### DIFF
--- a/.github/workflows/linux_server_build.yml
+++ b/.github/workflows/linux_server_build.yml
@@ -105,7 +105,7 @@ jobs:
 
     - name: Read image environment variables
       # Bring some environment variables out of the Runner (Docker) image's environment into the Job environment.
-      if: ${{matrix.image}} != ""
+      if: ${{matrix.image}}
       shell: bash
       run: |
         echo "RPM_SHORTHAND=$RPM_SHORTHAND" >> $GITHUB_ENV

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Read image environment variables
       # Bring some environment variables out of the Runner (Docker) image's environment into the Job environment.
-      if: ${{matrix.image}} != ""
+      if: ${{matrix.image}}
       shell: bash
       run: |
         echo "CONAN_HOME=$CONAN_HOME" >> $GITHUB_ENV

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -35,13 +35,13 @@ jobs:
           #  build_type: full
           #  qt_source: source
           - os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-02-09-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
+            image: docker.io/overte/overte-full-build:2026-05-05-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
             runner: ubuntu-latest
             arch: amd64
             build_type: full
             qt_source: system
           - os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-02-09-ubuntu-22.04-aarch64
+            image: docker.io/overte/overte-full-build:2026-05-05-ubuntu-22.04-aarch64
             runner: ubuntu-24.04-arm
             arch: aarch64
             build_type: full

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -176,24 +176,24 @@ jobs:
 
     - name: Build application
       shell: bash
-      run: cmake --build . --target $APP_TARGET_NAME $CMAKE_BUILD_EXTRA
+      run: cmake --build --target $APP_TARGET_NAME $CMAKE_BUILD_EXTRA
 
     - name: Build domain server
       shell: bash
-      run: cmake --build . --target domain-server $CMAKE_BUILD_EXTRA
+      run: cmake --build --target domain-server $CMAKE_BUILD_EXTRA
 
     - name: Build assignment client
       shell: bash
-      run: cmake --build . --target assignment-client $CMAKE_BUILD_EXTRA
+      run: cmake --build --target assignment-client $CMAKE_BUILD_EXTRA
 
     - name: Build console
       shell: bash
-      run: cmake --build . --target packaged-server-console $CMAKE_BUILD_EXTRA
+      run: cmake --build --target packaged-server-console $CMAKE_BUILD_EXTRA
 
     - name: Build installer
       shell: bash
       run: |
-        cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+        cmake --build --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
         rm build/Overte-*.json || true  # Remove JSON created by CPack External Generator to avoid it landing in the CI Artifacts.
 
     #- name: Sign installer (Windows)

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -41,14 +41,14 @@ jobs:
             #  build_type: full
             #  qt_source: aqt
             - os: Ubuntu 22.04 OpenGL
-              image: docker.io/overte/overte-full-build:2026-02-09-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
+              image: docker.io/overte/overte-full-build:2026-05-05-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
               runner: ubuntu-latest
               arch: amd64
               build_type: full
               qt_source: system
               rendering_backend: OpenGL
             - os: Ubuntu 22.04 Vulkan
-              image: docker.io/overte/overte-full-build:2026-02-09-ubuntu-22.04-amd64
+              image: docker.io/overte/overte-full-build:2026-05-05-ubuntu-22.04-amd64
               runner: ubuntu-latest
               arch: amd64
               build_type: full
@@ -60,14 +60,14 @@ jobs:
             #  apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0 python3-github python3-distro
             # Do not change the names of self-hosted runners without knowing what you are doing, as they correspond to labels that have to be set on the runner.
             - os: Ubuntu 22.04 OpenGL
-              image: docker.io/overte/overte-full-build:2026-02-09-ubuntu-22.04-aarch64
+              image: docker.io/overte/overte-full-build:2026-05-05-ubuntu-22.04-aarch64
               runner: ubuntu-24.04-arm
               arch: aarch64
               build_type: full
               qt_source: system
               rendering_backend: OpenGL
             - os: Ubuntu 22.04 Vulkan
-              image: docker.io/overte/overte-full-build:2026-02-09-ubuntu-22.04-aarch64
+              image: docker.io/overte/overte-full-build:2026-05-05-ubuntu-22.04-aarch64
               runner: ubuntu-24.04-arm
               arch: aarch64
               build_type: full

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -217,29 +217,29 @@ jobs:
     - name: Build Application
       if: matrix.build_type == 'full' || matrix.build_type == 'client'
       shell: bash
-      run: cmake --build . --target $APP_TARGET_NAME $CMAKE_BUILD_EXTRA
+      run: cmake --build --target $APP_TARGET_NAME $CMAKE_BUILD_EXTRA
 
     - name: Build Domain Server
       if: matrix.build_type == 'full'
       shell: bash
-      run: cmake --build . --target domain-server $CMAKE_BUILD_EXTRA
+      run: cmake --build --target domain-server $CMAKE_BUILD_EXTRA
 
     - name: Build Assignment Client
       if: matrix.build_type == 'full'
       shell: bash
-      run: cmake --build . --target assignment-client $CMAKE_BUILD_EXTRA
+      run: cmake --build --target assignment-client $CMAKE_BUILD_EXTRA
 
     - name: Build Console
       if: matrix.build_type == 'full' && matrix.arch != 'aarch64' || startsWith(matrix.os, 'windows')
       shell: bash
       run: |
-        cmake --build . --target packaged-server-console $CMAKE_BUILD_EXTRA
+        cmake --build --target packaged-server-console $CMAKE_BUILD_EXTRA
 
     - name: Build Installer
       if: matrix.build_type != 'android'
       shell: bash
       run: |
-        cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+        cmake --build --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
         rm build/Overte-*.json || true  # Remove JSON created by CPack External Generator to avoid it landing in the CI Artifacts.
 
     # As of 05/17/21 GitHub Virtual Environments changed their "Ubuntu 18.04.5 LTS" image to include two versions of CMake for Android

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Read image environment variables
       # Bring some environment variables out of the Runner (Docker) image's environment into the Job environment.
-      if: ${{matrix.image}} != ""
+      if: ${{matrix.image}}
       shell: bash
       run: |
         echo "CONAN_HOME=$CONAN_HOME" >> $GITHUB_ENV

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Read image environment variables
       # Bring some environment variables out of the Runner (Docker) image's environment into the Job environment.
-      if: ${{matrix.image}} != ""
+      if: ${{matrix.image}}
       shell: bash
       run: |
         echo "CONAN_HOME=$CONAN_HOME" >> $GITHUB_ENV

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -162,24 +162,24 @@ jobs:
 
     - name: Build application
       shell: bash
-      run: cmake --build . --target $APP_TARGET_NAME $CMAKE_BUILD_EXTRA
+      run: cmake --build --target $APP_TARGET_NAME $CMAKE_BUILD_EXTRA
 
     - name: Build domain server
       shell: bash
-      run: cmake --build . --target domain-server $CMAKE_BUILD_EXTRA
+      run: cmake --build --target domain-server $CMAKE_BUILD_EXTRA
 
     - name: Build assignment client
       shell: bash
-      run: cmake --build . --target assignment-client $CMAKE_BUILD_EXTRA
+      run: cmake --build --target assignment-client $CMAKE_BUILD_EXTRA
 
     - name: Build console
       shell: bash
-      run: cmake --build . --target packaged-server-console $CMAKE_BUILD_EXTRA
+      run: cmake --build --target packaged-server-console $CMAKE_BUILD_EXTRA
 
     - name: Build installer
       shell: bash
       run: |
-        cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+        cmake --build --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
         rm build/Overte-*.json || true  # Remove JSON created by CPack External Generator to avoid it landing in the CI Artifacts.
 
     #- name: Sign installer (Windows)

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -34,13 +34,13 @@ jobs:
             build_type: full
             qt_source: source  # Which Qt Conan package to use. `system`, `source`, or `aqt`.
           - os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-02-09-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
+            image: docker.io/overte/overte-full-build:2026-05-05-ubuntu-22.04-amd64  # Container image used for building. Built from /tools/ci-script/linux-ci/Dockerfile_x
             runner: ubuntu-latest
             arch: amd64
             build_type: full
             qt_source: system
           - os: Ubuntu 22.04
-            image: docker.io/overte/overte-full-build:2026-02-09-ubuntu-22.04-aarch64
+            image: docker.io/overte/overte-full-build:2026-05-05-ubuntu-22.04-aarch64
             runner: ubuntu-24.04-arm
             arch: aarch64
             build_type: full

--- a/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
+++ b/tools/ci-scripts/linux-ci/Dockerfile_build_ubuntu-22.04
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Docker file for building Overte
-# Example build: docker build --no-cache --progress=plain -t overte/overte-full-build:2026-02-09-ubuntu-22.04-amd64 -f Dockerfile_build_ubuntu-22.04 .
+# Example build: docker build --no-cache --progress=plain -t overte/overte-full-build:2026-05-05-ubuntu-22.04-amd64 -f Dockerfile_build_ubuntu-22.04 .
 FROM ubuntu:22.04
 LABEL maintainer="Julian Groß (julian.gro@overte.org)"
 LABEL description="Development image for full Overte builds"
@@ -95,8 +95,10 @@ EOF
 #
 # Setup Conan
 #
-# Set CONAN_HOME to its default, so we can read it in our GitHub Actions cache step.
-ENV CONAN_HOME=/root/.conan2
+# Set CONAN_HOME, so we can read it in our GitHub Actions cache step.
+# This needs to be set to a location that is unlikely to exist on the end-user's system to work around permission issues
+# with OpenXR-loader. See https://github.com/overte-org/overte/issues/2117
+ENV CONAN_HOME=/zgofepbi/.conan2
 RUN <<EOF
 conan remote add overte https://artifactory.overte.org/artifactory/api/conan/overte
 # Use our mirror of Conan Center to avoid rate limiting.


### PR DESCRIPTION
This PR works around https://github.com/overte-org/overte/issues/2117 by choosing a build directory that is unlikely to exist on any end-user's system.

While this works around the issue for AppImages built on the CI pipeline and will do so for other machine using a cached version of OpenXR built by the CI pipeline, this doesn't actually fix any of the underlying issues.