### PR TITLE
Initial attempt at floating point debugging

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -31,6 +31,7 @@
 #include <plugins/DisplayPlugin.h>
 #include <plugins/CodecPlugin.h>
 #include <shared/GlobalAppProperties.h>
+#include <fenv.h>
 
 #include "AddressManager.h"
 #include "Application.h"
@@ -46,6 +47,16 @@
 #include <Windows.h>
 extern "C" {
     typedef int(__stdcall* CHECKMINSPECPROC)();
+}
+#endif
+
+#ifdef Q_OS_UNIX
+#include <csignal>
+static int fpe_counter = 0;
+static void fpe_handler(int signum) {
+    // This currently exists just to have something to pass to the SIGFPE handler,
+    // and to serve as a point where to put a breakpoint.
+    ++fpe_counter;
 }
 #endif
 
@@ -372,6 +383,11 @@ int main(int argc, const char* argv[]) {
         "Which graphics API to target. Supports gl45, gl41, and gles32. Final API may vary based on system support.",
         "string"
     );
+    QCommandLineOption floatExceptionsOption(
+        "floatExcept",
+        "Trigger an exception for the chosen floating point conditions, comma separated:  divbyzero, inexact, invalid, overflow, underflow, all. This is a debugging option.",
+        "string"
+    );
 
     parser.addOption(urlOption);
     parser.addOption(protocolVersionOption);
@@ -419,6 +435,8 @@ int main(int argc, const char* argv[]) {
     parser.addOption(xrNoHandTrackingOption);
     parser.addOption(xrNoPalmPoseOption);
     parser.addOption(graphicsAPIOption);
+    parser.addOption(floatExceptionsOption);
+
 
     QString applicationPath;
     // A temporary application instance is needed to get the location of the running executable
@@ -585,6 +603,34 @@ int main(int argc, const char* argv[]) {
         return 0;
     }
 
+    if (parser.isSet(floatExceptionsOption)) {
+        QStringList opts = parser.value(floatExceptionsOption).split(",");
+        int flags = 0;
+
+        for (const auto &opt : opts) {
+            if (opt == "divbyzero") {
+                flags |= FE_DIVBYZERO;
+            } else if (opt == "inexact") {
+                flags |= FE_INEXACT;
+            } else if (opt == "invalid") {
+                flags |= FE_INVALID;
+            } else if (opt == "overflow") {
+                flags |= FE_OVERFLOW;
+            } else if (opt == "underflow") {
+                flags |= FE_UNDERFLOW;
+            } else if (opt == "all") {
+                flags = FE_ALL_EXCEPT;
+            } else {
+                qCritical() << "Invalid value for --floatExcept option: " << opt;
+                return 2;
+            }
+        }
+
+        feenableexcept(flags);
+#ifdef Q_OS_UNIX
+        signal(SIGFPE, fpe_handler);
+#endif
+    }
 
     static const QString APPLICATION_CONFIG_FILENAME = "config.json";
     QDir applicationDir(applicationPath);

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -461,14 +461,23 @@ void OffscreenSurface::finishQmlLoad(QQmlComponent* qmlComponent,
 
     // There's a huge amount of divides by zero that happen with floating point exceptions
     // enabled. It makes useful debugging impossible, so we're selectively disabling them
-    // here.
+    // here. Unfortunately fedisableexcept isn't standard and not available on Windows.
+    //
+    // On Windows, this might be unusable. Perhaps some sort of modification to QML
+    // might be possible.
+#ifndef Q_OS_WIN
     fexcept_t fflags;
 
     fegetexceptflag(&fflags, FE_ALL_EXCEPT);
     fedisableexcept(FE_ALL_EXCEPT);
+#endif
+
     qmlComponent->completeCreate();
 
+#ifndef Q_OS_WIN
     fesetexceptflag(&fflags, FE_ALL_EXCEPT);
+#endif
+
     qmlComponent->deleteLater();
 }
 

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -25,6 +25,7 @@
 #include <shared/ReadWriteLockable.h>
 #include <NetworkingConstants.h>
 #include <MetaverseAPI.h>
+#include <fenv.h>
 
 #include "Logging.h"
 #include "impl/SharedObject.h"
@@ -457,7 +458,17 @@ void OffscreenSurface::finishQmlLoad(QQmlComponent* qmlComponent,
         // Call this callback after rootitem is set, otherwise VrMenu wont work
         callback(qmlContext, newItem);
     }
+
+    // There's a huge amount of divides by zero that happen with floating point exceptions
+    // enabled. It makes useful debugging impossible, so we're selectively disabling them
+    // here.
+    fexcept_t fflags;
+
+    fegetexceptflag(&fflags, FE_ALL_EXCEPT);
+    fedisableexcept(FE_ALL_EXCEPT);
     qmlComponent->completeCreate();
+
+    fesetexceptflag(&fflags, FE_ALL_EXCEPT);
     qmlComponent->deleteLater();
 }
 


### PR DESCRIPTION
This is a bit of a hack to try to get to the bottom of all the NaN issues.

It adds a new parameter, which allows to enable floating point exceptions. There's a hack to disable this around QML because when enabled, there's an apparently limitless amount of divides by zero coming from the QML for `AvatarInputsBar.qml` for some reason.

With this patch, and running `interface --floatExcept divbyzero` here's what I get:

```
Thread 81 "Thread (pooled)" hit Breakpoint 5, fpe_handler (signum=8) at /home/vadim/git/overte/overte/interface/src/main.cpp:59
59	   ++fpe_counter;
(gdb) bt
#0  fpe_handler (signum=8) at /home/vadim/git/overte/overte/interface/src/main.cpp:59
#1  0x00007fffcce210b0 in <signal handler called> () at /lib64/libc.so.6
#2  _mm256_div_ps(float __vector(8), float __vector(8)) (__A=..., __B=...) at /usr/lib/gcc/x86_64-redhat-linux/16/include/avxintrin.h:227
#3  packBlendshapeOffsets_AVX2 (unpacked=unpacked@entry=0x7ffe602c9948, packed=packed@entry=0x7ffe60034aa8, size=size@entry=559)
    at /home/vadim/git/overte/overte/libraries/shared/src/avx2/BlendshapePacking_avx2.cpp:65
#4  0x00007ffff5cb9c10 in packBlendshapeOffsets (unpacked=unpacked@entry=0x7ffe602c9948, packed=0x7ffe60034aa8, size=559)
    at /home/vadim/git/overte/overte/libraries/render-utils/src/Model.cpp:1888
#5  0x00007ffff5cbac92 in Blender::run (this=0x31a37c60) at /home/vadim/git/overte/overte/libraries/render-utils/src/Model.cpp:1991
#6  0x00007ffff5e5dccb in QThreadPoolThread::run (this=0x27b594c0) at thread/qthreadpool.cpp:100
#7  0x00007ffff5e5aaaa in operator() (__closure=<optimized out>) at thread/qthread_unix.cpp:350
#8  (anonymous namespace)::terminate_on_exception<QThreadPrivate::start(void*)::<lambda()> > (t=<optimized out>) at thread/qthread_unix.cpp:287
#9  QThreadPrivate::start (arg=0x27b594c0) at thread/qthread_unix.cpp:310
#10 0x00007fffcce79d19 in start_thread (arg=<optimized out>) at pthread_create.c:454
#11 0x00007fffccefd64c in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
(gdb) frame 4
#4  0x00007ffff5cb9c10 in packBlendshapeOffsets (unpacked=unpacked@entry=0x7ffe602c9948, packed=0x7ffe60034aa8, size=559)
    at /home/vadim/git/overte/overte/libraries/render-utils/src/Model.cpp:1888
1888	       packBlendshapeOffsets_AVX2((float(*)[9])unpacked, (uint32_t(*)[4])packed, size);
(gdb) print unpacked
$6 = (BlendshapeOffsetUnpacked *) 0x7ffe602c9948
(gdb) print *unpacked
$7 = {positionOffsetX = 0, positionOffsetY = 0, positionOffsetZ = 0, normalOffsetX = 0, normalOffsetY = 0, normalOffsetZ = 0, tangentOffsetX = 0, tangentOffsetY = 0, 
  tangentOffsetZ = 0}
(gdb) frame 3
#3  packBlendshapeOffsets_AVX2 (unpacked=unpacked@entry=0x7ffe602c9948, packed=packed@entry=0x7ffe60034aa8, size=size@entry=559)
    at /home/vadim/git/overte/overte/libraries/shared/src/avx2/BlendshapePacking_avx2.cpp:65
65	       __m256 rcp = _mm256_div_ps(_mm256_set1_ps(1.0f), len);
(gdb) print len
$8 = {0, 0, 0, 0, 0, 0, 0, 0}
(gdb)  
```

@ada-tv  -- Does this help any?
