### PR TITLE
Fix -Wunused-but-set-variable warnings

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1840,7 +1840,7 @@ bool MyAvatar::updateStaleAvatarEntityBlobs() const {
     }
 
     std::set<EntityItemID> staleIDs = std::move(_staleCachedAvatarEntityBlobs);
-    int32_t numFound = 0;
+
     for (const auto& id : staleIDs) {
         bool found = false;
         EntityItemProperties properties;
@@ -1852,7 +1852,6 @@ bool MyAvatar::updateStaleAvatarEntityBlobs() const {
             }
         });
         if (found) {
-            ++numFound;
             QByteArray blob;
             _helperScriptEngine.run( [&] {
                 EntityItemProperties::propertiesToBlob(*_helperScriptEngine.get(), getID(), properties, blob);

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -71,19 +71,19 @@ void buildObjectIntersectionsMap(IntersectionType intersectionType, const std::v
  *
  * @typedef {object} IntersectingObject
  * @property {Uuid} id - The ID of the object.
- * @property {IntersectionType} type - The type of the object, either <code>1</code> for INTERSECTED_ENTITY or <code>3</code> 
+ * @property {IntersectionType} type - The type of the object, either <code>1</code> for INTERSECTED_ENTITY or <code>3</code>
  *     for INTERSECTED_AVATAR.
  * @property {CollisionContact[]} collisionContacts - Information on the penetration between the pick and the object.
  */
 
 /*@jsdoc
- * A pair of points that represents part of an overlap between a {@link CollisionPick} and an object in the physics engine. 
+ * A pair of points that represents part of an overlap between a {@link CollisionPick} and an object in the physics engine.
  * Points which are further apart represent deeper overlap.
  *
  * @typedef {object} CollisionContact
- * @property {Vec3} pointOnPick - A point representing a penetration of the object's surface into the volume of the pick, in 
+ * @property {Vec3} pointOnPick - A point representing a penetration of the object's surface into the volume of the pick, in
  *     world coordinates.
- * @property {Vec3} pointOnObject - A point representing a penetration of the pick's surface into the volume of the object, in 
+ * @property {Vec3} pointOnObject - A point representing a penetration of the pick's surface into the volume of the object, in
  *     world coordinates.
  * @property {Vec3} normalOnPick - The normal vector pointing away from the pick, representing the direction of collision.
  */
@@ -283,7 +283,6 @@ void CollisionPick::computeShapeInfo(const CollisionRegion& pick, ShapeInfo& sha
         triangleIndices.clear();
 
         Extents extents;
-        int32_t meshCount = 0;
         int32_t pointListIndex = 0;
         for (auto& mesh : meshes) {
             if (!mesh.vertices.size()) {
@@ -355,7 +354,6 @@ void CollisionPick::computeShapeInfo(const CollisionRegion& pick, ShapeInfo& sha
                 // flag end of mesh
                 triangleIndices.push_back(END_OF_MESH);
             }
-            ++meshCount;
         }
 
         // scale and shift
@@ -434,7 +432,7 @@ PickResultPointer CollisionPick::getEntityIntersection(const CollisionRegion& pi
         return std::make_shared<CollisionPickResult>(pick.toVariantMap(), std::vector<ContactTestResult>(), std::vector<ContactTestResult>());
     }
     getShapeInfoReady(pick);
-    
+
     auto entityIntersections = _physicsEngine->contactTest(USER_COLLISION_MASK_ENTITIES, *_mathPick.shapeInfo, pick.transform, pick.collisionGroup, pick.threshold);
     filterIntersections(entityIntersections);
     return std::make_shared<CollisionPickResult>(pick, entityIntersections, std::vector<ContactTestResult>());
@@ -446,7 +444,7 @@ PickResultPointer CollisionPick::getAvatarIntersection(const CollisionRegion& pi
         return std::make_shared<CollisionPickResult>(pick, std::vector<ContactTestResult>(), std::vector<ContactTestResult>());
     }
     getShapeInfoReady(pick);
-    
+
     auto avatarIntersections = _physicsEngine->contactTest(USER_COLLISION_MASK_AVATARS, *_mathPick.shapeInfo, pick.transform, pick.collisionGroup, pick.threshold);
     filterIntersections(avatarIntersections);
     return std::make_shared<CollisionPickResult>(pick, std::vector<ContactTestResult>(), avatarIntersections);

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -255,8 +255,6 @@ void fixBisectedAxis(float& full, float& negative, float& positive) {
 void UserInputMapper::update(float deltaTime) {
     Locker locker(_lock);
     InputRecorder* inputRecorder = InputRecorder::getInstance();
-    static uint64_t updateCount = 0;
-    ++updateCount;
 
     inputRecorder->resetFrame();
     // Reset the axis state for next loop

--- a/libraries/entities/src/EntityItemProperties.cpp.in
+++ b/libraries/entities/src/EntityItemProperties.cpp.in
@@ -1213,8 +1213,6 @@ bool EntityItemProperties::encodeCloneEntityMessage(const EntityItemID& entityID
 }
 
 bool EntityItemProperties::decodeCloneEntityMessage(const QByteArray& buffer, int& processedBytes, EntityItemID& entityIDToClone, EntityItemID& newEntityID) {
-    const unsigned char* packetData = (const unsigned char*)buffer.constData();
-    const unsigned char* dataAt = packetData;
     size_t packetLength = buffer.size();
     processedBytes = 0;
 
@@ -1225,12 +1223,10 @@ bool EntityItemProperties::decodeCloneEntityMessage(const QByteArray& buffer, in
 
     QByteArray encodedID = buffer.mid((int)processedBytes, NUM_BYTES_RFC4122_UUID);
     entityIDToClone = QUuid::fromRfc4122(encodedID);
-    dataAt += encodedID.size();
     processedBytes += encodedID.size();
 
     encodedID = buffer.mid((int)processedBytes, NUM_BYTES_RFC4122_UUID);
     newEntityID = QUuid::fromRfc4122(encodedID);
-    dataAt += encodedID.size();
     processedBytes += encodedID.size();
 
     return true;

--- a/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.cpp
@@ -158,9 +158,9 @@ void TouchscreenVirtualPadDevice::processInputDeviceForView() {
     // We use average across how many times we've got touchUpdate events.
     // Using the average instead of the full deltaX and deltaY, makes deltaTime in MyAvatar dont't accelerate rotation when there is a low touchUpdate rate (heavier domains).
     // (Because it multiplies this input value by deltaTime (with a coefficient)).
-    _inputDevice->_axisStateMap[controller::RX].value = 
+    _inputDevice->_axisStateMap[controller::RX].value =
         _viewTouchUpdateCount == 0 ? 0 : (_viewCurrentTouchPoint.x - _viewRefTouchPoint.x) / _viewTouchUpdateCount;
-    _inputDevice->_axisStateMap[controller::RY].value = 
+    _inputDevice->_axisStateMap[controller::RY].value =
         _viewTouchUpdateCount == 0 ? 0 : (_viewCurrentTouchPoint.y - _viewRefTouchPoint.y) / _viewTouchUpdateCount;
 
     // after use, save last touch point as ref
@@ -218,18 +218,9 @@ void TouchscreenVirtualPadDevice::debugPoints(const QTouchEvent* event, QString 
         glm::vec2 thisPoint(tPoints[i].pos().x(), tPoints[i].pos().y());
         points << thisPoint;
     }
-    QScreen* eventScreen = event->window()->screen();
-    int midScreenX = eventScreen->availableSize().width()/2;
-    int lefties = 0;
-    int righties = 0;
     vec2 currentPoint;
     for (int i = 0; i < points.length(); i++) {
         currentPoint = points.at(i);
-        if (currentPoint.x < midScreenX) {
-            lefties++;
-        } else {
-            righties++;
-        }
     }
 }
 

--- a/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.cpp
@@ -209,24 +209,10 @@ bool TouchscreenVirtualPadDevice::InputDevice::triggerHapticPulse(float strength
 void TouchscreenVirtualPadDevice::InputDevice::focusOutEvent() {
 }
 
-void TouchscreenVirtualPadDevice::debugPoints(const QTouchEvent* event, QString who) {
-    // convert the touch points into an average
-    const QList<QTouchEvent::TouchPoint>& tPoints = event->touchPoints();
-    QVector<glm::vec2> points;
-    int touchPoints = tPoints.count();
-    for (int i = 0; i < touchPoints; ++i) {
-        glm::vec2 thisPoint(tPoints[i].pos().x(), tPoints[i].pos().y());
-        points << thisPoint;
-    }
-    vec2 currentPoint;
-    for (int i = 0; i < points.length(); i++) {
-        currentPoint = points.at(i);
-    }
-}
+
 
 void TouchscreenVirtualPadDevice::touchBeginEvent(const QTouchEvent* event) {
     // touch begin here is a big begin -> begins both pads? maybe it does nothing
-    debugPoints(event, " BEGIN ++++++++++++++++");
     auto& virtualPadManager = VirtualPad::Manager::instance();
     if (!virtualPadManager.isEnabled() && !virtualPadManager.isHidden()) {
         return;
@@ -244,7 +230,6 @@ void TouchscreenVirtualPadDevice::touchEndEvent(const QTouchEvent* event) {
     // touch end here is a big reset -> resets both pads
     _touchPointCount = 0;
     _unusedTouches.clear();
-    debugPoints(event, " END ----------------");
     moveTouchEnd();
     viewTouchEnd();
     _buttonsManager.endTouchForAll();

--- a/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.h
+++ b/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.h
@@ -195,9 +195,7 @@ protected:
     void processUnusedTouches(std::map<int, TouchType> unusedTouchesInEvent);
 
     void processInputDeviceForView();
-// just for debug
-private:
-    void debugPoints(const QTouchEvent* event, QString who);
+
 
 };
 

--- a/libraries/model-baker/src/model-baker/BuildDracoMeshTask.cpp
+++ b/libraries/model-baker/src/model-baker/BuildDracoMeshTask.cpp
@@ -120,7 +120,6 @@ std::tuple<std::unique_ptr<draco::Mesh>, bool> createDracoMesh(const hfm::Mesh& 
             1, draco::DT_UINT16);
     }
 
-    auto partIndex = 0;
     draco::FaceIndex face;
     uint16_t materialID;
 
@@ -177,7 +176,6 @@ std::tuple<std::unique_ptr<draco::Mesh>, bool> createDracoMesh(const hfm::Mesh& 
             addFace(part.triangleIndices, i, face++);
         }
 
-        partIndex++;
     }
 
     auto dracoMesh = meshBuilder.Finalize();
@@ -200,7 +198,7 @@ std::tuple<std::unique_ptr<draco::Mesh>, bool> createDracoMesh(const hfm::Mesh& 
     if (needsOriginalIndices) {
         dracoMesh->attribute(originalIndexAttributeID)->set_unique_id(DRACO_ATTRIBUTE_ORIGINAL_INDEX);
     }
-    
+
     return std::make_tuple(std::move(dracoMesh), false);
 }
 #endif // not Q_OS_ANDROID

--- a/libraries/model-serializers/src/FBXSerializer.cpp
+++ b/libraries/model-serializers/src/FBXSerializer.cpp
@@ -1153,7 +1153,6 @@ HFMModel* FBXSerializer::extractHFMModel(const hifi::VariantHash& mapping, const
                             }
                         }
                     } else if (connection.properties.at(0) == OP) {
-                        int counter = 0;
                         hifi::ByteArray type = connection.properties.at(3).toByteArray().toLower();
                         if (type.contains("DiffuseFactor")) {
                             diffuseFactorTextures.insert(getID(connection.properties, 2), getID(connection.properties, 1));
@@ -1203,7 +1202,6 @@ HFMModel* FBXSerializer::extractHFMModel(const hifi::VariantHash& mapping, const
 
                         } else {
                             QString typenam = type.data();
-                            counter++;
                         }
                     }
                     if (_connectionParentMap.value(getID(connection.properties, 1)) == "0") {

--- a/libraries/model-serializers/src/OBJSerializer.cpp
+++ b/libraries/model-serializers/src/OBJSerializer.cpp
@@ -501,7 +501,6 @@ bool OBJSerializer::parseOBJGroup(OBJTokenizer& tokenizer, const hifi::VariantHa
     HFMMeshPart& meshPart = mesh.parts.last();
     bool sawG = false;
     bool result = true;
-    int originalFaceCountForDebugging = 0;
     QString currentGroup;
     bool anyVertexColor { false };
     int vertexCount { 0 };
@@ -637,7 +636,7 @@ bool OBJSerializer::parseOBJGroup(OBJTokenizer& tokenizer, const hifi::VariantHa
                 face.groupName = currentGroup;
                 face.materialName = currentMaterialName;
             }
-            originalFaceCountForDebugging++;
+
             foreach(OBJFace face, face.triangulate()) {
                 faces.append(face);
             }

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -36,8 +36,7 @@ static TemporaryPairwiseCollisionFilter _pairwiseFilter;
 bool applyPairwiseFilter(btManifoldPoint& cp,
         const btCollisionObjectWrapper* colObj0Wrap, int partId0, int index0,
         const btCollisionObjectWrapper* colObj1Wrap, int partId1, int index1) {
-    static int32_t numCalls = 0;
-    ++numCalls;
+
     // This callback is ONLY called on objects with btCollisionObject::CF_CUSTOM_MATERIAL_CALLBACK flag
     // and the flagged object will always be sorted to Obj0.  Hence the "other" is always Obj1.
     const btCollisionObject* other = colObj1Wrap->m_collisionObject;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -316,13 +316,11 @@ bool Model::updateGeometry() {
         }
 
         const HFMModel& hfmModel = getHFMModel();
-        int i = 0;
         foreach (const HFMMesh& mesh, hfmModel.meshes) {
             MeshState state;
             state.clusterDualQuaternions.resize(mesh.clusters.size());
             state.clusterMatrices.resize(mesh.clusters.size());
             _meshStates.push_back(state);
-            i++;
         }
         needFullUpdate = true;
         emit rigReady();

--- a/libraries/render/src/render/BlurTask.cpp
+++ b/libraries/render/src/render/BlurTask.cpp
@@ -77,7 +77,7 @@ void BlurParams::setFilterGaussianTaps(int numHalfTaps, float sigma) {
     assert(numTaps <= BLUR_MAX_NUM_TAPS);
     assert(sigma > 0.0f);
     const float inverseTwoSigmaSquared = float(0.5 / double(sigma*sigma));
-    float totalWeight = 1.0f;
+
     float weight;
     float offset;
     int i;
@@ -97,7 +97,6 @@ void BlurParams::setFilterGaussianTaps(int numHalfTaps, float sigma) {
         params.filterTaps[i + 1 + numHalfTaps].y = weight;
         params.filterTaps[i + 1 + numHalfTaps].z = 0.0f;
         params.filterTaps[i + 1 + numHalfTaps].w = 0.0f;
-        totalWeight += 2 * weight;
     }
 
     // Tap weights will be normalized in shader because side cases on edges of screen
@@ -146,7 +145,7 @@ bool BlurInOutResource::updateResources(const gpu::FramebufferPointer& sourceFra
     }
 
     auto blurBufferSize = sourceFramebuffer->getSize();
-    
+
     blurBufferSize.x /= _downsampleFactor;
     blurBufferSize.y /= _downsampleFactor;
 
@@ -164,7 +163,7 @@ bool BlurInOutResource::updateResources(const gpu::FramebufferPointer& sourceFra
         auto blurringSampler = Sampler(Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT, Sampler::WRAP_CLAMP);
         auto blurringTarget = gpu::Texture::createRenderBuffer(sourceFramebuffer->getRenderBuffer(0)->getTexelFormat(), blurBufferSize.x, blurBufferSize.y, gpu::Texture::SINGLE_MIP, blurringSampler);
         _blurredFramebuffer->setRenderBuffer(0, blurringTarget);
-    } 
+    }
 
     blurringResources.sourceTexture = sourceFramebuffer->getRenderBuffer(0);
     blurringResources.blurringFramebuffer = _blurredFramebuffer;
@@ -358,7 +357,7 @@ void BlurGaussianDepthAware::run(const RenderContextPointer& renderContext, cons
         // early exit if no valid blurring resources
         return;
     }
-    
+
     blurredFramebuffer = blurringResources.finalFramebuffer;
 
     auto blurVPipeline = getBlurVPipeline();

--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -229,7 +229,7 @@ QAction* Menu::addCheckableActionToQMenuAndActionHash(MenuWrapper* destinationMe
                                                     const QKeySequence& shortcut,
                                                     const bool checked,
                                                     int menuItemLocation,
-                                                    const QString& grouping) { 
+                                                    const QString& grouping) {
     auto action = addCheckableActionToQMenuAndActionHash(destinationMenu, actionName, shortcut, checked, nullptr, nullptr, menuItemLocation, grouping);
     connect(action, &QAction::triggered, handler);
     return action;
@@ -324,14 +324,13 @@ MenuWrapper* Menu::getMenu(const QString& menuName) {
     QStringList menuTree = menuName.split(">");
     MenuWrapper* parent = NULL;
     MenuWrapper* menu = NULL;
-    int item = 0;
+
     foreach (QString menuTreePart, menuTree) {
         menu = getSubMenuFromName(menuTreePart.trimmed(), parent);
         if (!menu) {
             break;
         }
         parent = menu;
-        item++;
     }
     return menu;
 }


### PR DESCRIPTION
This fixes a bunch of this:

```
/home/vadim/git/overte/overte/libraries/physics/src/CharacterController.cpp: In function ‘bool applyPairwiseFilter(btManifoldPoint&, const btCollisionObjectWrapper*, int, int, const btCollisionObjectWrapper*, int, int)’:
/home/vadim/git/overte/overte/libraries/physics/src/CharacterController.cpp:39:20: warning: variable ‘numCalls’ set but not used [-Wunused-but-set-variable=]
   39 |     static int32_t numCalls = 0;
```

This gets things back to a warning-free build.


