### PR TITLE
Add hand tracking toggle to OpenXR settings

### DIFF
--- a/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
@@ -18,8 +18,6 @@ import "."
 
 Flickable {
     id: flick
-    width: parent.width
-    height: parent.height
     anchors.fill: parent
     contentHeight: 550
     flickableDirection: Flickable.VerticalFlick
@@ -34,7 +32,7 @@ Flickable {
         z: 100  // Display over top of separators.
 
         background: Item {
-            implicitWidth: verticalScrollWidth
+            implicitWidth: 10
             Rectangle {
                 color: hifi.colors.baseGrayShadow
                 radius: 4
@@ -45,9 +43,9 @@ Flickable {
             }
         }
         contentItem: Item {
-            implicitWidth: verticalScrollShaft
+            implicitWidth: 10
             Rectangle {
-                radius: verticalScrollShaft/2
+                radius: 5
                 color: hifi.colors.white30
                 anchors {
                     fill: parent
@@ -90,9 +88,10 @@ Flickable {
             }
 
             Row {
-                id: otherConfig
+                id: hapticsRow
                 anchors.left: parent.left
                 anchors.leftMargin: leftMargin + 10
+                anchors.topMargin: 10
                 spacing: 10
 
                 HifiControls.CheckBox {
@@ -113,66 +112,60 @@ Flickable {
                 }
             }
 
+            Row {
+                id: handTrackingRow
+                anchors.left: parent.left
+                anchors.leftMargin: leftMargin + 10
+                anchors.top: hapticsRow.bottom
+                anchors.topMargin: 10
+                spacing: 10
+
+                HifiControls.CheckBox {
+                    id: handTrackingBox
+                    width: 15
+                    height: 15
+                    boxRadius: 7
+
+                    onClicked: {
+                        sendConfigurationSettings();
+                    }
+                }
+
+                RalewayBold {
+                    size: 12
+                    text: "Enable Hand Tracking"
+                    color: hifi.colors.lightGrayText
+                }
+            }
+
             RalewayBold {
-                id: bodyTracking
+                id: bodyTrackingTitle
 
                 text: "Body Tracking"
                 size: 12
 
                 color: hifi.colors.white
 
-                anchors.top: otherConfig.bottom
+                anchors.top: handTrackingRow.bottom
                 anchors.left: parent.left
                 anchors.leftMargin: leftMargin
                 anchors.topMargin: 10
             }
 
             RalewayRegular {
-                id: info
+                id: bodyTrackingInfo
 
-                text: "See Recommended Placement"
-                color: hifi.colors.blueHighlight
+                text: "Body tracking support is experimental on OpenXR. Calibration is incorrect, and tracking only works the Monado runtime currently. Other runtime vendors' body tracking extensions may be supported in the future."
                 size: 12
-                anchors {
-                    left: bodyTracking.right
-                    leftMargin: 10
-                    verticalCenter: bodyTracking.verticalCenter
-                    topMargin: 10
-                    top: bodyTracking.bottom
-                }
 
-                Rectangle {
-                    id: selected
-                    color: hifi.colors.blueHighlight
+                color: hifi.colors.white
+                wrapMode: Text.Wrap
 
-                    width: info.width
-                    height: 1
-
-                    anchors {
-                        top: info.bottom
-                        topMargin: 1
-                        left: info.left
-                        right: info.right
-                    }
-
-                    visible: false
-                }
-
-                MouseArea {
-                    anchors.fill: parent;
-                    hoverEnabled: true
-
-                    onEntered: {
-                        selected.visible = true;
-                    }
-
-                    onExited: {
-                        selected.visible = false;
-                    }
-                    onClicked: {
-                        stack.messageVisible = true;
-                    }
-                }
+                anchors.top: bodyTrackingTitle.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: leftMargin
+                anchors.topMargin: 10
             }
 
             color: hifi.colors.baseGray
@@ -191,7 +184,7 @@ Flickable {
 
                 width: glyphButton.width + calibrationText.width + padding
                 height: hifi.dimensions.controlLineHeight
-                anchors.top: bodyTracking.bottom
+                anchors.top: bodyTrackingInfo.bottom
                 anchors.topMargin: 15
                 anchors.left: parent.left
                 anchors.leftMargin: leftMargin
@@ -389,6 +382,7 @@ Flickable {
 
                 var settings = InputConfiguration.configurationSettings("OpenXR");
                 hapticsBox.checked = settings["enable_haptics"];
+                handTrackingBox.checked = settings["enable_hand_tracking"];
 
                 isConfiguring = false;
             }
@@ -397,6 +391,7 @@ Flickable {
                 var settings = InputConfiguration.configurationSettings("OpenXR");
 
                 settings["enable_haptics"] = hapticsBox.checked;
+                settings["enable_hand_tracking"] = handTrackingBox.checked;
 
                 InputConfiguration.setConfigurationSettings(settings, "OpenXR");
             }

--- a/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
@@ -155,7 +155,7 @@ Flickable {
             RalewayRegular {
                 id: bodyTrackingInfo
 
-                text: "Body tracking support is experimental on OpenXR. Calibration is incorrect, and tracking only works the Monado runtime currently. Other runtime vendors' body tracking extensions may be supported in the future."
+                text: "Body tracking is experimental on OpenXR. Monado's xdev tracker extension is partially supported, but calibration is broken. Other runtimes' body tracking extensions may be supported in the future."
                 size: 12
 
                 color: hifi.colors.white

--- a/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenXrConfiguration.qml
@@ -98,7 +98,6 @@ Flickable {
                     id: hapticsBox
                     width: 15
                     height: 15
-                    boxRadius: 7
 
                     onClicked: {
                         sendConfigurationSettings();
@@ -124,7 +123,6 @@ Flickable {
                     id: handTrackingBox
                     width: 15
                     height: 15
-                    boxRadius: 7
 
                     onClicked: {
                         sendConfigurationSettings();

--- a/plugins/openxr/src/OpenXrContext.cpp
+++ b/plugins/openxr/src/OpenXrContext.cpp
@@ -761,6 +761,11 @@ bool OpenXrContext::pollEvents() {
 
                     _vivePoseHack[i] = _viveControllerPath != XR_NULL_PATH && state.interactionProfile == _viveControllerPath;
 
+                    if (state.interactionProfile == XR_NULL_PATH) {
+                        qCInfo(xr_context_cat, "Controller %d was disconnected", i);
+                        continue;
+                    }
+
                     uint32_t bufferCountOutput;
                     char profilePath[XR_MAX_PATH_LENGTH];
                     res = xrPathToString(_instance, state.interactionProfile, XR_MAX_PATH_LENGTH, &bufferCountOutput,

--- a/plugins/openxr/src/OpenXrInputPlugin.cpp
+++ b/plugins/openxr/src/OpenXrInputPlugin.cpp
@@ -107,6 +107,11 @@ static glm::mat4 defaultPoseOffset(const controller::InputCalibrationData& data,
     }
 }
 
+// FIXME: This currently only works if you're
+// standing in the center of your playspace
+// and are directly facing "forward". The
+// stage space locating should probably be
+// local or floor-local instead.
 void OpenXrInputPlugin::guessXDevRoles(std::unordered_map<XrXDevIdMNDX, XDevTracker>& tracker_map) {
     std::vector<std::tuple<XrXDevIdMNDX, glm::vec3, controller::Pose>> tracker_list;
 
@@ -195,6 +200,7 @@ bool OpenXrInputPlugin::isSupported() const {
 void OpenXrInputPlugin::setConfigurationSettings(const QJsonObject configurationSettings) {
     const auto& calibration = configurationSettings["tracker_calibration"].toObject();
     _inputDevice->_hapticsEnabled = configurationSettings["enable_haptics"].toBool(true);
+    _inputDevice->_handTrackingEnabled = configurationSettings["enable_hand_tracking"].toBool(true);
 
     // grr qt5 doesnt support destructured iterating like std::map
     foreach (const auto& key, calibration.keys()) {
@@ -234,6 +240,7 @@ QJsonObject OpenXrInputPlugin::configurationSettings() {
     QJsonObject configurationSettings;
     configurationSettings["tracker_calibration"] = calibration;
     configurationSettings["enable_haptics"] = _inputDevice->_hapticsEnabled;
+    configurationSettings["enable_hand_tracking"] = _inputDevice->_handTrackingEnabled;
     return configurationSettings;
 }
 
@@ -307,6 +314,28 @@ void OpenXrInputPlugin::loadSettings() {
     Settings settings;
     settings.beginGroup(getName());
 
+    _inputDevice->_hapticsEnabled = settings.value("hapticsEnabled", true).toBool();
+    _inputDevice->_handTrackingEnabled = settings.value("handTrackingEnabled", true).toBool();
+
+    settings.beginGroup("trackerCalibration");
+
+    for (const auto& [name, channel] : stringToPoseChannel) {
+        if (!settings.contains(name)) { continue; }
+
+        vec3 translation = {};
+        quat rotation = {};
+
+        settings.getVec3ValueIfValid("translation", translation);
+        settings.getQuatValueIfValid("rotation", rotation);
+
+        _inputDevice->_trackerCalibrations.insert({
+            channel,
+            controller::Pose(translation, rotation),
+        });
+    }
+
+    settings.endGroup();
+
     settings.endGroup();
 }
 
@@ -314,13 +343,34 @@ void OpenXrInputPlugin::saveSettings() const {
     Settings settings;
     settings.beginGroup(getName());
 
+    settings.setValue("hapticsEnabled", _inputDevice->_hapticsEnabled);
+    settings.setValue("handTrackingEnabled", _inputDevice->_handTrackingEnabled);
+
+    // TODO: Should we save device serial->role mappings?
+    // HTCX_vive_tracker_interaction has preset roles and doesn't
+    // expose serials at all, and MNDX_xdev_space only has serials
+    // with no preset roles. Other skeletal body tracking extensions
+    // don't use serials either.
+    // This isn't really useful for MNDX_xdev_space yet since the
+    // recalibration step is also what assigns the roles to a tracker.
+    settings.beginGroup("trackerCalibration");
+
+    for (const auto& [channel, pose] : _inputDevice->_trackerCalibrations) {
+        settings.beginGroup(poseChannelToString.at(channel));
+        settings.setVec3Value("translation", pose.translation);
+        settings.setQuatValue("rotation", pose.rotation);
+        settings.endGroup();
+    }
+
+    settings.endGroup();
+
     settings.endGroup();
 }
 
 OpenXrInputPlugin::InputDevice::InputDevice(std::shared_ptr<OpenXrContext> c) : controller::InputDevice("OpenXR") {
     _context = c;
 
-    qCInfo(xr_input_cat) << "Hand tracking supported:" << _context->_handTrackingSupported;
+    qCDebug(xr_input_cat) << "Hand tracking supported:" << _context->_handTrackingSupported;
 }
 
 void OpenXrInputPlugin::InputDevice::focusOutEvent() {
@@ -1285,7 +1335,7 @@ void OpenXrInputPlugin::InputDevice::getHandTrackingInputs(int i, const mat4& se
 
     // if real hand tracking isn't available,
     // don't do any more than the capacitive touch tracking
-    if (!_context->_handTrackingSupported) {
+    if (!_context->_handTrackingSupported || !_handTrackingEnabled) {
         return;
     }
 

--- a/plugins/openxr/src/OpenXrInputPlugin.cpp
+++ b/plugins/openxr/src/OpenXrInputPlugin.cpp
@@ -107,6 +107,11 @@ static glm::mat4 defaultPoseOffset(const controller::InputCalibrationData& data,
     }
 }
 
+// FIXME: This currently only works if you're
+// standing in the center of your playspace
+// and are directly facing "forward". The
+// stage space locating should probably be
+// local or floor-local instead.
 void OpenXrInputPlugin::guessXDevRoles(std::unordered_map<XrXDevIdMNDX, XDevTracker>& tracker_map) {
     std::vector<std::tuple<XrXDevIdMNDX, glm::vec3, controller::Pose>> tracker_list;
 
@@ -195,6 +200,7 @@ bool OpenXrInputPlugin::isSupported() const {
 void OpenXrInputPlugin::setConfigurationSettings(const QJsonObject configurationSettings) {
     const auto& calibration = configurationSettings["tracker_calibration"].toObject();
     _inputDevice->_hapticsEnabled = configurationSettings["enable_haptics"].toBool(true);
+    _inputDevice->_handTrackingEnabled = configurationSettings["enable_hand_tracking"].toBool(true);
 
     // grr qt5 doesnt support destructured iterating like std::map
     foreach (const auto& key, calibration.keys()) {
@@ -234,6 +240,7 @@ QJsonObject OpenXrInputPlugin::configurationSettings() {
     QJsonObject configurationSettings;
     configurationSettings["tracker_calibration"] = calibration;
     configurationSettings["enable_haptics"] = _inputDevice->_hapticsEnabled;
+    configurationSettings["enable_hand_tracking"] = _inputDevice->_handTrackingEnabled;
     return configurationSettings;
 }
 
@@ -307,6 +314,28 @@ void OpenXrInputPlugin::loadSettings() {
     Settings settings;
     settings.beginGroup(getName());
 
+    _inputDevice->_hapticsEnabled = settings.value("hapticsEnabled", true).toBool();
+    _inputDevice->_handTrackingEnabled = settings.value("handTrackingEnabled", true).toBool();
+
+    settings.beginGroup("trackerCalibration");
+
+    for (const auto& [name, channel] : stringToPoseChannel) {
+        if (!settings.contains(name)) { continue; }
+
+        vec3 translation = {};
+        quat rotation = {};
+
+        settings.getVec3ValueIfValid("translation", translation);
+        settings.getQuatValueIfValid("rotation", rotation);
+
+        _inputDevice->_trackerCalibrations.insert({
+            channel,
+            controller::Pose(translation, rotation),
+        });
+    }
+
+    settings.endGroup();
+
     settings.endGroup();
 }
 
@@ -314,13 +343,34 @@ void OpenXrInputPlugin::saveSettings() const {
     Settings settings;
     settings.beginGroup(getName());
 
+    settings.setValue("hapticsEnabled", _inputDevice->_hapticsEnabled);
+    settings.setValue("handTrackingEnabled", _inputDevice->_handTrackingEnabled);
+
+    // TODO: Should we save device serial->role mappings?
+    // HTCX_vive_tracker_interaction has preset roles and doesn't
+    // expose serials at all, and MNDX_xdev_space only has serials
+    // with no preset roles. Other skeletal body tracking extensions
+    // don't use serials either.
+    // This isn't really useful for MNDX_xdev_space yet since the
+    // recalibration step is also what assigns the roles to a tracker.
+    settings.beginGroup("trackerCalibration");
+
+    for (const auto& [channel, pose] : _inputDevice->_trackerCalibrations) {
+        settings.beginGroup(poseChannelToString.at(channel));
+        settings.setVec3Value("translation", pose.translation);
+        settings.setQuatValue("rotation", pose.rotation);
+        settings.endGroup();
+    }
+
+    settings.endGroup();
+
     settings.endGroup();
 }
 
 OpenXrInputPlugin::InputDevice::InputDevice(std::shared_ptr<OpenXrContext> c) : controller::InputDevice("OpenXR") {
     _context = c;
 
-    qCInfo(xr_input_cat) << "Hand tracking supported:" << _context->_handTrackingSupported;
+    qCDebug(xr_input_cat) << "Hand tracking supported:" << _context->_handTrackingSupported;
 }
 
 void OpenXrInputPlugin::InputDevice::focusOutEvent() {
@@ -1345,7 +1395,7 @@ void OpenXrInputPlugin::InputDevice::getHandTrackingInputs(int i, const mat4& se
 
     // if real hand tracking isn't available,
     // don't do any more than the capacitive touch tracking
-    if (!_context->_handTrackingSupported) {
+    if (!_context->_handTrackingSupported || !_handTrackingEnabled) {
         return;
     }
 

--- a/plugins/openxr/src/OpenXrInputPlugin.h
+++ b/plugins/openxr/src/OpenXrInputPlugin.h
@@ -122,7 +122,7 @@ private:
         bool _wantsCalibrate = false;
 
         XrHandTrackerEXT _handTracker[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
-
+        bool _handTrackingEnabled = true;
         bool _hapticsEnabled = true;
 
         bool initActions();

--- a/plugins/openxr/src/OpenXrInputPlugin.h
+++ b/plugins/openxr/src/OpenXrInputPlugin.h
@@ -123,7 +123,7 @@ private:
         bool _wantsCalibrate = false;
 
         XrHandTrackerEXT _handTracker[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
-
+        bool _handTrackingEnabled = true;
         bool _hapticsEnabled = true;
 
         bool initActions();


### PR DESCRIPTION
Also actually implements the setting loading/saving functions so the settings will persist and there's a stub for saving tracker calibration offsets that'll be useful later once we support something that can keep track of the tracker roles

Fixes #2285