### PR TITLE
Fix mirrors in VR

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
@@ -1021,7 +1021,7 @@ void GLBackend::updatePresentFrame(const Mat4& correction, bool primary) {
         flippedRotation.z *= -1.0f;
         vec3 flippedTranslation = _transform._presentFrame.unflippedCorrection[3];
         flippedTranslation.x *= -1.0f;
-        _transform._presentFrame.flippedCorrection = glm::translate(glm::mat4_cast(flippedRotation), flippedTranslation);
+        _transform._presentFrame.flippedCorrection = glm::translate(glm::mat4(), flippedTranslation) * glm::mat4_cast(flippedRotation);
         _transform._presentFrame.mirrorViewCorrection = false;
     }
 }

--- a/libraries/render-utils/src/RenderCommonTask.cpp
+++ b/libraries/render-utils/src/RenderCommonTask.cpp
@@ -296,9 +296,13 @@ public:
             return;
         }
 
+        // TODO: Half and quarter sized mirror framebuffers?
+        // Naively reducing the texture resolution doesn't work,
+        // maybe there's a differently sized depth buffer or an
+        // MSAA resolve buffer
         auto inputFramebuffer = inputs.get1();
         if (!_mirrorFramebuffer || _mirrorFramebuffer->getWidth() != inputFramebuffer->getWidth() || _mirrorFramebuffer->getHeight() != inputFramebuffer->getHeight()) {
-            _mirrorFramebuffer.reset(gpu::Framebuffer::create("mirror" + _mirrorIndex, gpu::Element::COLOR_SRGBA_32, inputFramebuffer->getWidth(), inputFramebuffer->getHeight()));
+            _mirrorFramebuffer.reset(gpu::Framebuffer::create("mirror" + std::to_string(_mirrorIndex), gpu::Element::COLOR_SRGBA_32, inputFramebuffer->getWidth(), inputFramebuffer->getHeight()));
         }
 
         render::ItemBound mirror = items[_mirrorIndex];
@@ -309,6 +313,10 @@ public:
         _cachedArgsPointer->_mirrorDepth = args->_mirrorDepth;
         _cachedArgsPointer->_numMirrorFlips = args->_numMirrorFlips;
 
+        // FIXME: This is only modifying the "main" frustum, which is the real
+        // view frustum on desktop, but only the *culling* frustum in VR, which
+        // is why the mirror's near clipping plane doesn't work in VR. This will
+        // need to be refactored to also modify the stereo eye frustums.
         ViewFrustum srcViewFrustum = args->getViewFrustum();
         ItemID portalExitID = args->_scene->getItem(mirror.id).computeMirrorView(srcViewFrustum);
 

--- a/libraries/render-utils/src/RenderCommonTask.cpp
+++ b/libraries/render-utils/src/RenderCommonTask.cpp
@@ -282,7 +282,7 @@ void ResolveFramebuffer::run(const render::RenderContextPointer& renderContext, 
 class SetupMirrorTask {
 public:
     using Input = RenderMirrorTask::Inputs;
-    using Outputs = render::VaryingSet3<render::ItemBound, gpu::FramebufferPointer, RenderArgsPointer>;
+    using Outputs = render::VaryingSet4<render::ItemBound, gpu::FramebufferPointer, RenderArgsPointer, std::array<ViewFrustum, 2>>;
     using JobModel = render::Job::ModelIO<SetupMirrorTask, Input, Outputs>;
 
     SetupMirrorTask(size_t mirrorIndex, size_t depth) : _mirrorIndex(mirrorIndex), _depth(depth) {}
@@ -320,6 +320,41 @@ public:
         ViewFrustum srcViewFrustum = args->getViewFrustum();
         ItemID portalExitID = args->_scene->getItem(mirror.id).computeMirrorView(srcViewFrustum);
 
+        std::array<ViewFrustum, 2> cachedEyes {};
+
+        // FIXME: Why isn't this being applied to the RenderViewTask that happens after this?
+        if (args->isStereo()) {
+            std::array<glm::mat4, 2> views {};
+            std::array<glm::mat4, 2> projections {};
+
+            args->_context->getStereoViews(views.data());
+            args->_context->getStereoProjections(projections.data());
+
+            glm::mat4 cameraView = args->getViewFrustum().getView();
+            glm::mat4 cameraViewInv = glm::inverse(cameraView);
+
+            for (int i = 0; i < 2; i++) {
+                ViewFrustum eye {};
+                eye.setView(views[i]);
+                eye.setProjection(projections[i]);
+
+                cachedEyes[i] = eye;
+
+                // The stereo views are IPD offsets, so we need to factor in
+                // the base camera's view for computing the mirror views
+                eye.setView(cameraView * views[i]);
+                eye.calculate();
+
+                args->_scene->getItem(mirror.id).computeMirrorView(eye);
+
+                views[i] = cameraViewInv * eye.getView();
+                projections[i] = eye.getProjection();
+            }
+
+            args->_context->setStereoViews(views.data());
+            args->_context->setStereoProjections(projections.data());
+        }
+
         args->_blitFramebuffer = _mirrorFramebuffer;
         args->_ignoreItem = portalExitID != Item::INVALID_ITEM_ID ? portalExitID : mirror.id;
         args->_mirrorDepth = _depth;
@@ -338,6 +373,7 @@ public:
         outputs.edit0() = mirror;
         outputs.edit1() = inputFramebuffer;
         outputs.edit2() = _cachedArgsPointer;
+        outputs.edit3() = cachedEyes;
     }
 
 protected:
@@ -371,6 +407,7 @@ public:
         auto mirror = inputs.get0();
         auto framebuffer = inputs.get1();
         auto cachedArgs = inputs.get2();
+        auto cachedEyes = inputs.get3();
 
         if (cachedArgs) {
             args->_renderMode = cachedArgs->_renderMode;
@@ -404,6 +441,19 @@ public:
             args->_ignoreItem = cachedArgs->_ignoreItem;
             args->_mirrorDepth = cachedArgs->_mirrorDepth;
             args->_numMirrorFlips = cachedArgs->_numMirrorFlips;
+
+            if (args->isStereo()) {
+                std::array<glm::mat4, 2> views {};
+                std::array<glm::mat4, 2> projections {};
+
+                for (int i = 0; i < 2; i++) {
+                    views[i] = cachedEyes[i].getView();
+                    projections[i] = cachedEyes[i].getProjection();
+                }
+
+                args->_context->setStereoViews(views.data());
+                args->_context->setStereoProjections(projections.data());
+            }
         }
     }
 

--- a/libraries/shared/src/ViewFrustum.cpp
+++ b/libraries/shared/src/ViewFrustum.cpp
@@ -41,6 +41,15 @@ void ViewFrustum::setPosition(const glm::vec3& position) {
     _view = glm::translate(mat4(), _position) * glm::mat4_cast(_orientation);
 }
 
+void ViewFrustum::setView(const glm::mat4& view) {
+    _view = view;
+    _orientation = glm::quat_cast(_view);
+    _position = glm::vec3(_view[3]);
+    _right = glm::vec3(_orientation * glm::vec4(IDENTITY_RIGHT, 0.0f));
+    _up = glm::vec3(_orientation * glm::vec4(IDENTITY_UP,    0.0f));
+    _direction = glm::vec3(_orientation * glm::vec4(IDENTITY_FORWARD, 0.0f));
+}
+
 // Order cooresponds to the order defined in the BoxVertex enum.
 static const glm::vec4 NDC_VALUES[NUM_FRUSTUM_CORNERS] = {
     glm::vec4(-1.0f, -1.0f, -1.0f, 1.0f),

--- a/libraries/shared/src/ViewFrustum.h
+++ b/libraries/shared/src/ViewFrustum.h
@@ -38,6 +38,7 @@ public:
     // setters for camera attributes
     void setPosition(const glm::vec3& position);
     void setOrientation(const glm::quat& orientation);
+    void setView(const glm::mat4& view);
 
     // getters for camera attributes
     const glm::vec3& getPosition() const { return _position; }


### PR DESCRIPTION
- [x] Fix incorrectly transformed view correction in mirrors<p>Can be tested with the "deadlock interface" option in the dev settings, which will stop the game thread from updating the camera position and the view correction will kick in</p>
- [x] Figure out why the clipping planes don't work
- [ ] Fix the clipping planes
- [ ] Fix the weird eye offsets<p>I have a feeling this is related to the clipping planes thing, it's likely that the main camera view is being transformed by the mirror but the eye IPD offsets and projection matrices *aren't*, which would explain why mirrors look more broken in certain orientations than others and why mirrors use the raw eye near plane rather than the transformed one</p>

@HifiExperiments: Maybe you'd have some advice on how I could hook up the stereo eyes to be transformed?