### PR TITLE
Sanitizer fixes

### DIFF
--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -74,7 +74,7 @@ AssignmentClientMonitor::AssignmentClientMonitor(const unsigned int numAssignmen
     auto addressManager = DependencyManager::set<AddressManager>();
     auto nodeList = DependencyManager::set<LimitedNodeList>(listenPort);
 
-    auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();
+    auto& packetReceiver = DependencyManager::get<LimitedNodeList>()->getPacketReceiver();
     packetReceiver.registerListener(PacketType::AssignmentClientStatus,
         PacketReceiver::makeUnsourcedListenerReference<AssignmentClientMonitor>(this, &AssignmentClientMonitor::handleChildStatusPacket));
 
@@ -130,7 +130,7 @@ void AssignmentClientMonitor::childProcessFinished(qint64 pid, quint16 listenPor
 
 void AssignmentClientMonitor::stopChildProcesses() {
     qDebug() << "Stopping child processes";
-    auto nodeList = DependencyManager::get<NodeList>();
+    auto nodeList = DependencyManager::get<LimitedNodeList>();
 
     // ask child processes to terminate
     for (auto& ac : _childProcesses) {
@@ -209,7 +209,7 @@ void AssignmentClientMonitor::spawnChildClient() {
     // tell children which assignment monitor port to use
     // for now they simply talk to us on localhost
     _childArguments.append("--" + ASSIGNMENT_CLIENT_MONITOR_PORT_OPTION);
-    _childArguments.append(QString::number(DependencyManager::get<NodeList>()->getLocalSockAddr().getPort()));
+    _childArguments.append(QString::number(DependencyManager::get<LimitedNodeList>()->getLocalSockAddr().getPort()));
 
     _childArguments.append("--" + PARENT_PID_OPTION);
     _childArguments.append(QString::number(QCoreApplication::applicationPid()));
@@ -294,7 +294,7 @@ void AssignmentClientMonitor::spawnChildClient() {
 }
 
 void AssignmentClientMonitor::checkSpares() {
-    auto nodeList = DependencyManager::get<NodeList>();
+    auto nodeList = DependencyManager::get<LimitedNodeList>();
     QUuid aSpareId = "";
     unsigned int spareCount = 0;
     unsigned int totalCount = 0;
@@ -336,7 +336,7 @@ void AssignmentClientMonitor::handleChildStatusPacket(QSharedPointer<ReceivedMes
     // read out the sender ID
     QUuid senderID = QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID));
 
-    auto nodeList = DependencyManager::get<NodeList>();
+    auto nodeList = DependencyManager::get<LimitedNodeList>();
 
     SharedNodePointer matchingNode = nodeList->nodeWithUUID(senderID);
     const SockAddr& senderSockAddr = message->getSenderSockAddr();

--- a/assignment-client/src/avatars/AvatarMixerWorker.cpp
+++ b/assignment-client/src/avatars/AvatarMixerWorker.cpp
@@ -41,7 +41,7 @@ void AvatarMixerWorker::configure(ConstIter begin, ConstIter end) {
     _end = end;
 }
 
-void AvatarMixerWorker::configureBroadcast(ConstIter begin, ConstIter end, 
+void AvatarMixerWorker::configureBroadcast(ConstIter begin, ConstIter end,
                                 p_high_resolution_clock::time_point lastFrameTimestamp,
                                 float maxKbpsPerNode, float throttlingRatio,
                                 float priorityReservedFraction) {
@@ -185,7 +185,7 @@ qint64 AvatarMixerWorker::addChangedTraitsToBulkPacket(AvatarMixerClientData* li
                 // look for existing acked version for this instance
                 auto ackedInstanceIt = std::find_if(ackIDValuePairs.begin(), ackIDValuePairs.end(),
                                                     [instanceID](auto& ackInstance) { return ackInstance.id == instanceID; });
-                
+
                 // if we have a sent version, then we must have an acked instance of the same trait with the same
                 // version to go on, otherwise we drop the received trait
                 if (sentInstanceIt != sentIDValuePairs.end() &&
@@ -378,7 +378,7 @@ void AvatarMixerWorker::broadcastAvatarDataToAgent(const SharedNodePointer& node
     enum PriorityVariants { kHero, kNonhero };
     AvatarPriorityQueue avatarPriorityQueues[2] =
     {
-        {cameraViews, AvatarData::_avatarSortCoefficientSize, 
+        {cameraViews, AvatarData::_avatarSortCoefficientSize,
             AvatarData::_avatarSortCoefficientCenter, AvatarData::_avatarSortCoefficientAge},
         {cameraViews, AvatarData::_avatarSortCoefficientSize,
             AvatarData::_avatarSortCoefficientCenter, AvatarData::_avatarSortCoefficientAge}
@@ -482,7 +482,7 @@ void AvatarMixerWorker::broadcastAvatarDataToAgent(const SharedNodePointer& node
             avatarPriorityQueues[avatarNodeData->getHasPriority() ? kHero : kNonhero].push(
                 SortableAvatar(avatarNodeData, sourceAvatarNode, lastEncodeTime));
         }
-        
+
         // If Node A's PAL WAS open but is no longer open, AND
         // Node A is ignoring Avatar B OR Node B is ignoring Avatar A...
         //
@@ -517,7 +517,8 @@ void AvatarMixerWorker::broadcastAvatarDataToAgent(const SharedNodePointer& node
     auto identityPacketList = NLPacketList::create(PacketType::AvatarIdentity, QByteArray(), true, true);
 
     // Loop over two priorities - hero avatars then everyone else:
-    for (PriorityVariants currentVariant = kHero; currentVariant <= kNonhero; ++((int&)currentVariant)) {
+    std::array<PriorityVariants, 2> priority_order = { PriorityVariants::kHero, PriorityVariants::kNonhero };
+    for (PriorityVariants currentVariant : priority_order) {
         const auto& sortedAvatarVector = avatarPriorityQueues[currentVariant].getSortedVector(numToSendEst);
         for (const auto& sortedAvatar : sortedAvatarVector) {
             const Node* sourceNode = sortedAvatar.getNode();
@@ -700,7 +701,7 @@ void AvatarMixerWorker::broadcastAvatarDataToDownstreamMixer(const SharedNodePoi
         if (!AvatarMixer::shouldReplicateTo(*agentNode, *node)) {
             return;
         }
-        
+
         // collect agents that we have avatar data for that we are supposed to replicate
         if (agentNode->getType() == NodeType::Agent && agentNode->getLinkedData() && agentNode->isReplicated()) {
             const AvatarMixerClientData* agentNodeData = reinterpret_cast<const AvatarMixerClientData*>(agentNode->getLinkedData());
@@ -713,7 +714,7 @@ void AvatarMixerWorker::broadcastAvatarDataToDownstreamMixer(const SharedNodePoi
             // since we have no idea if they're online and receiving our packets
 
             // so we always send a full update for this avatar
-            
+
             quint64 start = usecTimestampNow();
             AvatarDataPacket::SendStatus sendStatus;
 

--- a/libraries/networking/src/SocketType.h
+++ b/libraries/networking/src/SocketType.h
@@ -31,8 +31,16 @@ public:
     /// @param socketType The SocketType value.
     /// @return The name of the SocketType value.
     static QString socketTypeToString (SocketType socketType) {
-        static QStringList SOCKET_TYPE_STRINGS { "Unknown", "UDP", "WebRTC" };
-        return SOCKET_TYPE_STRINGS[(int)socketType];
+        switch (socketType) {
+            case SocketType::Unknown:
+                return QStringLiteral("Unknown");
+            case SocketType::UDP:
+                return QStringLiteral("UDP");
+            case SocketType::WebRTC:
+                return QStringLiteral("WebRTC");
+            default:
+                return QStringLiteral("Unknown value in enum! BUG!");
+        }
     }
 };
 


### PR DESCRIPTION
This fixes 3 issues detected with the sanitizer on the domain server.

* PriorityVariants -- the code during the loop creates an invalid enum value. Probably harmless, but fixes a sanitizer warning.
* LimitedNodeList -- In the monitor code there are places where a LimitedNodeList (base class) can be incorrectly cast to NodeList (derived). The code's just fine with the LimitedNodeList API.
* PriorityVariants -- during shutdown, the QStringList gets freed early and then still used by the code. Probably not a big deal, but it does cause sanitizer warnings.

This probably doesn't result in any noticeable changes, but so far for me fixes everything that pops up in the domain server other than for V8 (which may be spurious)