### PR TITLE
Skip NaNs in bloom threshold shader

### DIFF
--- a/libraries/render-utils/src/BloomThreshold.slf
+++ b/libraries/render-utils/src/BloomThreshold.slf
@@ -14,7 +14,7 @@
 <@include render-utils/ShaderConstants.h@>
 
 // Luminance in bloom effect needs to be clamped to avoid excessive sparkling.
-#define BLOOM_MAX_LUMINANCE 300.0
+#define BLOOM_MAX_LUMINANCE 10.0
 
 TEXTURE(RENDER_UTILS_TEXTURE_BLOOM_COLOR, sampler2D, colorMap);
 UNIFORM_BUFFER(RENDER_UTILS_BUFFER_BLOOM_PARAMS, parametersBuffer) {
@@ -33,6 +33,8 @@ void main(void) {
 
         for (int x=0 ; x<parameters._downsamplingFactor ; x++) {
             vec4 color = texture(colorMap, uv);
+            color = mix(color, vec4(0.0), isnan(color));
+
             float luminance = (color.r+color.g+color.b) / 3.0;
             // Luminance in bloom effect needs to be clamped to avoid excessive sparkling.
             if (luminance > BLOOM_MAX_LUMINANCE) {


### PR DESCRIPTION
*Actually* fixes #2081, by having the bloom threshold shader clamp NaNs to zero, instead of letting them through into the blur passes.

Also lowers the maximum luminance cap, which reduces how often single-pixel fireflies can blow out into big bloom blobs, with Text entities on forward and the tutorial trees being good examples.