### PR TITLE
Add source changes needed for Flatpak source builds without networking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # https://www.git-scm.com/docs/gitignore
 #
 # Copyright 2013-2019 High Fidelity, Inc.
-# Copyright 2022-2025 Overte e.V.
+# Copyright 2022-2026 Overte e.V.
 # SPDX-License-Identifier: Apache-2.0
 
 VideoDecodeStats
@@ -138,3 +138,7 @@ interface/compiledResources
 
 # Act local GitHub Actions
 .secret
+
+# Flatpak
+/repo/
+/.flatpak-builder/

--- a/conanfile.py
+++ b/conanfile.py
@@ -61,7 +61,7 @@ class Overte(ConanFile):
         self.requires("draco/1.3.5") # FIXME: update to newer version
         self.requires("etc2comp/cci.20170424") # NOTE: archived upstream
         self.requires("gifcreator/2016.11@overte/stable")
-        self.requires("glad/0.1.36") # NOTE: glad 2 is released
+        self.requires("glad/0.1.36@overte/experimental#9612a3032fecdd1d8781dfb1b2bd6dc6") # NOTE: glad 2 is released
         self.requires("gli/cci.20210515") # NOTE: not maintained for 4 years
         self.requires("glslang/1.4.350.0")
         self.requires("liblo/0.35@overte/stable") # For hifiOSC

--- a/interface/org.overte.interface.desktop
+++ b/interface/org.overte.interface.desktop
@@ -5,4 +5,4 @@ Terminal=false
 Type=Application
 Exec=interface
 Icon=interface
-Categories=Network;Qt;
+Categories=Network;Qt;Game;

--- a/tools/conan-profiles/flathub
+++ b/tools/conan-profiles/flathub
@@ -1,0 +1,19 @@
+include(default)
+
+[settings]
+compiler.cppstd=gnu20
+
+[platform_tool_requires]
+# Use system CMake
+# The version number is us telling Conan which cmake version we have on our system.
+cmake/4.2.0
+# We lie about our version here, so Conan doesn't try to get CMake version <4.
+cmake/3.31.12
+
+[conf]
+# Avoid dependencies failing to build on GCC 15 and newer.
+tools.build:cxxflags=['-include', 'cstdint']
+
+[options]
+# Required for building oneTBB.
+hwloc/*:shared=True


### PR DESCRIPTION
- Add a flathub Conan profile, which is intended for building against system Qt (since we build against the KDE runtime there).
- Added Overte to the Game category in our desktop file.
- Use a `glad` recipe which doesn't require an internet connection. (Upstream PR: https://github.com/conan-io/conan-center-index/pull/30433 A thumbs up there would be appreciated.)
- Add common Flatpak Builder folders to .gitignore.

Once this has made it into a release, I can give it another try to make it into Flathub.