### PR TITLE
Revert "Fix NaN blotches and super bright single-pixel sparkles on bloom"

### DIFF
--- a/libraries/render-utils/src/ShadingModel.slh
+++ b/libraries/render-utils/src/ShadingModel.slh
@@ -99,9 +99,7 @@ float specularDistribution(SurfaceData surface) {
     float smithInvG1NdotL = evalSmithInvG1(surface.roughness4, surface.ndotl);
     denom *= surface.smithInvG1NdotV * smithInvG1NdotL;
     // Don't divide by PI as this is part of the light normalization factor
-    // NOTE: Epsilon limit has to be here or infinities and unreasonably-bright
-    // pixels can sneak in and break the bloom pass rendering
-    float power = surface.roughness4 / max(0.001, denom);
+    float power = surface.roughness4 / denom;
     return power;
 }
 


### PR DESCRIPTION
This unfortunately broke specular highlights ;;

It's safe to revert since it turns out there are *multiple* sources of NaNs/infinities on forward, so this kinda just broke stuff with no real benefit :pensive:

Fixes #2291