### PR TITLE
fix assertion in OtherAvatar.cpp

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1366,11 +1366,12 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
         QWriteLocker writeLock(&_jointDataLock);
         _jointData.resize(numJoints);
 
-        const int COMPRESSED_QUATERNION_SIZE = 6;
-        PACKET_READ_CHECK(JointRotations, numValidJointRotations * COMPRESSED_QUATERNION_SIZE);
         if (_hasNewJointDataVec.size() != static_cast<size_t>(numJoints)) {
             _hasNewJointDataVec.resize(numJoints, false);
         }
+
+        const int COMPRESSED_QUATERNION_SIZE = 6;
+        PACKET_READ_CHECK(JointRotations, numValidJointRotations * COMPRESSED_QUATERNION_SIZE);
         for (int i = 0; i < numJoints; i++) {
             JointData& data = _jointData[i];
             if (validRotations[i]) {
@@ -1488,6 +1489,9 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
         int numJoints = (int)*sourceBuffer++;
 
         _jointData.resize(numJoints);
+        if (_hasNewJointDataVec.size() != static_cast<size_t>(numJoints)) {
+            _hasNewJointDataVec.resize(numJoints, false);
+        }
 
         size_t bitVectorSize = calcBitVectorSize(numJoints);
         PACKET_READ_CHECK(JointDefaultPoseFlagsRotationFlags, bitVectorSize);


### PR DESCRIPTION
I had this assert here:

```
[06/18 21:21:52] [FATAL] [default] ASSERT: "_hasNewJointDataVec.size() == static_cast<size_t>(_jointData.size())" in file /home/vadim/git/overte/overte/interface/src/avatar/OtherAvatar.cpp, line 380
```

I think the problem is because the `PACKET_READ_CHECK` macro is dangerous -- it contains a return if there's not enough data. Therefore code around it has to be placed carefully to avoid things getting out of sync.

