### PR TITLE
Fix NaNs in flow and IK solvers

### DIFF
--- a/libraries/animation/src/AnimTwoBoneIK.cpp
+++ b/libraries/animation/src/AnimTwoBoneIK.cpp
@@ -148,7 +148,7 @@ const AnimPoseVec& AnimTwoBoneIK::evaluate(const AnimVariantMap& animVars, const
     // http://mathworld.wolfram.com/Circle-CircleIntersection.html
     float midAngle = 0.0f;
     if ((d < r0 + r1) && (d > 0.0f) && (r0 > 0.0f) && (r1 > 0.0f)) {
-        float y = sqrtf((-d + r1 - r0) * (-d - r1 + r0) * (-d + r1 + r0) * (d + r1 + r0)) / (2.0f * d);
+        float y = sqrtf(fabsf((-d + r1 - r0) * (-d - r1 + r0) * (-d + r1 + r0) * (d + r1 + r0))) / (2.0f * d);
         float yR0Quotient = glm::clamp(y / r0, -1.0f, 1.0f);
         float yR1Quotient = glm::clamp(y / r1, -1.0f, 1.0f);
         midAngle = PI - (acosf(yR0Quotient) + acosf(yR1Quotient));

--- a/libraries/animation/src/Flow.cpp
+++ b/libraries/animation/src/Flow.cpp
@@ -222,11 +222,24 @@ void FlowNode::update(float deltaTime, const glm::vec3& accelerationOffset) {
         glm::vec3 deltaAcceleration = _acceleration * accelerationFactor;
         // Calculate new position        
         _currentPosition = _currentPosition + (_currentVelocity * _settings._damping) + deltaAcceleration;
+
+        // This only seems to happen on a single timestep - usually after teleporting,
+        // where the velocity blows up since it's taken from a position delta.
+        // Clearing the bad current state lets the solver continue working with a finite delta.
+        if (
+            !std::isfinite(_currentPosition.x) ||
+            !std::isfinite(_currentPosition.y) ||
+            !std::isfinite(_currentPosition.z)
+        ) {
+            _acceleration = {};
+            _currentVelocity = {};
+            _currentPosition = _initialPosition;
+        }
     } else {
         _acceleration = glm::vec3(0.0f);
         _currentVelocity = glm::vec3(0.0f);
     }
-};
+}
 
 
 void FlowNode::solve(const glm::vec3& constrainPoint, float maxDistance, const FlowCollisionResult& collision) {


### PR DESCRIPTION
The flow NaNs happened because the solver takes position deltas as velocity, and if the position delta is too high then the velocity blows up to infinity.

The fix is just to reset the flow state back to its rest position if a node gets an infinite position.

This can be tested by running these in the JS console:
```js
MyAvatar.position = [3e30, 0, 0]
```
```js
MyAvatar.position = [0, 0, 0]
```

---

The IK NaNs happened because the leg/arm solver were able to pass a negative number to `sqrtf`.

The fix is to instead pass an absolute value to `sqrtf`.

This can be tested by crouching in VR or by using my body poser app from the More list. This seems kinda hard to reproduce on a lot of avatars though. Some avatars will never NaN, and it's very easy to trigger on my synth avatars.

---

### Master
[animator-nans-master.webm](https://github.com/user-attachments/assets/d345d21c-7418-48d6-a0e5-458ec381a661)

### This PR
[animator-nans-fix.webm](https://github.com/user-attachments/assets/a9d38024-826e-49d9-9db8-bb30ea30278a)

(the bump where the legs go from straightening back to bending is the area that would have previously been negative)

Closes #2334
Closes #2218