### PR TITLE
Fix `error: 'operator[]' is a private member of 'QMultiMap<QString, QVariant>'` error spam

### DIFF
--- a/libraries/task/src/task/Config.h
+++ b/libraries/task/src/task/Config.h
@@ -70,7 +70,7 @@ public:
         if (_presets.contains(preset)) {
             // Always start back at default to remain deterministic
             QVariantMap config = _default;
-            QVariantMap presetConfig = _presets[preset].toMap();
+            QVariantMap presetConfig = _presets.value(preset).toMap();
             for (auto it = presetConfig.cbegin(); it != presetConfig.cend(); it++) {
                 config.insert(it.key(), it.value());
             }


### PR DESCRIPTION
Fix `libraries/task/src/task/Config.h:73:48: error: 'operator[]' is a private member of 'QMultiMap<QString, QVariant>'` error spam.

This PR fixes one error that clang-tidy and clang-static-analyzer keep throwing for when running through CodeChecker. This single line change lowered the number of log messages during the CodeChecker run by almost 200000.

The change is cherry-picked out of the Qt6 branch: https://github.com/overte-org/overte/pull/1848/changes#diff-ebae517f462c16b046e1c1de4b5f909ad238f12b28e9b889d35ea6ebb3c01f81
While I don't really understand it, it was written by 7 (who presumably had more understanding of what they were doing), the compiler doesn't complain, it runs, and to really use all tools I have available, I also had CLion's LLM thingee check it.

I am hoping that @ada-tv or @daleglass have more understanding of that is happening here. My understanding is that this switches from using a private method in Qt to using something public, but that is mostly just repeating what Clang has been telling me.

Example Clang output:
```
 [ERROR 2026-07-02 10:30:11] - Error generating function map.
 
 command:
 
 /usr/lib/llvm-22/bin/clang-extdef-mapping /__w/overte/overte/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp -- --target=x86_64-linux-gnu -c -x c++ -DGLM_ENABLE_EXPERIMENTAL -DGLM_FORCE_CTOR_INIT -DGLM_FORCE_RADIANS -DGPU_POINTER_STORAGE_RAW -DHAS_JOURNALD -DHAVE_EXT_clip_cull_distance -DOVERTE_WARNINGS_ALLOWLIST_GCC -DPR_BUILD -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_WEBSOCKETS_LIB -DQT_WIDGETS_LIB -DUSE_GL -Dmodel_baker_EXPORTS -I/__w/overte/overte/build/libraries/model-baker -I/__w/overte/overte/libraries/model-baker -I/__w/overte/overte/build/includes -I/__w/overte/overte/libraries/shared/src -I/__w/overte/overte/build/libraries/shared -I/__w/overte/overte/libraries/shaders/src -I/__w/overte/overte/build/libraries/shaders -I/__w/overte/overte/libraries/task/src -I/__w/overte/overte/build/libraries/task -I/__w/overte/overte/libraries/gpu/src -I/__w/overte/overte/build/libraries/gpu -I/__w/overte/overte/libraries/graphics/src -I/__w/overte/overte/build/libraries/graphics -I/__w/overte/overte/libraries/hfm/src -I/__w/overte/overte/build/libraries/hfm -I/__w/overte/overte/libraries/procedural/src -I/__w/overte/overte/build/libraries/procedural -I/__w/overte/overte/libraries/material-networking/src -I/__w/overte/overte/libraries/networking/src -I/__w/overte/overte/libraries/image/src -I/__w/overte/overte/libraries/ktx/src -isystem /__w/overte/overte/build/libraries/model-baker/model-baker_autogen/include -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -isystem /usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++ -isystem /zgofepbi/.conan2/p/glmea591a8356612/p/include -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -isystem /usr/include/x86_64-linux-gnu/qt5/QtNetwork -isystem /zgofepbi/.conan2/p/zlibee5ac5445c492/p/include -isystem /zgofepbi/.conan2/p/nlohm1bed1ddc0a2fa/p/include -isystem /usr/include/x86_64-linux-gnu/qt5/QtWidgets -isystem /zgofepbi/.conan2/p/b/glad270cf54fda8f2/p/include -isystem /zgofepbi/.conan2/p/nvidi4f1566b725025/p/include -isystem /zgofepbi/.conan2/p/onetb33173cd640051/p/include -isystem /zgofepbi/.conan2/p/etc2c67e3d4bc13a24/p/include -isystem /zgofepbi/.conan2/p/opene7e2e3fc2eb438/p/include -isystem /zgofepbi/.conan2/p/opene7e2e3fc2eb438/p/include/OpenEXR -isystem /zgofepbi/.conan2/p/imathe974bb77e7f1c/p/include -isystem /zgofepbi/.conan2/p/imathe974bb77e7f1c/p/include/Imath -isystem /usr/include/x86_64-linux-gnu/qt5/QtWebSockets -isystem /zgofepbi/.conan2/p/webrt8354c1cdc6f69/p/include/webrtc-audio-processing-2 -isystem /zgofepbi/.conan2/p/absei1dbabb32accc4/p/include -isystem /zgofepbi/.conan2/p/dracof3035c8359285/p/include -falign-functions=32 -fPIC -m64 -msse3 -m64 -include cstdint -fno-strict-aliasing -Wno-unused-parameter -falign-functions -DDEBUG -std=gnu++20 -fPIC -fPIC -fopenmp -idirafter /usr/include/c++/11 -idirafter /usr/include/x86_64-linux-gnu/c++/11 -idirafter /usr/include/c++/11/backward -idirafter /usr/local/include -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include
 
 stderr:
 
 In file included from /__w/overte/overte/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp:12:
 In file included from /__w/overte/overte/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.h:18:
 In file included from /__w/overte/overte/libraries/model-baker/src/model-baker/Engine.h:15:
 In file included from /__w/overte/overte/libraries/task/src/task/Task.h:17:
 /__w/overte/overte/libraries/task/src/task/Config.h:73:48: error: 'operator[]' is a private member of 'QMultiMap<QString, QVariant>'
    73 |             QVariantMap presetConfig = _presets[preset].toMap();
       |                                        ~~~~~~~~^~~~~~~
 /usr/include/x86_64-linux-gnu/qt5/QtCore/qmap.h:1191:8: note: declared private here
  1191 |     T &operator[](const Key &key);
       |        ^
 1 error generated.
 Error while processing /__w/overte/overte/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp.
```