### PR TITLE
Server packaging script

### DIFF
--- a/pkg-scripts/new-server
+++ b/pkg-scripts/new-server
@@ -28,7 +28,11 @@ if [ -d "/var/lib/overte/$1" ]; then
 fi
 
 mkdir -p /var/lib/overte/$1/.local/share
+# Old development builds.
 ln -s ../.. /var/lib/overte/$1/.local/share/Overte\ -\ dev
+ln -s ../.. /var/lib/overte/$1/.local/share/Overte\ -\ PR
+ln -s ../.. /var/lib/overte/$1/.local/share/Overte\ -\ Dev
+ln -s ../.. /var/lib/overte/$1/.local/share/Overte\ -\ Nightly
 ln -s ../.. /var/lib/overte/$1/.local/share/Overte
 mkdir -p /var/lib/overte/$1/domain-server
 echo "{\"metaverse\": {\"local_port\": $(($2 + 2))},\"version\": 2.4}" > /var/lib/overte/$1/domain-server/config.json

--- a/pkg-scripts/server-postinst
+++ b/pkg-scripts/server-postinst
@@ -29,12 +29,14 @@ case "$1" in
         systemctl enable overte-server@default.target
         systemctl start overte-server@default.target
     else # Default server was already created in the past.
-        # Starting default server in case we removed but didn't purge it.
-        systemctl enable overte-server@default.target
-        systemctl start overte-server@default.target
-        # SystemD can have Units in "memory" which are not actually "loaded", for example because they do not exist anymore.
-        systemctl list-units --state=loaded \
-            | grep -P -o "(overte-assignment-client|overte-domain-server|overte-server)\S+" \
+        if systemctl is-enabled overte-server@default.target | grep -q 'disabled'; then
+            echo "The default server was already created in the past but is disabled."
+            echo "You can reenable it with:"
+            echo "  sudo systemctl enable overte-server@default.target"
+        fi
+        # This lists all enabled targets, such as overte-server@default.target and restarts them.
+        systemctl list-units --type=target \
+            | grep -P -o "overte-server\S+" \
             | xargs systemctl restart
     fi
     ;;


### PR DESCRIPTION
This PR adds more symlinks for non-release builds to the Debian server package. (There is nothing like trying to test a PR and being dumped into a black void instead of the world you expected.)
It also changes the postinstall script to not reenable the overte-server@default.target during an update if it was disabled. In my case, I named all the targets on the domain-beta.overte.org server, so the @default target has been replaced by an @Overte_Hub target. Without this PR, every update would reenable and restart the @default target.

I tested this on a separate server. It won't create the symlinks after the fact, but when installing from scratch or when creating a new server.