### PR TITLE
Don't pack CPack JSON with AppImages

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -192,7 +192,9 @@ jobs:
 
     - name: Build installer
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+      run: |
+        cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+        rm build/Overte-*.json || true  # Remove JSON created by CPack External Generator to avoid it landing in the CI Artifacts.
 
     #- name: Sign installer (Windows)
     #  if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -238,7 +238,9 @@ jobs:
     - name: Build Installer
       if: matrix.build_type != 'android'
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+      run: |
+        cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+        rm build/Overte-*.json || true  # Remove JSON created by CPack External Generator to avoid it landing in the CI Artifacts.
 
     # As of 05/17/21 GitHub Virtual Environments changed their "Ubuntu 18.04.5 LTS" image to include two versions of CMake for Android
     # https://github.com/actions/virtual-environments/blob/ubuntu18/20210517.1/images/linux/Ubuntu1804-README.md

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -178,7 +178,9 @@ jobs:
 
     - name: Build installer
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+      run: |
+        cmake --build . --config $BUILD_TYPE --target package $CMAKE_BUILD_EXTRA
+        rm build/Overte-*.json || true  # Remove JSON created by CPack External Generator to avoid it landing in the CI Artifacts.
 
     #- name: Sign installer (Windows)
     #  if: startsWith(matrix.os, 'windows')


### PR DESCRIPTION
This PR fixes a little gripe of mine: On master, the AppImage CI artifacts contain a JSON file next to the AppImage, which makes AppImages extract into a separate folder on my system.