### PR TITLE
Fix a leak in octree

### DIFF
--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -811,7 +811,7 @@ bool Octree::readJSONFromStream(
     std::array<char, READ_JSON_BUFFER_SIZE> rawData;
 
     while (!inputStream.atEnd()) {
-        int got = inputStream.readRawData(rawData.data(), READ_JSON_BUFFER_SIZE - 1);
+        int got = inputStream.readRawData(rawData.data(), rawData.size());
         if (got < 0) {
             qCritical() << "error while reading from json stream";
             return false;

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -808,18 +808,18 @@ bool Octree::readJSONFromStream(
     // we get an eof.  Leave streamLength parameter for consistency.
 
     QByteArray jsonBuffer;
-    char* rawData = new char[READ_JSON_BUFFER_SIZE];
+    std::array<char, READ_JSON_BUFFER_SIZE> rawData;
+
     while (!inputStream.atEnd()) {
-        int got = inputStream.readRawData(rawData, READ_JSON_BUFFER_SIZE - 1);
+        int got = inputStream.readRawData(rawData.data(), READ_JSON_BUFFER_SIZE - 1);
         if (got < 0) {
             qCritical() << "error while reading from json stream";
-            delete[] rawData;
             return false;
         }
         if (got == 0) {
             break;
         }
-        jsonBuffer += QByteArray(rawData, got);
+        jsonBuffer += QByteArray(rawData.data(), got);
     }
 
     OctreeEntitiesFileParser octreeParser;
@@ -833,7 +833,6 @@ bool Octree::readJSONFromStream(
     }
 
     bool success = readFromMap(asMap, isImport);
-    delete[] rawData;
     return success;
 }
 


### PR DESCRIPTION
The leak is in the error handling path.

Use a statically allocated buffer instead. Since it's just 2K there's no much reason to allocate it dynamically.
