### PR TITLE
Congestion control fixes

### DIFF
--- a/assignment-client/src/assets/AssetServer.cpp
+++ b/assignment-client/src/assets/AssetServer.cpp
@@ -936,8 +936,8 @@ void AssetServer::sendStatsPacket() {
         connectionStats["3. RTT (ms)"] = stats.rtt;
         connectionStats["4. CW (P)"] = stats.congestionWindowSize;
         connectionStats["5. Period (us)"] = stats.packetSendPeriod;
-        connectionStats["6. Up (Mb/s)"] = stats.sentBytes * megabitsPerSecPerByte;
-        connectionStats["7. Down (Mb/s)"] = stats.receivedBytes * megabitsPerSecPerByte;
+        connectionStats["6. Up (Mbit/s)"] = stats.sentBytes * megabitsPerSecPerByte;
+        connectionStats["7. Down (Mbit/s)"] = stats.receivedBytes * megabitsPerSecPerByte;
         connectionStats["last_heard_time_msecs"] = date.toUTC().toMSecsSinceEpoch();
         connectionStats["last_heard_ago_msecs"] = date.msecsTo(QDateTime::currentDateTime());
 

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -49,6 +49,8 @@ public:
 
     virtual int estimatedTimeout() const = 0;
 
+    virtual int roundTripTime() { return _roundTripTime; }
+
 protected:
     void setMSS(int mss) { _mss = mss; }
     virtual void setInitialSendSequenceNumber(SequenceNumber seqNum) = 0;
@@ -56,6 +58,7 @@ protected:
     void setPacketSendPeriod(double newSendPeriod); // call this internally to ensure send period doesn't go past max bandwidth
     
     double _packetSendPeriod { 1.0 }; // Packet sending period, in microseconds
+    int _roundTripTime { -1 }; // Round trip time, in milliseconds
     int _congestionWindowSize { 16 }; // Congestion window size, in packets
 
     std::atomic<int> _maxBandwidth { -1 }; // Maximum desired bandwidth, bits per second

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -23,7 +23,7 @@
 
 namespace udt {
     
-static const int32_t DEFAULT_SYN_INTERVAL = 10000; // 10 ms
+static const int32_t DEFAULT_SYN_INTERVAL = 2000000; // 2000 ms
 
 class Connection;
 class Packet;
@@ -58,7 +58,7 @@ protected:
     void setPacketSendPeriod(double newSendPeriod); // call this internally to ensure send period doesn't go past max bandwidth
     
     double _packetSendPeriod { 1.0 }; // Packet sending period, in microseconds
-    int _roundTripTime { -1 }; // Round trip time, in milliseconds
+    int _roundTripTime { -1 }; // Round trip time, in microseconds
     int _congestionWindowSize { 16 }; // Congestion window size, in packets
 
     std::atomic<int> _maxBandwidth { -1 }; // Maximum desired bandwidth, bits per second

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -437,6 +437,7 @@ void Connection::updateCongestionControlAndSendQueue(std::function<void ()> cong
     
     // record connection stats
     _stats.recordPacketSendPeriod(_congestionControl->_packetSendPeriod);
+    _stats.recordRoundTripTime(_congestionControl->roundTripTime() / 1000);
     _stats.recordCongestionWindowSize(_congestionControl->_congestionWindowSize);
 }
 

--- a/libraries/networking/src/udt/ConnectionStats.cpp
+++ b/libraries/networking/src/udt/ConnectionStats.cpp
@@ -82,6 +82,10 @@ void ConnectionStats::recordUnreliableReceivedPackets(int payload, int total) {
     _currentSample.receivedUnreliableBytes += total;
 }
 
+void ConnectionStats::recordRoundTripTime(int sample) {
+    _currentSample.rtt = sample;
+}
+
 void ConnectionStats::recordCongestionWindowSize(int sample) {
     _currentSample.congestionWindowSize = sample;
 }

--- a/libraries/networking/src/udt/ConnectionStats.h
+++ b/libraries/networking/src/udt/ConnectionStats.h
@@ -91,6 +91,7 @@ public:
     void recordUnreliableSentPackets(int payload, int total);
     void recordUnreliableReceivedPackets(int payload, int total);
 
+    void recordRoundTripTime(int sample);
     void recordCongestionWindowSize(int sample);
     void recordPacketSendPeriod(int sample);
     

--- a/libraries/networking/src/udt/TCPVegasCC.cpp
+++ b/libraries/networking/src/udt/TCPVegasCC.cpp
@@ -76,6 +76,7 @@ bool TCPVegasCC::calculateRTT(p_high_resolution_clock::time_point sendTime, p_hi
     // add 1 to the number of RTT samples collected during this RTT window
     ++_numRTTs;
 
+    _roundTripTime = _ewmaRTT;
     return true;
 }
 

--- a/libraries/networking/src/udt/TCPVegasCC.cpp
+++ b/libraries/networking/src/udt/TCPVegasCC.cpp
@@ -252,7 +252,7 @@ void TCPVegasCC::performCongestionAvoidance(udt::SequenceNumber ack) {
 
 
 int TCPVegasCC::estimatedTimeout() const {
-    return _ewmaRTT == -1 ? DEFAULT_SYN_INTERVAL : _ewmaRTT + _rttVariance * 4;
+    return _ewmaRTT == -1 ? DEFAULT_SYN_INTERVAL * 200 : _ewmaRTT + _rttVariance * 4;
 }
 
 bool TCPVegasCC::isCongestionWindowLimited() {

--- a/libraries/networking/src/udt/TCPVegasCC.cpp
+++ b/libraries/networking/src/udt/TCPVegasCC.cpp
@@ -252,7 +252,7 @@ void TCPVegasCC::performCongestionAvoidance(udt::SequenceNumber ack) {
 
 
 int TCPVegasCC::estimatedTimeout() const {
-    return _ewmaRTT == -1 ? DEFAULT_SYN_INTERVAL * 200 : _ewmaRTT + _rttVariance * 4;
+    return _ewmaRTT == -1 ? DEFAULT_SYN_INTERVAL : _ewmaRTT + _rttVariance * 4;
 }
 
 bool TCPVegasCC::isCongestionWindowLimited() {


### PR DESCRIPTION
This PR fixes connection resets in high latency environments, due to overwhelming the connection with retransmissions.

While the algorithm still needs improvement to get up to speed a lot faster (it leaves the accelerated ramp-up too early), this should fix a lot of connection reliability issues.
I tested it by building the server on my Mac and connecting to it using my Linux laptop with simulated high latency of 1000ms. This fix should work until the latency gets a good amount over 2000ms, which I believe would be enough to connect to Overte from the moon.

The PR is running on the Hub right now, if anyone wants to try it. I tested it myself, but better safe than sorry.