### PR TITLE
Remove two number log spam from armored_chat

### DIFF
--- a/scripts/communityScripts/armored-chat/armored_chat.js
+++ b/scripts/communityScripts/armored-chat/armored_chat.js
@@ -338,7 +338,6 @@
         const date = new Date(timestamp);
         const day = date.getDate();
         const dayString = String(day).padStart(2, '0')
-        console.log(dayString[0], dayString[1]);
         // const suffix = (dayString[0] != '1' && dayString[1] === '1') ? 'st' : (dayString[0] != '1' && dayString[1] === '2') ? 'nd' : (dayString[0] != '1' && dayString[1]) === '3' ? 'rd' : 'th';
 
         timeArray.push(`${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`);


### PR DESCRIPTION
armored_chat regularly drops two numbers into the logs

> [4/19 12:32:51] [armored_chat.js] 1 9

This PR removes those log lines.