### PR TITLE
Troubleshoot CodeChecker diffs being too large

### DIFF
--- a/.github/actions/debug-info/action.yml
+++ b/.github/actions/debug-info/action.yml
@@ -15,3 +15,8 @@ runs:
       working-directory: build
       run: cat ./_CPack_Packages/win64/NSIS/NSISOutput.log || echo "No NSIS log found. Continuing…"
 
+    - name: Output CodeChecker JSON compilation database
+      if: matrix.id == 'codechecker'
+      shell: bash
+      continue-on-error: true
+      run: cat ${{ env.GITHUB_WORKSPACE }}/codechecker_codechecker_compilation_database.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,7 +248,7 @@ jobs:
       if: matrix.id == 'codechecker' && github.event.action != 'tag'
       id: codechecker
       with:
-        build-command: cmake --build --preset conan-debug --target codegen
+        build-command: cmake --build --preset conan-debug
         skipfile: ${{ env.GITHUB_WORKSPACE }}/.github/codechecker/skipfile.txt
         # Allow static analyzers to analyze across files instead of one file at a time.
         ctu: true


### PR DESCRIPTION
As far as I can tell, the huge differences in Nightly and Pull Requests when it comes to warnings is that Nightly is just not checking some components; at least `assignment-client/*` and interface's `Keyboard.cpp` were not checked in the latest Nightly run.
I don't know why the `codegen` target would have such a discrepancy between Nightly and Pull Requests, but as far as I can tell, the `codegen` target misses a whole bunch of stuff even on Pull Request builds. So rather than using the `codegen` target, I switched CodeChecker to use the default `all` target instead. The `codegen` target doesn't work as it should on our codebase anyway, so I wouldn't be surprised if the static analyzers shouldn't have been able to work with it at all in the first place.