### PR TITLE
Nightly nightly builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches:
-      - master
     tags:
       # Release tags. E.g. 2024.06.1
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       - "[0-9][0-9][0-9][0-9].[0-9][0-9].**"
+  schedule:  # Only applies to the default branch.
+    # Nightly builds.
+    # Run every day at 07:33 UTC, which is night in US east, where most of the CI Runners are located.
+    - cron: "33 7 * * *"
 
 env:
   # Many environment variables are already set in our Docker images or in other Actions.
@@ -31,7 +33,32 @@ env:
   PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
 
 jobs:
+  check_if_new_nightly_commit:
+    runs-on: ubuntu-latest
+    name: Check if there is a new commit
+    outputs:
+      skip_nightly_build: ${{ steps.check_latest_commit.outputs.skip_nightly_build }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check if the latest commit was created less than a day ago.
+        id: check_latest_commit
+        run: |
+          if git rev-list --after="24 hours 5 minutes" ${{ github.sha }} | grep -q "${{ github.sha }}"; then
+            echo "Our latest commit is less than a day old. Continuing…"
+            echo "skip_nightly_build=False" >> $GITHUB_OUTPUT
+          elif [ "${{github.event_name}}" = "schedule" ]; then
+            echo "Our latest commit is older than a day. Skipping Nightly build…"
+            echo "skip_nightly_build=True" >> $GITHUB_OUTPUT
+          else
+            echo "Not a scheduled Nightly build. Continuing…"
+            echo "skip_nightly_build=False" >> $GITHUB_OUTPUT
+          fi
+
   build:
+    # Skip Nightly build if there is no new commit.
+    needs: check_if_new_nightly_commit
+    if: ${{ needs.check_if_new_nightly_commit.outputs.skip_nightly_build != 'True' }}
+
     name: "${{matrix.job_name_prefix}}${{matrix.os}}, ${{matrix.rendering_backend}}, ${{matrix.arch}}, ${{matrix.cmake_build_type}}"
     strategy:
       matrix:


### PR DESCRIPTION
This PR changes our Nightly builds to actually run nightly instead of on every new commit on master.
This has a couple of upsides:
- We waste less resources on creating builds nobody is going to use when merging multiple PRs in one day.
- The cooling for the servers is probably more efficient at night (since it is colder at night).
- It is more feasible to always run the latest Nightly. Users and scripts can simply check for a new build every morning.

This change would have saved us around 30720 Runner minutes (after multipliers) over the last 30 days. That is equivalent to 122,88€ if those Runners weren't sponsored or free. Granted, the last 30 days were quite busy.

I tested the changes locally using `act`.