### PR TITLE
Revert improved culling frustum in OpenVR.

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -362,67 +362,17 @@ glm::mat4 OpenVrDisplayPlugin::getEyeProjection(Eye eye, const glm::mat4& basePr
     }
 }
 
-inline static glm::mat4 fovToCullingProjection(const std::array<float, 4> fov, const float _near, const float _far) {
-    const float left = fov[0];
-    const float right = fov[1];
-    const float down = fov[2];
-    const float up = fov[3];
-
-    const float width = right - left;
-    const float height = up - down;
-
-    const float m11 = 2 / width;
-    const float m22 = 2 / height;
-    const float m33 = -(_far + _near) / (_far - _near);
-
-    const float m31 = (right + left) / width;
-    const float m32 = (up + down) / height;
-    const float m43 = -(_far * (_near + _near)) / (_far - _near);
-
-    // clang-format off
-    const float mat[16] = {
-        m11, 0  , 0  ,  0,
-        0  , m22, 0  ,  0,
-        m31, m32, m33, -1,
-        0  , 0  , m43,  0,
-    };
-    // clang-format on
-
-    return glm::make_mat4(mat);
-}
-
 glm::mat4 OpenVrDisplayPlugin::getCullingProjection(const glm::mat4& baseProjection) const {
-    if (!_system) {
+    if (_system) {
+        ViewFrustum baseFrustum;
+        baseFrustum.setProjection(baseProjection);
+        float baseNearClip = baseFrustum.getNearClip();
+        float baseFarClip = baseFrustum.getFarClip();
+        // FIXME Calculate the proper combined projection by using GetProjectionRaw values from both eyes
+        return toGlm(_system->GetProjectionMatrix((vr::EVREye)0, baseNearClip, baseFarClip));
+    } else {
         return baseProjection;
     }
-
-    std::array<std::array<float, 4>, 2> fovs;
-
-    for (auto i = 0; i < 2; i++) {
-        _system->GetProjectionRaw(
-            (vr::EVREye)i,
-            &fovs[i][0],
-            &fovs[i][1],
-            &fovs[i][2],
-            &fovs[i][3]
-        );
-    }
-
-    // FIXME: OpenVR gives us tan(angle), how can we clamp
-    // this to within ~170° when multiplied by margin?
-    // const float maxAngle = 0.9f * PI;
-    const float margin = 1.0f;
-
-    std::array<float, 4> fovMax = {
-        std::min(fovs[0][0], fovs[1][0]) * margin, // left
-        std::max(fovs[0][1], fovs[1][1]) * margin, // right
-        std::min(fovs[0][2], fovs[1][2]) * margin, // bottom (flipped)
-        std::max(fovs[0][3], fovs[1][3]) * margin, // top (flipped)
-    };
-
-    ViewFrustum frustum;
-    frustum.setProjection(baseProjection);
-    return fovToCullingProjection(fovMax, frustum.getNearClip(), frustum.getFarClip());
 }
 
 float OpenVrDisplayPlugin::getTargetFrameRate() const {
@@ -510,7 +460,8 @@ bool OpenVrDisplayPlugin::internalActivate() {
             _eyeOffsets[eye] = toGlm(_system->GetEyeToHeadTransform(eye));
             _eyeProjections[eye] = toGlm(_system->GetProjectionMatrix(eye, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP));
         });
-        _cullingProjection = getCullingProjection(_eyeProjections[0]);
+        // FIXME Calculate the proper combined projection by using GetProjectionRaw values from both eyes
+        _cullingProjection = _eyeProjections[0];
     });
 
     // enable async time warp


### PR DESCRIPTION
Fixes https://github.com/overte-org/overte/issues/2242
Reverts the OpenVR part of fcf5981e98a234fb1104f3053dda0fac30d059e9

I probably spent 40 hours on https://github.com/overte-org/overte/issues/2242 already, and I don't feel like I am any closer to the issue than before. I get the impression that it is a bug in our renderer which happens only on OpenVR's reprojection Matrix. If I set OpenXR to exactly the same culling projection, the picture is all warped, but the issue doesn't appear. So, as far as I can tell, the culling projection doesn't actually have anything to do with the issue? Not being able to reproduce the issue on OpenXR, even with hard-coding a known-broken culling projection, seems very fishy to me.

Whatever the case, it seems preferable to have the culling projection wrong for the right eye, rather than having flashing black squares and upside down haze on most configurations.
Some culling projection values do work, so we could theoretically hard-code some known-working values and map whatever OpenVR outputs to the nearest known-good value, but that would be incredibly hacky.

(I tested this PR locally, and it does what I expect.)