### PR TITLE
Convert sRGB colors to linear for skybox and light

### DIFF
--- a/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableLightEntityItem.cpp
@@ -36,7 +36,7 @@ void LightEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPoint
     float largestDiameter = glm::compMax(dimensions);
     light->setMaximumRadius(largestDiameter / 2.0f);
 
-    light->setColor(toGlm(entity->getColor()));
+    light->setColor(ColorUtils::toVec3(entity->getColor()));
 
     _intensity = entity->getIntensity();
     light->setIntensity(_intensity);

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -436,9 +436,9 @@ void ZoneEntityRenderer::updateHazeFromEntity(const TypedEntityPointer& entity) 
 
     haze->setHazeRangeFactor(graphics::Haze::convertHazeRangeToHazeRangeFactor(_hazeProperties.getHazeRange()));
     glm::u8vec3 hazeColor = _hazeProperties.getHazeColor();
-    haze->setHazeColor(toGlm(hazeColor));
+    haze->setHazeColor(ColorUtils::toVec3(hazeColor));
     glm::u8vec3 hazeGlareColor = _hazeProperties.getHazeGlareColor();
-    haze->setHazeGlareColor(toGlm(hazeGlareColor));
+    haze->setHazeGlareColor(ColorUtils::toVec3(hazeGlareColor));
     haze->setHazeEnableGlare(_hazeProperties.getHazeEnableGlare());
     haze->setHazeGlareBlend(graphics::Haze::convertGlareAngleToPower(_hazeProperties.getHazeGlareAngle()));
 
@@ -502,7 +502,7 @@ void ZoneEntityRenderer::updateKeyBackgroundFromEntity(const TypedEntityPointer&
     _skyboxMode = (ComponentMode)entity->getSkyboxMode();
 
     editBackground();
-    setSkyboxColor(toGlm(_skyboxProperties.getColor()));
+    setSkyboxColor(ColorUtils::toVec3(_skyboxProperties.getColor()));
     setProceduralUserData(_proceduralUserData);
     setSkyboxURL(_skyboxProperties.getUrl());
 }

--- a/libraries/shared/src/ColorUtils.h
+++ b/libraries/shared/src/ColorUtils.h
@@ -42,7 +42,7 @@ public:
 
 inline glm::vec3 ColorUtils::toVec3(const glm::u8vec3& color) {
     const float ONE_OVER_255 = 1.0f / 255.0f;
-    return glm::vec3(color.x * ONE_OVER_255, color.y * ONE_OVER_255, color.z * ONE_OVER_255);
+    return sRGBToLinearVec3(glm::vec3(color.x * ONE_OVER_255, color.y * ONE_OVER_255, color.z * ONE_OVER_255));
 }
 
 inline glm::vec3 ColorUtils::toGamma22Vec3(const glm::vec3& linear) {


### PR DESCRIPTION
The colors on skybox elements and lights were incorrectly interpreting the sRGB property values as linear colors, which made them look washed out and made it difficult to properly set them.

This is a breaking change, but will make world authoring easier in the future, since the skybox and light colors will now correctly match up with color pickers.

I've checked and it looks like the skybox and light colors were the only places that were affected by this bug. The colors on Shapes, Webs, and Images already look correct.

Closes #2249

### Light
A spotlight with color `#fcd7a6` and intensity 30 facing a 50% gray `#808080` wall. Note how the release light washed out, while the new light looks a lot closer to the original color value.

| 2026.04.1 | This PR
| --- | ---
| <img width="734" height="546" alt="image" src="https://github.com/user-attachments/assets/e98a7051-5d56-4a2d-bd61-c182f9a40cee" /> | <img width="627" height="481" alt="image" src="https://github.com/user-attachments/assets/ca41cfb7-fdfc-4830-804b-dc9bd8b6c8d4" />

### My Serverless Home
A sky set to 50% gray `#808080` with 25% gray `#404040` haze.

Note that if you open these in an image editor, the PR version *actually* has 50% and 25% gray, while the release one has not-quite 75% gray and 50% gray.

| 2026.04.1 | This PR
| ---       | ---
| <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/152daf47-df6b-4aeb-84d0-e0931219c6e5" /> | <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/1a1a1403-f2d8-4dd0-8388-83fe65feab45" />

### Tutorial
| 2026.04.1 | This PR
| ---    | ---
| <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/d304bb88-4331-4889-9acb-4c43df7b74d6" /> | <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/37f8672d-acb4-48d4-8dc7-adb1ba5e343c" />

### Hytrion Junction
| 2026.04.1 | This PR
| ---       | ---
| <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/6e22f54a-d7e8-4b7f-8243-ef112c21e6f8" /> | <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/d3bc6245-5731-47fb-ab30-f9b342c70ce3" />

### Ceon
| 2026.04.1 | This PR
| ---       | ---
| <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/45edc54a-120d-414e-996f-1560bc0500cb" /> | <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/a11aa0a8-aa99-44eb-a0e9-57497e244937" />

### Virz-Junction
| 2026.04.1 | This PR
| ---       | ---
| <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/d474fbec-ceb8-45c5-922e-21f9d2d0e5e0" /> | <img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/2379453e-c219-4614-a2bf-90f0c4c70728" />
