### PR TITLE
Revert "initial pass at OtherAvatar rotation interpolation"

### DIFF
--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -274,13 +274,13 @@ void OtherAvatar::setCollisionWithOtherAvatarsFlags() {
 }
 
 void OtherAvatar::interpolateJoints() {
+    auto now = usecTimestampNow();
+
     // there's no history to interpolate from,
     // just set the rig poses to whatever we have
     if ((size_t)_jointData.size() != _jointHistory.size()) {
         goto finishRigSetup;
     }
-
-    auto now = usecTimestampNow();
 
     for (int i = 0; i < _jointData.size(); i++) {
         const auto &history{_jointHistory[i]};

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -274,26 +274,13 @@ void OtherAvatar::setCollisionWithOtherAvatarsFlags() {
 }
 
 void OtherAvatar::interpolateJoints() {
-    auto now = usecTimestampNow();
-
-    if (true /* TODO */) {
-        auto [aTime, aQuat] = _orientationHistory[0];
-        auto [bTime, bQuat] = _orientationHistory[1];
-
-        float alpha = std::min(
-            1.0f,
-            // FIXME: should be now - aTime but im bad at the math that makes it work
-            static_cast<float>(now - bTime) / static_cast<float>(std::max(1ULL, bTime - aTime))
-        );
-
-        setLocalOrientation(glm::slerp(aQuat, bQuat, alpha));
-    }
-
     // there's no history to interpolate from,
     // just set the rig poses to whatever we have
     if ((size_t)_jointData.size() != _jointHistory.size()) {
         goto finishRigSetup;
     }
+
+    auto now = usecTimestampNow();
 
     for (int i = 0; i < _jointData.size(); i++) {
         const auto &history{_jointHistory[i]};
@@ -346,10 +333,10 @@ void OtherAvatar::interpolateJoints() {
 
         quint64 timeDiff = timePoint >= oldKeyframe.first ? timePoint - oldKeyframe.first : 0;
         // We need to avoid division by zero:
-        const float alpha = std::min(1.0f, static_cast<float>(timeDiff) /
+        const float theta = std::min(1.0f, static_cast<float>(timeDiff) /
             static_cast<float>(std::max(newKeyframe.first - oldKeyframe.first, 1ULL)));
-        _jointData[i].rotation = glm::slerp(oldKeyframe.second.rotation, newKeyframe.second.rotation, alpha);
-        _jointData[i].translation = glm::mix(oldKeyframe.second.translation, newKeyframe.second.translation, alpha);
+        _jointData[i].rotation = glm::slerp(oldKeyframe.second.rotation, newKeyframe.second.rotation, theta);
+        _jointData[i].translation = glm::mix(oldKeyframe.second.translation, newKeyframe.second.translation, theta);
     }
 
 finishRigSetup:

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1093,8 +1093,8 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
         glm::quat currentOrientation = getLocalOrientation();
 
         if (currentOrientation != newOrientation) {
-            _orientationHistory[0] = _orientationHistory[1];
-            _orientationHistory[1] = { usecTimestampNow(), newOrientation };
+            _hasNewJointData = true;
+            setLocalOrientation(newOrientation);
         }
         int numBytesRead = sourceBuffer - startSection;
         _avatarOrientationRate.increment(numBytesRead);

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1604,7 +1604,6 @@ protected:
     /// Per-joint variable signalizing availability of the new transforms.
     /// Set in AvatarData, cleared in OtherAvatar.
     std::vector<bool> _hasNewJointDataVec;
-    std::array<std::pair<quint64, glm::quat>, 2> _orientationHistory;
 
     mutable HeadData* _headData { nullptr };
 


### PR DESCRIPTION
This reverts commit 2a7fb1824b565a2e2e5e0f91732a729e8c682f60.

Fixes: https://github.com/overte-org/overte/issues/2264

Works on my machine.