### PR TITLE
Minor changes

### DIFF
--- a/interface/resources/serverless/tutorial.json
+++ b/interface/resources/serverless/tutorial.json
@@ -381,7 +381,7 @@
             "visible": false,
             "name": "portalCube",
             "locked": true,
-            "userData": "{\"destination\":\"hifi://overte_hub/8.78229,-27.241,121.826/0,0.711478,0,0.702708\"}",
+            "userData": "{\"destination\":\"hifi://overte_hub/\"}",
             "position": {
                 "x":2004.5484619140625,
                 "y":1996.08203125,

--- a/interface/src/Application_Plugins.cpp
+++ b/interface/src/Application_Plugins.cpp
@@ -108,7 +108,7 @@ void Application::initializePluginManager(const QCommandLineParser& parser) {
     } else if (!displayPluginSpecified) {
         const QStringList choices = {
             tr("Desktop"),
-            tr("OpenXR (experimental)"),
+            tr("OpenXR"),
             tr("OpenVR (compatibility)"),
         };
 


### PR DESCRIPTION
This PR changes the portal in the tutorial world to point to the default spawn location of the Overte_Hub instead of hardcoded coordinates.
It also removes the "experimental" from the OpenXR option's name. It has been perfectly stable for quite a while now, and should be preferred over OpenVR in all cases except for body tracking and Windows Mixed Reality using official software.