### PR TITLE
Fix Nightly CodeChecker uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           echo "OVERTE_RELEASE_TYPE=PR" >> $GITHUB_ENV
           echo "OVERTE_RELEASE_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
           echo "GIT_COMMIT_SHORT=${PULL_REQUEST_SHA::7}" >> $GITHUB_ENV
-        elif [ "${{github.event_name}}" = "push" && github.event.action == 'tag' ]; then
+        elif [ "${{github.event_name}}" = "push" ] && [ "${{github.event.action}}" == "tag" ]; then
           echo "OVERTE_RELEASE_TYPE=RELEASE" >> $GITHUB_ENV
           echo "OVERTE_RELEASE_NUMBER=" >> $GITHUB_ENV
           echo "GIT_COMMIT_SHORT=${GITHUB_SHA::7}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,10 @@ jobs:
       shell: bash
       id: buildenv1
       run: |
+        # Use our United States cache instead of our origin to avoid extremely low download speeds on Depot runners.
+        conan remote update overte --url https://us-east-artifactory.overte.org/artifactory/api/conan/overte
+        conan remote update conancenter --url https://us-east-artifactory.overte.org/artifactory/api/conan/conan-center
+
         # Work around https://github.com/actions/runner/issues/2058
         echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" >> $GITHUB_ENV
         # Create envionment variable for later Bash Parameter Expansion

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
         ctu: true
 
         # Update CodeChecker master branch results.
-        store: ${{ github.event_name == 'push' }} && ${{ github.ref_name == 'master' }}
+        store: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
         store-url: "https://codechecker.overte.org/overte"
         store-username: ${{ secrets.CODECHECKER_STORE_USER }}
         store-password: ${{ secrets.CODECHECKER_STORE_PASSWORD }}


### PR DESCRIPTION
Fixes: https://github.com/overte-org/overte/issues/2348
The syntax was successfully tested here: https://github.com/overte-org/overte/actions/runs/28204799425/workflow#L238

This PR also fixes a bash syntax error specific to release builds.
While trying to work on this, I ran into issues with our Runners getting <10mbit/s speeds and dropping connection before they could download binary artifacts from our Artifactory; Because of this I set up https://us-east-artifactory.overte.org as a caching reverse proxy. Even without a cache hit, it fixes the bandwidth/connectivity issues. Both Depot and GitHub host their Runners in the United States.