### PR TITLE
Qt6: Work around GLM type names in V8 method proxy instead of changing header decls

### DIFF
--- a/assignment-client/src/octree/OctreeHeadlessViewer.h
+++ b/assignment-client/src/octree/OctreeHeadlessViewer.h
@@ -50,7 +50,7 @@ public slots:
      * @function EntityViewer.setOrientation
      * @param {Quat} orientation - The orientation of the view frustum.
      */
-    void setOrientation(const glm::qua<float,glm::packed_highp>& orientation) { _hasViewFrustum = true; _viewFrustum.setOrientation(orientation); }
+    void setOrientation(const glm::quat& orientation) { _hasViewFrustum = true; _viewFrustum.setOrientation(orientation); }
 
     /*@jsdoc
      * Sets the radius of the center "keyhole" in the view frustum.
@@ -106,7 +106,7 @@ public slots:
      * @function EntityViewer.getOrientation
      * @returns {Quat} The orientation of the view frustum.
      */
-    const glm::qua<float,glm::packed_highp>& getOrientation() const { return _viewFrustum.getOrientation(); }
+    const glm::quat& getOrientation() const { return _viewFrustum.getOrientation(); }
 
 
     // getters for LOD and PPS

--- a/assignment-client/src/octree/OctreeHeadlessViewer.h
+++ b/assignment-client/src/octree/OctreeHeadlessViewer.h
@@ -43,7 +43,7 @@ public slots:
      * @function EntityViewer.setPosition
      * @param {Vec3} position - The position of the view frustum.
      */
-    void setPosition(const glm::vec<3,float,glm::packed_highp>& position) { _hasViewFrustum = true; _viewFrustum.setPosition(position); }
+    void setPosition(const glm::vec3& position) { _hasViewFrustum = true; _viewFrustum.setPosition(position); }
 
     /*@jsdoc
      * Sets the orientation of the view frustum.
@@ -99,7 +99,7 @@ public slots:
      * @function EntityViewer.getPosition
      * @returns {Vec3} The position of the view frustum.
      */
-    const glm::vec<3,float,glm::packed_highp>& getPosition() const { return _viewFrustum.getPosition(); }
+    const glm::vec3& getPosition() const { return _viewFrustum.getPosition(); }
 
     /*@jsdoc
      * Gets the orientation of the view frustum.

--- a/interface/src/SecondaryCamera.h
+++ b/interface/src/SecondaryCamera.h
@@ -22,7 +22,7 @@ class SecondaryCameraJobConfig : public render::Task::Config { // Exposes second
     Q_PROPERTY(QUuid attachedEntityId MEMBER attachedEntityId NOTIFY dirty)  // entity whose properties define camera position and orientation
     Q_PROPERTY(QUuid portalEntranceEntityId MEMBER portalEntranceEntityId NOTIFY dirty)  // entity whose properties define a portal's entrance position and orientation
     Q_PROPERTY(glm::vec3 position READ getPosition WRITE setPosition)  // of viewpoint to render from
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> orientation READ getOrientation WRITE setOrientation)  // of viewpoint to render from
+    Q_PROPERTY(glm::quat orientation READ getOrientation WRITE setOrientation)  // of viewpoint to render from
     Q_PROPERTY(float vFoV MEMBER vFoV NOTIFY dirty)  // Secondary camera's vertical field of view. In degrees.
     Q_PROPERTY(float nearClipPlaneDistance MEMBER nearClipPlaneDistance NOTIFY dirty)  // Secondary camera's near clip plane distance. In meters.
     Q_PROPERTY(float farClipPlaneDistance MEMBER farClipPlaneDistance NOTIFY dirty)  // Secondary camera's far clip plane distance. In meters.
@@ -32,7 +32,7 @@ public:
     QUuid attachedEntityId;
     QUuid portalEntranceEntityId;
     glm::vec3 position;
-    glm::qua<float,glm::packed_highp> orientation;
+    glm::quat orientation;
     float vFoV { DEFAULT_FIELD_OF_VIEW_DEGREES };
     float nearClipPlaneDistance { DEFAULT_NEAR_CLIP };
     float farClipPlaneDistance { DEFAULT_FAR_CLIP };
@@ -47,8 +47,8 @@ signals:
 public slots:
     glm::vec3 getPosition() { return position; }
     void setPosition(glm::vec3 pos);
-    glm::qua<float,glm::packed_highp> getOrientation() { return orientation; }
-    void setOrientation(glm::qua<float,glm::packed_highp> orient);
+    glm::quat getOrientation() { return orientation; }
+    void setOrientation(glm::quat orient);
     void enableSecondaryCameraRenderConfigs(bool enabled);
     void resetSizeSpectatorCamera(int width, int height);
 };

--- a/interface/src/SecondaryCamera.h
+++ b/interface/src/SecondaryCamera.h
@@ -21,7 +21,7 @@ class SecondaryCameraJobConfig : public render::Task::Config { // Exposes second
     Q_OBJECT
     Q_PROPERTY(QUuid attachedEntityId MEMBER attachedEntityId NOTIFY dirty)  // entity whose properties define camera position and orientation
     Q_PROPERTY(QUuid portalEntranceEntityId MEMBER portalEntranceEntityId NOTIFY dirty)  // entity whose properties define a portal's entrance position and orientation
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> position READ getPosition WRITE setPosition)  // of viewpoint to render from
+    Q_PROPERTY(glm::vec3 position READ getPosition WRITE setPosition)  // of viewpoint to render from
     Q_PROPERTY(glm::qua<float,glm::packed_highp> orientation READ getOrientation WRITE setOrientation)  // of viewpoint to render from
     Q_PROPERTY(float vFoV MEMBER vFoV NOTIFY dirty)  // Secondary camera's vertical field of view. In degrees.
     Q_PROPERTY(float nearClipPlaneDistance MEMBER nearClipPlaneDistance NOTIFY dirty)  // Secondary camera's near clip plane distance. In meters.
@@ -31,7 +31,7 @@ class SecondaryCameraJobConfig : public render::Task::Config { // Exposes second
 public:
     QUuid attachedEntityId;
     QUuid portalEntranceEntityId;
-    glm::vec<3,float,glm::packed_highp> position;
+    glm::vec3 position;
     glm::qua<float,glm::packed_highp> orientation;
     float vFoV { DEFAULT_FIELD_OF_VIEW_DEGREES };
     float nearClipPlaneDistance { DEFAULT_NEAR_CLIP };
@@ -45,8 +45,8 @@ public:
 signals:
     void dirty();
 public slots:
-    glm::vec<3,float,glm::packed_highp> getPosition() { return position; }
-    void setPosition(glm::vec<3,float,glm::packed_highp> pos);
+    glm::vec3 getPosition() { return position; }
+    void setPosition(glm::vec3 pos);
     glm::qua<float,glm::packed_highp> getOrientation() { return orientation; }
     void setOrientation(glm::qua<float,glm::packed_highp> orient);
     void enableSecondaryCameraRenderConfigs(bool enabled);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -613,7 +613,7 @@ public:
     virtual void postUpdate(float deltaTime, const render::ScenePointer& scene) override;
     void preDisplaySide(const RenderArgs* renderArgs);
 
-    const glm::mat<4,4,float,glm::packed_highp>& getHMDSensorMatrix() const { return _hmdSensorMatrix; }
+    const glm::mat4& getHMDSensorMatrix() const { return _hmdSensorMatrix; }
     const glm::vec<3,float,glm::packed_highp>& getHMDSensorPosition() const { return _hmdSensorPosition; }
     const glm::qua<float,glm::packed_highp>& getHMDSensorOrientation() const { return _hmdSensorOrientation; }
 
@@ -637,13 +637,13 @@ public:
     // Pass a recent sample of the HMD to the avatar.
     // This can also update the avatar's position to follow the HMD
     // as it moves through the world.
-    void updateFromHMDSensorMatrix(const glm::mat<4,4,float,glm::packed_highp>& hmdSensorMatrix);
+    void updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix);
 
     // compute the hip to hand average azimuth.
     glm::vec<2,float,glm::packed_highp> computeHandAzimuth() const;
 
     // read the location of a hand controller and save the transform
-    void updateJointFromController(controller::Action poseKey, ThreadSafeValueCache<glm::mat<4,4,float,glm::packed_highp>>& matrixCache);
+    void updateJointFromController(controller::Action poseKey, ThreadSafeValueCache<glm::mat4>& matrixCache);
 
     // best called at end of main loop, just before rendering.
     // update sensor to world matrix from current body position and hmd sensor.
@@ -1629,16 +1629,16 @@ public:
     virtual glm::vec<3,float,glm::packed_highp> getAbsoluteJointTranslationInObjectFrame(int index) const override;
 
     // all calibration matrices are in absolute sensor space.
-    glm::mat<4,4,float,glm::packed_highp> getCenterEyeCalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getHeadCalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getSpine2CalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getHipsCalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getLeftFootCalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getRightFootCalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getRightArmCalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getLeftArmCalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getLeftHandCalibrationMat() const;
-    glm::mat<4,4,float,glm::packed_highp> getRightHandCalibrationMat() const;
+    glm::mat4 getCenterEyeCalibrationMat() const;
+    glm::mat4 getHeadCalibrationMat() const;
+    glm::mat4 getSpine2CalibrationMat() const;
+    glm::mat4 getHipsCalibrationMat() const;
+    glm::mat4 getLeftFootCalibrationMat() const;
+    glm::mat4 getRightFootCalibrationMat() const;
+    glm::mat4 getRightArmCalibrationMat() const;
+    glm::mat4 getLeftArmCalibrationMat() const;
+    glm::mat4 getLeftHandCalibrationMat() const;
+    glm::mat4 getRightHandCalibrationMat() const;
 
     void addHoldAction(AvatarActionHold* holdAction);  // thread-safe
     void removeHoldAction(AvatarActionHold* holdAction);  // thread-safe
@@ -1647,16 +1647,16 @@ public:
 
     // derive avatar body position and orientation from the current HMD Sensor location.
     // results are in sensor frame (-z forward)
-    glm::mat<4,4,float,glm::packed_highp> deriveBodyFromHMDSensor(const bool forceFollowYPos = false) const;
+    glm::mat4 deriveBodyFromHMDSensor(const bool forceFollowYPos = false) const;
 
-    glm::mat<4,4,float,glm::packed_highp> getSpine2RotationRigSpace() const;
+    glm::mat4 getSpine2RotationRigSpace() const;
 
     glm::vec<3,float,glm::packed_highp> computeCounterBalance();
 
     // derive avatar body position and orientation from using the current HMD Sensor location in relation to the previous
     // location of the base of support of the avatar.
     // results are in sensor frame (-z foward)
-    glm::mat<4,4,float,glm::packed_highp> deriveBodyUsingCgModel();
+    glm::mat4 deriveBodyUsingCgModel();
 
     /*@jsdoc
      * Tests whether a vector is pointing in the general direction of the avatar's "up" direction (i.e., dot product of vectors

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -338,7 +338,7 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(AudioListenerMode audioListenerModeCamera READ getAudioListenerModeCamera)
     Q_PROPERTY(AudioListenerMode audioListenerModeCustom READ getAudioListenerModeCustom)
     Q_PROPERTY(glm::vec3 customListenPosition READ getCustomListenPosition WRITE setCustomListenPosition)
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> customListenOrientation READ getCustomListenOrientation WRITE setCustomListenOrientation)
+    Q_PROPERTY(glm::quat customListenOrientation READ getCustomListenOrientation WRITE setCustomListenOrientation)
     Q_PROPERTY(float rotationRecenterFilterLength READ getRotationRecenterFilterLength WRITE setRotationRecenterFilterLength)
     Q_PROPERTY(float rotationThreshold READ getRotationThreshold WRITE setRotationThreshold)
     Q_PROPERTY(bool enableStepResetRotation READ getEnableStepResetRotation WRITE setEnableStepResetRotation)
@@ -615,7 +615,7 @@ public:
 
     const glm::mat4& getHMDSensorMatrix() const { return _hmdSensorMatrix; }
     const glm::vec3& getHMDSensorPosition() const { return _hmdSensorPosition; }
-    const glm::qua<float,glm::packed_highp>& getHMDSensorOrientation() const { return _hmdSensorOrientation; }
+    const glm::quat& getHMDSensorOrientation() const { return _hmdSensorOrientation; }
 
     /*@jsdoc
      * Gets the avatar orientation. Suitable for use in QML.
@@ -632,7 +632,7 @@ public:
     Q_INVOKABLE QVariant getOrientationVar() const;
 
     // A method intended to be overriden by MyAvatar for polling orientation for network transmission.
-    glm::qua<float,glm::packed_highp> getOrientationOutbound() const override;
+    glm::quat getOrientationOutbound() const override;
 
     // Pass a recent sample of the HMD to the avatar.
     // This can also update the avatar's position to follow the HMD
@@ -1297,14 +1297,14 @@ public:
     void snapOtherAvatarLookAtTargetsToMe(const AvatarHash& hash);
     void clearLookAtTargetAvatar();
 
-    virtual void setJointRotations(const QVector<glm::qua<float,glm::packed_highp>>& jointRotations) override;
-    virtual void setJointData(int index, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& translation) override;
-    virtual void setJointRotation(int index, const glm::qua<float,glm::packed_highp>& rotation) override;
+    virtual void setJointRotations(const QVector<glm::quat>& jointRotations) override;
+    virtual void setJointData(int index, const glm::quat& rotation, const glm::vec3& translation) override;
+    virtual void setJointRotation(int index, const glm::quat& rotation) override;
     virtual void setJointTranslation(int index, const glm::vec3& translation) override;
     virtual void clearJointData(int index) override;
 
-    virtual void setJointData(const QString& name, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& translation)  override;
-    virtual void setJointRotation(const QString& name, const glm::qua<float,glm::packed_highp>& rotation)  override;
+    virtual void setJointData(const QString& name, const glm::quat& rotation, const glm::vec3& translation)  override;
+    virtual void setJointRotation(const QString& name, const glm::quat& rotation)  override;
     virtual void setJointTranslation(const QString& name, const glm::vec3& translation)  override;
     virtual void clearJointData(const QString& name) override;
     virtual void clearJointsData() override;
@@ -1318,7 +1318,7 @@ public:
      * @param {Quat} orientation - The orientation of the joint in world coordinates.
      * @returns {boolean} <code>true</code> if the joint was pinned, <code>false</code> if it wasn't.
      */
-    Q_INVOKABLE bool pinJoint(int index, const glm::vec3& position, const glm::qua<float,glm::packed_highp>& orientation);
+    Q_INVOKABLE bool pinJoint(int index, const glm::vec3& position, const glm::quat& orientation);
 
     bool isJointPinned(int index);
 
@@ -1371,7 +1371,7 @@ public:
 
     void updateMotors();
     void prepareForPhysicsSimulation();
-    void nextAttitude(glm::vec3 position, glm::qua<float,glm::packed_highp> orientation); // Can be safely called at any time.
+    void nextAttitude(glm::vec3 position, glm::quat orientation); // Can be safely called at any time.
     void harvestResultsFromPhysicsSimulation(float deltaTime);
 
     const QString& getCollisionSoundURL() { return _collisionSoundURL; }
@@ -1407,8 +1407,8 @@ public:
     void setAudioListenerMode(AudioListenerMode audioListenerMode);
     glm::vec3 getCustomListenPosition() { return _customListenPosition; }
     void setCustomListenPosition(glm::vec3 customListenPosition) { _customListenPosition = customListenPosition; }
-    glm::qua<float,glm::packed_highp> getCustomListenOrientation() { return _customListenOrientation; }
-    void setCustomListenOrientation(glm::qua<float,glm::packed_highp> customListenOrientation) { _customListenOrientation = customListenOrientation; }
+    glm::quat getCustomListenOrientation() { return _customListenOrientation; }
+    void setCustomListenOrientation(glm::quat customListenOrientation) { _customListenOrientation = customListenOrientation; }
 
     virtual void rebuildCollisionShape() override;
 
@@ -1420,8 +1420,8 @@ public:
     void setHeadControllerFacingMovingAverage(glm::vec2 currentHeadControllerFacing) { _headControllerFacingMovingAverage = currentHeadControllerFacing; }
     float getCurrentStandingHeight() const { return _currentStandingHeight; }
     void setCurrentStandingHeight(float newMode) { _currentStandingHeight = newMode; }
-    const glm::qua<float,glm::packed_highp> getAverageHeadRotation() const { return _averageHeadRotation; }
-    void setAverageHeadRotation(glm::qua<float,glm::packed_highp> rotation) { _averageHeadRotation = rotation; }
+    const glm::quat getAverageHeadRotation() const { return _averageHeadRotation; }
+    void setAverageHeadRotation(glm::quat rotation) { _averageHeadRotation = rotation; }
     bool getResetMode() const { return _resetMode; }
     void setResetMode(bool hasBeenReset) { _resetMode = hasBeenReset; }
 
@@ -1613,7 +1613,7 @@ public:
      * var headRotation = MyAvatar.getAbsoluteJointRotationInObjectFrame(headIndex);
      * print("Head rotation: " + JSON.stringify(Quat.safeEulerAngles(headRotation))); // Degrees
      */
-    virtual glm::qua<float,glm::packed_highp> getAbsoluteJointRotationInObjectFrame(int index) const override;
+    virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
 
     /*@jsdoc
      * Gets the translation of a joint relative to the avatar.
@@ -1714,7 +1714,7 @@ public:
     bool isReadyForPhysics() const;
 
     float computeStandingHeightMode(const controller::Pose& head);
-    glm::qua<float,glm::packed_highp> computeAverageHeadRotation(const controller::Pose& head);
+    glm::quat computeAverageHeadRotation(const controller::Pose& head);
 
     glm::vec3 getNextPosition() { return _goToPending ? _goToPosition : getWorldPosition(); }
     void prepareAvatarEntityDataForReload();
@@ -1773,7 +1773,7 @@ public:
      */
     Q_INVOKABLE bool setPointAt(const glm::vec3& pointAtTarget);
 
-    glm::qua<float,glm::packed_highp> getLookAtRotation() { return _lookAtYaw * _lookAtPitch; }
+    glm::quat getLookAtRotation() { return _lookAtYaw * _lookAtPitch; }
 
     /*@jsdoc
      * Creates a new grab that grabs an entity.
@@ -1803,7 +1803,7 @@ public:
      * }, 10000);
      */
     Q_INVOKABLE const QUuid grab(const QUuid& targetID, int parentJointIndex,
-                                 glm::vec3 positionalOffset, glm::qua<float,glm::packed_highp> rotationalOffset);
+                                 glm::vec3 positionalOffset, glm::quat rotationalOffset);
 
     /*@jsdoc
      * Releases (deletes) a grab to stop grabbing an entity.
@@ -1883,7 +1883,7 @@ public:
      * @param {Vec3} position - The position where the avatar should sit.
      * @param {Quat} rotation - The initial orientation of the seated avatar.
      */
-    Q_INVOKABLE void beginSit(const glm::vec3& position, const glm::qua<float,glm::packed_highp>& rotation);
+    Q_INVOKABLE void beginSit(const glm::vec3& position, const glm::quat& rotation);
 
     /*@jsdoc
      * Ends a sitting action for the avatar.
@@ -1891,7 +1891,7 @@ public:
      * @param {Vec3} position - The position of the avatar when standing up.
      * @param {Quat} rotation - The orientation of the avatar when standing up.
      */
-    Q_INVOKABLE void endSit(const glm::vec3& position, const glm::qua<float,glm::packed_highp>& rotation);
+    Q_INVOKABLE void endSit(const glm::vec3& position, const glm::quat& rotation);
 
     /*@jsdoc
      * Gets whether the avatar is in a seated pose. The seated pose is set by calling {@link MyAvatar.beginSit}.
@@ -1995,7 +1995,7 @@ public slots:
      *      the new position and orientate the avatar to face the position.
      */
     void goToFeetLocation(const glm::vec3& newPosition, bool hasOrientation = false,
-        const glm::qua<float,glm::packed_highp>& newOrientation = glm::qua<float,glm::packed_highp>(), bool shouldFaceLocation = false);
+        const glm::quat& newOrientation = glm::quat(), bool shouldFaceLocation = false);
 
     /*@jsdoc
      * Moves the avatar to a new position and/or orientation in the domain.
@@ -2008,7 +2008,7 @@ public slots:
      * @param {boolean} [withSafeLanding=true] - Set to <code>false</code> to disable safe landing when teleporting.
      */
     void goToLocation(const glm::vec3& newPosition,
-                      bool hasOrientation = false, const glm::qua<float,glm::packed_highp>& newOrientation = glm::qua<float,glm::packed_highp>(),
+                      bool hasOrientation = false, const glm::quat& newOrientation = glm::quat(),
                       bool shouldFaceLocation = false, bool withSafeLanding = true);
     /*@jsdoc
      * Moves the avatar to a new position and (optional) orientation in the domain, with safe landing.
@@ -2257,7 +2257,7 @@ public slots:
      * @function MyAvatar.getOrientationForAudio
      * @returns {Quat} The orientation of your listening position.
      */
-    glm::qua<float,glm::packed_highp> getOrientationForAudio();
+    glm::quat getOrientationForAudio();
 
     /*@jsdoc
      * @function MyAvatar.setModelScale

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -326,9 +326,9 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(QVector3D qmlPosition READ getQmlPosition)
     QVector3D getQmlPosition() { auto p = getWorldPosition(); return QVector3D(p.x, p.y, p.z); }
 
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> feetPosition READ getWorldFeetPosition WRITE goToFeetLocation)
+    Q_PROPERTY(glm::vec3 feetPosition READ getWorldFeetPosition WRITE goToFeetLocation)
     Q_PROPERTY(bool shouldRenderLocally READ getShouldRenderLocally WRITE setShouldRenderLocally)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> motorVelocity READ getScriptedMotorVelocity WRITE setScriptedMotorVelocity)
+    Q_PROPERTY(glm::vec3 motorVelocity READ getScriptedMotorVelocity WRITE setScriptedMotorVelocity)
     Q_PROPERTY(float motorTimescale READ getScriptedMotorTimescale WRITE setScriptedMotorTimescale)
     Q_PROPERTY(QString motorReferenceFrame READ getScriptedMotorFrame WRITE setScriptedMotorFrame)
     Q_PROPERTY(QString motorMode READ getScriptedMotorMode WRITE setScriptedMotorMode)
@@ -337,7 +337,7 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(AudioListenerMode audioListenerModeHead READ getAudioListenerModeHead)
     Q_PROPERTY(AudioListenerMode audioListenerModeCamera READ getAudioListenerModeCamera)
     Q_PROPERTY(AudioListenerMode audioListenerModeCustom READ getAudioListenerModeCustom)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> customListenPosition READ getCustomListenPosition WRITE setCustomListenPosition)
+    Q_PROPERTY(glm::vec3 customListenPosition READ getCustomListenPosition WRITE setCustomListenPosition)
     Q_PROPERTY(glm::qua<float,glm::packed_highp> customListenOrientation READ getCustomListenOrientation WRITE setCustomListenOrientation)
     Q_PROPERTY(float rotationRecenterFilterLength READ getRotationRecenterFilterLength WRITE setRotationRecenterFilterLength)
     Q_PROPERTY(float rotationThreshold READ getRotationThreshold WRITE setRotationThreshold)
@@ -345,10 +345,10 @@ class MyAvatar : public Avatar {
     Q_PROPERTY(bool enableDrawAverageFacing READ getEnableDrawAverageFacing WRITE setEnableDrawAverageFacing)
     //TODO: make gravity feature work Q_PROPERTY(glm::vec3 gravity READ getGravity WRITE setGravity)
 
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> leftHandPosition READ getLeftHandPosition)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> rightHandPosition READ getRightHandPosition)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> leftHandTipPosition READ getLeftHandTipPosition)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> rightHandTipPosition READ getRightHandTipPosition)
+    Q_PROPERTY(glm::vec3 leftHandPosition READ getLeftHandPosition)
+    Q_PROPERTY(glm::vec3 rightHandPosition READ getRightHandPosition)
+    Q_PROPERTY(glm::vec3 leftHandTipPosition READ getLeftHandTipPosition)
+    Q_PROPERTY(glm::vec3 rightHandTipPosition READ getRightHandTipPosition)
 
     Q_PROPERTY(controller::Pose leftHandPose READ getLeftHandPose)
     Q_PROPERTY(controller::Pose rightHandPose READ getRightHandPose)
@@ -614,7 +614,7 @@ public:
     void preDisplaySide(const RenderArgs* renderArgs);
 
     const glm::mat4& getHMDSensorMatrix() const { return _hmdSensorMatrix; }
-    const glm::vec<3,float,glm::packed_highp>& getHMDSensorPosition() const { return _hmdSensorPosition; }
+    const glm::vec3& getHMDSensorPosition() const { return _hmdSensorPosition; }
     const glm::qua<float,glm::packed_highp>& getHMDSensorOrientation() const { return _hmdSensorOrientation; }
 
     /*@jsdoc
@@ -662,7 +662,7 @@ public:
      * var defaultEyePosition = MyAvatar.getDefaultEyePosition();
      * print(JSON.stringify(defaultEyePosition));
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getDefaultEyePosition() const;
+    Q_INVOKABLE glm::vec3 getDefaultEyePosition() const;
 
     float getRealWorldFieldOfView() { return _realWorldFieldOfView.get(); }
 
@@ -1135,7 +1135,7 @@ public:
      * @example <caption>Report the current position of your avatar's head.</caption>
      * print(JSON.stringify(MyAvatar.getHeadPosition()));
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getHeadPosition() const { return getHead()->getPosition(); }
+    Q_INVOKABLE glm::vec3 getHeadPosition() const { return getHead()->getPosition(); }
 
     /*@jsdoc
      * Gets the yaw of the avatar's head relative to its body.
@@ -1175,7 +1175,7 @@ public:
      * var eyePosition = MyAvatar.getEyePosition();
      * print(JSON.stringify(eyePosition));
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getEyePosition() const { return getHead()->getEyePosition(); }
+    Q_INVOKABLE glm::vec3 getEyePosition() const { return getHead()->getEyePosition(); }
 
     /*@jsdoc
      * Gets the position of the avatar your avatar is currently looking at.
@@ -1186,7 +1186,7 @@ public:
      */
     // FIXME: If not looking at an avatar, the most recently looked-at position is returned. This should be fixed to return
     // undefined or {NaN, NaN, NaN} or similar.
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getTargetAvatarPosition() const { return _targetAvatarPosition; }
+    Q_INVOKABLE glm::vec3 getTargetAvatarPosition() const { return _targetAvatarPosition; }
 
     /*@jsdoc
      * Gets information on the avatar your avatar is currently looking at.
@@ -1207,7 +1207,7 @@ public:
      * @example <caption>Report the position of your left hand relative to your avatar.</caption>
      * print(JSON.stringify(MyAvatar.getLeftHandPosition()));
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getLeftHandPosition() const;
+    Q_INVOKABLE glm::vec3 getLeftHandPosition() const;
 
     /*@jsdoc
      * Gets the position of the avatar's right hand, relative to the avatar, as positioned by a hand controller (e.g., Oculus
@@ -1220,7 +1220,7 @@ public:
      * @example <caption>Report the position of your right hand relative to your avatar.</caption>
      * print(JSON.stringify(MyAvatar.getLeftHandPosition()));
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getRightHandPosition() const;
+    Q_INVOKABLE glm::vec3 getRightHandPosition() const;
 
     /*@jsdoc
      * Gets the position 0.3m in front of the left hand's position in the direction along the palm, in avatar coordinates, as
@@ -1229,7 +1229,7 @@ public:
      * @returns {Vec3} The position 0.3m in front of the left hand's position in the direction along the palm, in avatar
      *     coordinates. If the hand isn't being positioned by a controller, <code>{@link Vec3(0)|Vec3.ZERO}</code> is returned.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getLeftHandTipPosition() const;
+    Q_INVOKABLE glm::vec3 getLeftHandTipPosition() const;
 
     /*@jsdoc
      * Gets the position 0.3m in front of the right hand's position in the direction along the palm, in avatar coordinates, as
@@ -1238,7 +1238,7 @@ public:
      * @returns {Vec3} The position 0.3m in front of the right hand's position in the direction along the palm, in avatar
      *     coordinates. If the hand isn't being positioned by a controller, <code>{@link Vec3(0)|Vec3.ZERO}</code> is returned.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getRightHandTipPosition() const;
+    Q_INVOKABLE glm::vec3 getRightHandTipPosition() const;
 
 
     /*@jsdoc
@@ -1298,14 +1298,14 @@ public:
     void clearLookAtTargetAvatar();
 
     virtual void setJointRotations(const QVector<glm::qua<float,glm::packed_highp>>& jointRotations) override;
-    virtual void setJointData(int index, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& translation) override;
+    virtual void setJointData(int index, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& translation) override;
     virtual void setJointRotation(int index, const glm::qua<float,glm::packed_highp>& rotation) override;
-    virtual void setJointTranslation(int index, const glm::vec<3,float,glm::packed_highp>& translation) override;
+    virtual void setJointTranslation(int index, const glm::vec3& translation) override;
     virtual void clearJointData(int index) override;
 
-    virtual void setJointData(const QString& name, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& translation)  override;
+    virtual void setJointData(const QString& name, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& translation)  override;
     virtual void setJointRotation(const QString& name, const glm::qua<float,glm::packed_highp>& rotation)  override;
-    virtual void setJointTranslation(const QString& name, const glm::vec<3,float,glm::packed_highp>& translation)  override;
+    virtual void setJointTranslation(const QString& name, const glm::vec3& translation)  override;
     virtual void clearJointData(const QString& name) override;
     virtual void clearJointsData() override;
 
@@ -1318,7 +1318,7 @@ public:
      * @param {Quat} orientation - The orientation of the joint in world coordinates.
      * @returns {boolean} <code>true</code> if the joint was pinned, <code>false</code> if it wasn't.
      */
-    Q_INVOKABLE bool pinJoint(int index, const glm::vec<3,float,glm::packed_highp>& position, const glm::qua<float,glm::packed_highp>& orientation);
+    Q_INVOKABLE bool pinJoint(int index, const glm::vec3& position, const glm::qua<float,glm::packed_highp>& orientation);
 
     bool isJointPinned(int index);
 
@@ -1371,7 +1371,7 @@ public:
 
     void updateMotors();
     void prepareForPhysicsSimulation();
-    void nextAttitude(glm::vec<3,float,glm::packed_highp> position, glm::qua<float,glm::packed_highp> orientation); // Can be safely called at any time.
+    void nextAttitude(glm::vec3 position, glm::qua<float,glm::packed_highp> orientation); // Can be safely called at any time.
     void harvestResultsFromPhysicsSimulation(float deltaTime);
 
     const QString& getCollisionSoundURL() { return _collisionSoundURL; }
@@ -1405,8 +1405,8 @@ public:
 
     AudioListenerMode getAudioListenerMode() { return _audioListenerMode; }
     void setAudioListenerMode(AudioListenerMode audioListenerMode);
-    glm::vec<3,float,glm::packed_highp> getCustomListenPosition() { return _customListenPosition; }
-    void setCustomListenPosition(glm::vec<3,float,glm::packed_highp> customListenPosition) { _customListenPosition = customListenPosition; }
+    glm::vec3 getCustomListenPosition() { return _customListenPosition; }
+    void setCustomListenPosition(glm::vec3 customListenPosition) { _customListenPosition = customListenPosition; }
     glm::qua<float,glm::packed_highp> getCustomListenOrientation() { return _customListenOrientation; }
     void setCustomListenOrientation(glm::qua<float,glm::packed_highp> customListenOrientation) { _customListenOrientation = customListenOrientation; }
 
@@ -1626,7 +1626,7 @@ public:
      * var headTranslation = MyAvatar.getAbsoluteJointTranslationInObjectFrame(headIndex);
      * print("Head translation: " + JSON.stringify(headTranslation));
      */
-    virtual glm::vec<3,float,glm::packed_highp> getAbsoluteJointTranslationInObjectFrame(int index) const override;
+    virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;
 
     // all calibration matrices are in absolute sensor space.
     glm::mat4 getCenterEyeCalibrationMat() const;
@@ -1651,7 +1651,7 @@ public:
 
     glm::mat4 getSpine2RotationRigSpace() const;
 
-    glm::vec<3,float,glm::packed_highp> computeCounterBalance();
+    glm::vec3 computeCounterBalance();
 
     // derive avatar body position and orientation from using the current HMD Sensor location in relation to the previous
     // location of the base of support of the avatar.
@@ -1666,7 +1666,7 @@ public:
      * @returns {boolean} <code>true</code> if the direction vector is pointing generally in the direction of the avatar's "up"
      *     direction.
      */
-    Q_INVOKABLE bool isUp(const glm::vec<3,float,glm::packed_highp>& direction) { return glm::dot(direction, _worldUpDirection) > 0.0f; }; // true iff direction points up wrt avatar's definition of up.
+    Q_INVOKABLE bool isUp(const glm::vec3& direction) { return glm::dot(direction, _worldUpDirection) > 0.0f; }; // true iff direction points up wrt avatar's definition of up.
 
     /*@jsdoc
      * Tests whether a vector is pointing in the general direction of the avatar's "down" direction (i.e., dot product of
@@ -1676,14 +1676,14 @@ public:
      * @returns {boolean} <code>true</code> if the direction vector is pointing generally in the direction of the avatar's
      *     "down" direction.
      */
-    Q_INVOKABLE bool isDown(const glm::vec<3,float,glm::packed_highp>& direction) { return glm::dot(direction, _worldUpDirection) < 0.0f; };
+    Q_INVOKABLE bool isDown(const glm::vec3& direction) { return glm::dot(direction, _worldUpDirection) < 0.0f; };
 
     void setUserHeight(float value);
     float getUserHeight() const;
     float getUserEyeHeight() const;
 
     virtual SpatialParentTree* getParentTree() const override;
-    virtual glm::vec<3,float,glm::packed_highp> scaleForChildren() const override { return glm::vec3(getSensorToWorldScale()); }
+    virtual glm::vec3 scaleForChildren() const override { return glm::vec3(getSensorToWorldScale()); }
 
     const QUuid& getSelfID() const { return AVATAR_SELF_ID; }
 
@@ -1716,7 +1716,7 @@ public:
     float computeStandingHeightMode(const controller::Pose& head);
     glm::qua<float,glm::packed_highp> computeAverageHeadRotation(const controller::Pose& head);
 
-    glm::vec<3,float,glm::packed_highp> getNextPosition() { return _goToPending ? _goToPosition : getWorldPosition(); }
+    glm::vec3 getNextPosition() { return _goToPending ? _goToPosition : getWorldPosition(); }
     void prepareAvatarEntityDataForReload();
 
     /*@jsdoc
@@ -1726,14 +1726,14 @@ public:
      * @function MyAvatar.setHeadLookAt
      * @param {Vec3} lookAtTarget - The target point in world coordinates.
      */
-    Q_INVOKABLE void setHeadLookAt(const glm::vec<3,float,glm::packed_highp>& lookAtTarget);
+    Q_INVOKABLE void setHeadLookAt(const glm::vec3& lookAtTarget);
 
     /*@jsdoc
      * Gets the current target point of the head's look direction in world coordinates.
      * @function MyAvatar.getHeadLookAt
      * @returns {Vec3} The head's look-at target in world coordinates.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getHeadLookAt() { return _lookAtCameraTarget; }
+    Q_INVOKABLE glm::vec3 getHeadLookAt() { return _lookAtCameraTarget; }
 
     /*@jsdoc
      * Returns control of the avatar's head to the engine, and releases control from API calls.
@@ -1748,14 +1748,14 @@ public:
      * @function MyAvatar.setEyesLookAt
      * @param {Vec3} lookAtTarget - The target point in world coordinates.
      */
-    Q_INVOKABLE void setEyesLookAt(const glm::vec<3,float,glm::packed_highp>& lookAtTarget);
+    Q_INVOKABLE void setEyesLookAt(const glm::vec3& lookAtTarget);
 
     /*@jsdoc
      * Gets the current target point of the eyes look direction in world coordinates.
      * @function MyAvatar.getEyesLookAt
      * @returns {Vec3} The eyes' look-at target in world coordinates.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getEyesLookAt() { return _eyesLookAtTarget.get(); }
+    Q_INVOKABLE glm::vec3 getEyesLookAt() { return _eyesLookAtTarget.get(); }
 
     /*@jsdoc
      * Returns control of the avatar's eyes to the engine, and releases control from API calls.
@@ -1771,7 +1771,7 @@ public:
      * @param {Vec3} pointAtTarget - The target to point at, in world coordinates.
      * @returns {boolean} <code>true</code> if the target point was set, <code>false</code> if it wasn't.
      */
-    Q_INVOKABLE bool setPointAt(const glm::vec<3,float,glm::packed_highp>& pointAtTarget);
+    Q_INVOKABLE bool setPointAt(const glm::vec3& pointAtTarget);
 
     glm::qua<float,glm::packed_highp> getLookAtRotation() { return _lookAtYaw * _lookAtPitch; }
 
@@ -1803,7 +1803,7 @@ public:
      * }, 10000);
      */
     Q_INVOKABLE const QUuid grab(const QUuid& targetID, int parentJointIndex,
-                                 glm::vec<3,float,glm::packed_highp> positionalOffset, glm::qua<float,glm::packed_highp> rotationalOffset);
+                                 glm::vec3 positionalOffset, glm::qua<float,glm::packed_highp> rotationalOffset);
 
     /*@jsdoc
      * Releases (deletes) a grab to stop grabbing an entity.
@@ -1883,7 +1883,7 @@ public:
      * @param {Vec3} position - The position where the avatar should sit.
      * @param {Quat} rotation - The initial orientation of the seated avatar.
      */
-    Q_INVOKABLE void beginSit(const glm::vec<3,float,glm::packed_highp>& position, const glm::qua<float,glm::packed_highp>& rotation);
+    Q_INVOKABLE void beginSit(const glm::vec3& position, const glm::qua<float,glm::packed_highp>& rotation);
 
     /*@jsdoc
      * Ends a sitting action for the avatar.
@@ -1891,7 +1891,7 @@ public:
      * @param {Vec3} position - The position of the avatar when standing up.
      * @param {Quat} rotation - The orientation of the avatar when standing up.
      */
-    Q_INVOKABLE void endSit(const glm::vec<3,float,glm::packed_highp>& position, const glm::qua<float,glm::packed_highp>& rotation);
+    Q_INVOKABLE void endSit(const glm::vec3& position, const glm::qua<float,glm::packed_highp>& rotation);
 
     /*@jsdoc
      * Gets whether the avatar is in a seated pose. The seated pose is set by calling {@link MyAvatar.beginSit}.
@@ -1916,8 +1916,8 @@ public:
     void debugDrawPose(controller::Action action, const char* channelName, float size);
 
     bool getIsJointOverridden(int jointIndex) const;
-    glm::vec<3,float,glm::packed_highp> getLookAtPivotPoint();
-    glm::vec<3,float,glm::packed_highp> getCameraEyesPosition(float deltaTime);
+    glm::vec3 getLookAtPivotPoint();
+    glm::vec3 getCameraEyesPosition(float deltaTime);
     bool isJumping();
     bool getHMDCrouchRecenterEnabled() const;
     bool isAllowedToLean() const;
@@ -1994,7 +1994,7 @@ public slots:
      * @param {boolean} [shouldFaceLocation=false] - Set to <code>true</code> to position the avatar a short distance away from
      *      the new position and orientate the avatar to face the position.
      */
-    void goToFeetLocation(const glm::vec<3,float,glm::packed_highp>& newPosition, bool hasOrientation = false,
+    void goToFeetLocation(const glm::vec3& newPosition, bool hasOrientation = false,
         const glm::qua<float,glm::packed_highp>& newOrientation = glm::qua<float,glm::packed_highp>(), bool shouldFaceLocation = false);
 
     /*@jsdoc
@@ -2007,7 +2007,7 @@ public slots:
      *     the new position and orientate the avatar to face the position.
      * @param {boolean} [withSafeLanding=true] - Set to <code>false</code> to disable safe landing when teleporting.
      */
-    void goToLocation(const glm::vec<3,float,glm::packed_highp>& newPosition,
+    void goToLocation(const glm::vec3& newPosition,
                       bool hasOrientation = false, const glm::qua<float,glm::packed_highp>& newOrientation = glm::qua<float,glm::packed_highp>(),
                       bool shouldFaceLocation = false, bool withSafeLanding = true);
     /*@jsdoc
@@ -2022,7 +2022,7 @@ public slots:
      * @function MyAvatar.goToLocationAndEnableCollisions
      * @param {Vec3} position - The new position for the avatar, in world coordinates.
      */
-    void goToLocationAndEnableCollisions(const glm::vec<3,float,glm::packed_highp>& newPosition);
+    void goToLocationAndEnableCollisions(const glm::vec3& newPosition);
 
     /*@jsdoc
      * @function MyAvatar.safeLanding
@@ -2030,7 +2030,7 @@ public slots:
      * @returns {boolean} <code>true</code> if the avatar was moved, <code>false</code> if it wasn't.
      * @deprecated This function is deprecated and will be removed.
      */
-    bool safeLanding(const glm::vec<3,float,glm::packed_highp>& position);
+    bool safeLanding(const glm::vec3& position);
 
 
     /*@jsdoc
@@ -2055,7 +2055,7 @@ public slots:
      *     properties instead.
      */
     //  Set/Get update the thrust that will move the avatar around
-    void addThrust(glm::vec<3,float,glm::packed_highp> newThrust) { _thrust += newThrust; };
+    void addThrust(glm::vec3 newThrust) { _thrust += newThrust; };
 
     /*@jsdoc
      * Gets the thrust currently being applied to your avatar.
@@ -2064,7 +2064,7 @@ public slots:
      * @deprecated This function is deprecated and will be removed. Use {@link MyAvatar|MyAvatar.motorVelocity} and related
      *     properties instead.
      */
-    glm::vec<3,float,glm::packed_highp> getThrust() { return _thrust; };
+    glm::vec3 getThrust() { return _thrust; };
 
     /*@jsdoc
      * Sets the thrust to be applied to your avatar for a short while.
@@ -2073,7 +2073,7 @@ public slots:
      * @deprecated This function is deprecated and will be removed. Use {@link MyAvatar|MyAvatar.motorVelocity} and related
      *     properties instead.
      */
-    void setThrust(glm::vec<3,float,glm::packed_highp> newThrust) { _thrust = newThrust; }
+    void setThrust(glm::vec3 newThrust) { _thrust = newThrust; }
 
 
     /*@jsdoc
@@ -2249,7 +2249,7 @@ public slots:
      * @function MyAvatar.getPositionForAudio
      * @returns {Vec3} Your listening position.
      */
-    glm::vec<3,float,glm::packed_highp> getPositionForAudio();
+    glm::vec3 getPositionForAudio();
 
     /*@jsdoc
      * Gets the orientation of your listening position for spatialized audio. The orientation depends on the value of the

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -640,7 +640,7 @@ public:
     void updateFromHMDSensorMatrix(const glm::mat4& hmdSensorMatrix);
 
     // compute the hip to hand average azimuth.
-    glm::vec<2,float,glm::packed_highp> computeHandAzimuth() const;
+    glm::vec2 computeHandAzimuth() const;
 
     // read the location of a hand controller and save the transform
     void updateJointFromController(controller::Action poseKey, ThreadSafeValueCache<glm::mat4>& matrixCache);

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -56,7 +56,7 @@ public:
      *     }
      * }
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getContentsDimensions();
+    Q_INVOKABLE glm::vec3 getContentsDimensions();
 
     /*@jsdoc
      * Gets the largest dimension of the extents of the entities held in the clipboard.
@@ -135,7 +135,7 @@ public:
      * @returns {Uuid[]} The IDs of the new entities that were created as a result of the paste operation. If entities couldn't 
      *     be created then an empty array is returned.
      */
-    Q_INVOKABLE QVector<EntityItemID> pasteEntities(glm::vec<3,float,glm::packed_highp> position, const QString& entityHostType = "domain");
+    Q_INVOKABLE QVector<EntityItemID> pasteEntities(glm::vec3 position, const QString& entityHostType = "domain");
 };
 
 #endif // hifi_ClipboardScriptingInterface_h

--- a/interface/src/scripting/ControllerScriptingInterface.h
+++ b/interface/src/scripting/ControllerScriptingInterface.h
@@ -345,7 +345,7 @@ public slots:
      * @function Controller.getViewportDimensions
      * @returns {Vec2} The dimensions of the Interface window interior if in desktop mode or HUD surface if in HMD mode.
      */
-    virtual glm::vec<2,float,glm::packed_highp> getViewportDimensions() const;
+    virtual glm::vec2 getViewportDimensions() const;
 
     /*@jsdoc
      * Gets the recommended area to position UI on the HUD surface if in HMD mode or Interface's window interior if in desktop 

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -90,7 +90,7 @@ class ScriptEngine;
  */
 class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Dependency {
     Q_OBJECT
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> position READ getPosition)
+    Q_PROPERTY(glm::vec3 position READ getPosition)
     Q_PROPERTY(glm::qua<float,glm::packed_highp> orientation READ getOrientation)
     Q_PROPERTY(bool showTablet READ getShouldShowTablet)
     Q_PROPERTY(bool tabletContextualMode READ getTabletContextualMode)
@@ -103,7 +103,7 @@ class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Depen
     Q_PROPERTY(int miniTabletHand READ getCurrentMiniTabletHand WRITE setCurrentMiniTabletHand)
     Q_PROPERTY(bool miniTabletEnabled READ getMiniTabletEnabled WRITE setMiniTabletEnabled)
     Q_PROPERTY(QVariant playArea READ getPlayAreaRect);
-    Q_PROPERTY(QVector<glm::vec<3,float,glm::packed_highp>> sensorPositions READ getSensorPositions);
+    Q_PROPERTY(QVector<glm::vec3> sensorPositions READ getSensorPositions);
 
     Q_PROPERTY(float visionSqueezeRatioX READ getVisionSqueezeRatioX WRITE setVisionSqueezeRatioX);
     Q_PROPERTY(float visionSqueezeRatioY READ getVisionSqueezeRatioY WRITE setVisionSqueezeRatioY);
@@ -142,9 +142,9 @@ public:
      *     Overlays.deleteOverlay(square);
      * });
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> calculateRayUICollisionPoint(const glm::vec<3,float,glm::packed_highp>& position, const glm::vec<3,float,glm::packed_highp>& direction) const;
+    Q_INVOKABLE glm::vec3 calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction) const;
 
-    glm::vec<3,float,glm::packed_highp> calculateParabolaUICollisionPoint(const glm::vec<3,float,glm::packed_highp>& position, const glm::vec<3,float,glm::packed_highp>& velocity, const glm::vec<3,float,glm::packed_highp>& acceleration, float& parabolicDistance) const;
+    glm::vec3 calculateParabolaUICollisionPoint(const glm::vec3& position, const glm::vec3& velocity, const glm::vec3& acceleration, float& parabolicDistance) const;
 
     /*@jsdoc
      * Gets the 2D HUD overlay coordinates of a 3D point on the HUD overlay.
@@ -170,7 +170,7 @@ public:
      *     Overlays.deleteOverlay(square);
      * });
      */
-    Q_INVOKABLE glm::vec<2,float,glm::packed_highp> overlayFromWorldPoint(const glm::vec<3,float,glm::packed_highp>& position) const;
+    Q_INVOKABLE glm::vec2 overlayFromWorldPoint(const glm::vec3& position) const;
 
     /*@jsdoc
      * Gets the 3D world coordinates of a 2D point on the HUD overlay.
@@ -179,7 +179,7 @@ public:
      * @param {Vec2} coordinates - The point on the HUD overlay in HUD coordinates.
      * @returns {Vec3} The point on the HUD overlay in world coordinates.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> worldPointFromOverlay(const glm::vec<2,float,glm::packed_highp>& overlay) const;
+    Q_INVOKABLE glm::vec3 worldPointFromOverlay(const glm::vec2& overlay) const;
 
     /*@jsdoc
      * Gets the 2D point on the HUD overlay represented by given spherical coordinates. 
@@ -190,7 +190,7 @@ public:
      * @param {Vec2} sphericalPos - The point on the HUD overlay in spherical coordinates.
      * @returns {Vec2} The point on the HUD overlay in HUD coordinates.
      */
-    Q_INVOKABLE glm::vec<2,float,glm::packed_highp> sphericalToOverlay(const glm::vec<2,float,glm::packed_highp> & sphericalPos) const;
+    Q_INVOKABLE glm::vec2 sphericalToOverlay(const glm::vec2 & sphericalPos) const;
 
     /*@jsdoc
      * Gets the spherical coordinates of a 2D point on the HUD overlay.
@@ -201,7 +201,7 @@ public:
      * @param {Vec2} overlayPos - The point on the HUD overlay in HUD coordinates.
      * @returns {Vec2} The point on the HUD overlay in spherical coordinates.
      */
-    Q_INVOKABLE glm::vec<2,float,glm::packed_highp> overlayToSpherical(const glm::vec<2,float,glm::packed_highp> & overlayPos) const;
+    Q_INVOKABLE glm::vec2 overlayToSpherical(const glm::vec2 & overlayPos) const;
 
     /*@jsdoc
      * Recenters the HMD HUD to the current HMD position and orientation.
@@ -488,9 +488,9 @@ public:
     bool getAwayStateWhenFocusLostInVREnabled();
 
     QVariant getPlayAreaRect();
-    QVector<glm::vec<3,float,glm::packed_highp>> getSensorPositions();
+    QVector<glm::vec3> getSensorPositions();
 
-    glm::vec<3,float,glm::packed_highp> getPosition() const;
+    glm::vec3 getPosition() const;
 
 private:
     bool _showTablet { false };

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -91,7 +91,7 @@ class ScriptEngine;
 class HMDScriptingInterface : public AbstractHMDScriptingInterface, public Dependency {
     Q_OBJECT
     Q_PROPERTY(glm::vec3 position READ getPosition)
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> orientation READ getOrientation)
+    Q_PROPERTY(glm::quat orientation READ getOrientation)
     Q_PROPERTY(bool showTablet READ getShouldShowTablet)
     Q_PROPERTY(bool tabletContextualMode READ getTabletContextualMode)
     Q_PROPERTY(QUuid tabletID READ getCurrentTabletFrameID WRITE setCurrentTabletFrameID)
@@ -506,7 +506,7 @@ private:
     bool _miniTabletEnabled { true };
 
     // Get the orientation of the HMD
-    glm::qua<float,glm::packed_highp> getOrientation() const;
+    glm::quat getOrientation() const;
 
     bool getHUDLookAtPosition3D(glm::vec3& result) const;
     glm::mat4 getWorldHMDMatrix() const;

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -492,7 +492,7 @@ public slots:
      * @function Window.getDeviceSize
      * @returns {Vec2} The width and height of the Interface window or HMD rendering surface, in pixels.
      */
-    glm::vec<2,float,glm::packed_highp> getDeviceSize() const;
+    glm::vec2 getDeviceSize() const;
 
     /*@jsdoc
      * Gets the last domain connection error when a connection is refused.

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -409,7 +409,7 @@ public slots:
      *     <code>".jpeg"</code>, <code>".png"</code>, or <code>".webp"</code> &mdash; or if not provided then in the format chosen in general settings, 
      *     Default is PNG. Animated images are saved in GIF format.</p>
      */
-    void takeSecondaryCamera360Snapshot(const glm::vec<3,float,glm::packed_highp>& cameraPosition, const bool& cubemapOutputFormat = false, const bool& notify = true, const QString& filename = QString());
+    void takeSecondaryCamera360Snapshot(const glm::vec3& cameraPosition, const bool& cubemapOutputFormat = false, const bool& notify = true, const QString& filename = QString());
 
     /*@jsdoc
      * Emits a {@link Window.connectionAdded|connectionAdded} or a {@link Window.connectionError|connectionError} signal that

--- a/interface/src/ui/InteractiveWindow.h
+++ b/interface/src/ui/InteractiveWindow.h
@@ -186,10 +186,10 @@ class InteractiveWindow : public QObject {
     Q_OBJECT
 
     Q_PROPERTY(QString title READ getTitle WRITE setTitle)
-    Q_PROPERTY(glm::vec<2,float,glm::packed_highp> position READ getPosition WRITE setPosition)
+    Q_PROPERTY(glm::vec2 position READ getPosition WRITE setPosition)
     Q_PROPERTY(RelativePositionAnchor relativePositionAnchor READ getRelativePositionAnchor WRITE setRelativePositionAnchor)
-    Q_PROPERTY(glm::vec<2,float,glm::packed_highp> relativePosition READ getRelativePosition WRITE setRelativePosition)
-    Q_PROPERTY(glm::vec<2,float,glm::packed_highp> size READ getSize WRITE setSize)
+    Q_PROPERTY(glm::vec2 relativePosition READ getRelativePosition WRITE setRelativePosition)
+    Q_PROPERTY(glm::vec2 size READ getSize WRITE setSize)
     Q_PROPERTY(bool visible READ isVisible WRITE setVisible)
     Q_PROPERTY(int presentationMode READ getPresentationMode WRITE setPresentationMode)
 
@@ -202,8 +202,8 @@ private:
     Q_INVOKABLE QString getTitle() const;
     Q_INVOKABLE void setTitle(const QString& title);
 
-    Q_INVOKABLE glm::vec<2,float,glm::packed_highp> getPosition() const;
-    Q_INVOKABLE void setPosition(const glm::vec<2,float,glm::packed_highp>& position);
+    Q_INVOKABLE glm::vec2 getPosition() const;
+    Q_INVOKABLE void setPosition(const glm::vec2& position);
     
     RelativePositionAnchor _relativePositionAnchor{ RelativePositionAnchor::NO_ANCHOR };
     Q_INVOKABLE RelativePositionAnchor getRelativePositionAnchor() const;
@@ -212,16 +212,16 @@ private:
     // This "relative position" is relative to the "relative position anchor" and excludes the window frame.
     // This position will ALWAYS include the geometry of a docked widget, if one is present.
     glm::vec2 _relativePosition{ 0.0f, 0.0f };
-    Q_INVOKABLE glm::vec<2,float,glm::packed_highp> getRelativePosition() const;
-    Q_INVOKABLE void setRelativePosition(const glm::vec<2,float,glm::packed_highp>& position);
+    Q_INVOKABLE glm::vec2 getRelativePosition() const;
+    Q_INVOKABLE void setRelativePosition(const glm::vec2& position);
 
     Q_INVOKABLE void setPositionUsingRelativePositionAndAnchor(const QRect& mainWindowGeometry);
 
     bool _isFullScreenWindow{ false };
     Q_INVOKABLE void repositionAndResizeFullScreenWindow();
 
-    Q_INVOKABLE glm::vec<2,float,glm::packed_highp> getSize() const;
-    Q_INVOKABLE void setSize(const glm::vec<2,float,glm::packed_highp>& size);
+    Q_INVOKABLE glm::vec2 getSize() const;
+    Q_INVOKABLE void setSize(const glm::vec2& size);
 
     Q_INVOKABLE void setVisible(bool visible);
     Q_INVOKABLE bool isVisible() const;

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -379,7 +379,7 @@ QUuid Overlays::getOverlayAtPoint(const glm::vec2& point) {
     if (QThread::currentThread() != thread()) {
         QUuid result;
         BLOCKING_INVOKE_METHOD(this, "getOverlayAtPoint", Q_GENERIC_RETURN_ARG(QUuid, result),
-            QArgument<const glm::vec<2,float,glm::packed_highp>& >("const glm::vec<2,float,glm::packed_highp>&", point));
+            Q_GENERIC_ARG(const glm::vec2&, point));
         return result;
     }
 

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -306,7 +306,7 @@ public slots:
      *     print("Clicked: " + overlay);
      * });
      */
-    QUuid getOverlayAtPoint(const glm::vec<2,float,glm::packed_highp>& point);
+    QUuid getOverlayAtPoint(const glm::vec2& point);
 
     /*@jsdoc
      * Finds the closest 3D overlay (or local entity) intersected by a {@link PickRay}.

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -371,7 +371,7 @@ public slots:
      * var overlaysFound = Overlays.findOverlays(MyAvatar.position, 5.0);
      * print("Overlays found: " + JSON.stringify(overlaysFound));
      */
-    QVector<QUuid> findOverlays(const glm::vec<3,float,glm::packed_highp>& center, float radius);
+    QVector<QUuid> findOverlays(const glm::vec3& center, float radius);
 
     /*@jsdoc
      * Checks whether an overlay's (or entity's) assets have been loaded. For example, for an

--- a/libraries/animation/src/AnimationObject.h
+++ b/libraries/animation/src/AnimationObject.h
@@ -76,7 +76,7 @@ public:
 /// Scriptable wrapper for animation frames.
 class AnimationFrameObject : public QObject, protected Scriptable {
     Q_OBJECT
-    Q_PROPERTY(QVector<glm::qua<float,glm::packed_highp>> rotations READ getRotations)
+    Q_PROPERTY(QVector<glm::quat> rotations READ getRotations)
 
 public:
     
@@ -85,7 +85,7 @@ public:
      * @function AnimationFrameObject.getRotations
      * @returns {Quat[]} The joint rotations in the animation frame.
      */
-    Q_INVOKABLE QVector<glm::qua<float,glm::packed_highp>> getRotations() const;
+    Q_INVOKABLE QVector<glm::quat> getRotations() const;
 };
 
 void registerAnimationTypes(ScriptEngine* engine);

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -151,7 +151,7 @@ public:
 
     void setIsPlayingBackRecording(bool isPlayingBackRecording) { _isPlayingBackRecording = isPlayingBackRecording; }
 
-    Q_INVOKABLE void setAvatarBoundingBoxParameters(glm::vec3 corner, glm::vec<3,float,glm::packed_highp> scale);
+    Q_INVOKABLE void setAvatarBoundingBoxParameters(glm::vec3 corner, glm::vec3 scale);
 
     bool outputLocalInjector(const AudioInjectorPointer& injector) override;
 

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -194,9 +194,9 @@ public:
     };
     virtual void indicateLoadingStatus(LoadingStatus loadingStatus) { _loadingStatus = loadingStatus; }
 
-    virtual QVector<glm::qua<float,glm::packed_highp>> getJointRotations() const override;
+    virtual QVector<glm::quat> getJointRotations() const override;
     using AvatarData::getJointRotation;
-    virtual glm::qua<float,glm::packed_highp> getJointRotation(int index) const override;
+    virtual glm::quat getJointRotation(int index) const override;
     virtual QVector<glm::vec3> getJointTranslations() const override;
     using AvatarData::getJointTranslation;
     virtual glm::vec3 getJointTranslation(int index) const override;
@@ -213,7 +213,7 @@ public:
      * @param {number} index - The joint index.
      * @returns {Quat} The default rotation of the joint if the joint index is valid, otherwise {@link Quat(0)|Quat.IDENTITY}.
      */
-    Q_INVOKABLE virtual glm::qua<float,glm::packed_highp> getDefaultJointRotation(int index) const;
+    Q_INVOKABLE virtual glm::quat getDefaultJointRotation(int index) const;
 
     /*@jsdoc
      * Gets the default translation of a joint (in the current avatar) relative to its parent, in model coordinates.
@@ -239,7 +239,7 @@ public:
      * var defaultHeadRotation = MyAvatar.getAbsoluteDefaultJointRotationInObjectFrame(headIndex);
      * print("Default head rotation: " + JSON.stringify(Quat.safeEulerAngles(defaultHeadRotation))); // Degrees
      */
-    Q_INVOKABLE virtual glm::qua<float,glm::packed_highp> getAbsoluteDefaultJointRotationInObjectFrame(int index) const;
+    Q_INVOKABLE virtual glm::quat getAbsoluteDefaultJointRotationInObjectFrame(int index) const;
 
     /*@jsdoc
      * Gets the default joint translations in avatar coordinates.
@@ -257,7 +257,7 @@ public:
 
 
     virtual glm::vec3 getAbsoluteJointScaleInObjectFrame(int index) const override;
-    virtual glm::qua<float,glm::packed_highp> getAbsoluteJointRotationInObjectFrame(int index) const override;
+    virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
     virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;
 
     /*@jsdoc
@@ -268,7 +268,7 @@ public:
      * @param {Quat} rotation - The rotation of the joint relative to the avatar. <em>Not used.</em>
      * @returns {boolean} <code>false</code>.
      */
-    virtual bool setAbsoluteJointRotationInObjectFrame(int index, const glm::qua<float,glm::packed_highp>& rotation) override { return false; }
+    virtual bool setAbsoluteJointRotationInObjectFrame(int index, const glm::quat& rotation) override { return false; }
 
     /*@jsdoc
      * Sets the translation of a joint relative to the avatar.
@@ -311,7 +311,7 @@ public:
      * @param {number} [jointIndex=-1] - The index of the joint.
      * @returns {Quat} The rotation in the joint's coordinate system, or avatar coordinate system if no joint is specified.
     */
-    Q_INVOKABLE glm::qua<float,glm::packed_highp> worldToJointRotation(const glm::qua<float,glm::packed_highp>& rotation, const int jointIndex = -1) const;
+    Q_INVOKABLE glm::quat worldToJointRotation(const glm::quat& rotation, const int jointIndex = -1) const;
 
     /*@jsdoc
      * Transforms a position in a joint's coordinates, or avatar coordinates if no joint is specified, to a position in world
@@ -341,7 +341,7 @@ public:
      * @param {number} [jointIndex=-1] - The index of the joint.
      * @returns {Quat} The rotation in world coordinates.
      */
-    Q_INVOKABLE glm::qua<float,glm::packed_highp> jointToWorldRotation(const glm::qua<float,glm::packed_highp>& rotation, const int jointIndex = -1) const;
+    Q_INVOKABLE glm::quat jointToWorldRotation(const glm::quat& rotation, const int jointIndex = -1) const;
 
     Q_INVOKABLE virtual void setSkeletonModelURL(const QUrl& skeletonModelURL) override;
 
@@ -417,7 +417,7 @@ public:
     void scaleVectorRelativeToPosition(glm::vec3& positionToScale) const;
 
     void slamPosition(const glm::vec3& position);
-    virtual void updateAttitude(const glm::qua<float,glm::packed_highp>& orientation) override;
+    virtual void updateAttitude(const glm::quat& orientation) override;
 
     // Call this when updating Avatar position with a delta.  This will allow us to
     // _accurately_ measure position changes and compute the resulting velocity
@@ -439,7 +439,7 @@ public:
     Q_INVOKABLE glm::vec3 getWorldFeetPosition();
 
     void setPositionViaScript(const glm::vec3& position) override;
-    void setOrientationViaScript(const glm::qua<float,glm::packed_highp>& orientation) override;
+    void setOrientationViaScript(const glm::quat& orientation) override;
 
     /*@jsdoc
      * Gets the ID of the entity or avatar that the avatar is parented to.
@@ -486,9 +486,9 @@ public:
 
     // NOT thread safe, must be called on main thread.
     glm::vec3 getUncachedLeftPalmPosition() const;
-    glm::qua<float,glm::packed_highp> getUncachedLeftPalmRotation() const;
+    glm::quat getUncachedLeftPalmRotation() const;
     glm::vec3 getUncachedRightPalmPosition() const;
-    glm::qua<float,glm::packed_highp> getUncachedRightPalmRotation() const;
+    glm::quat getUncachedRightPalmRotation() const;
 
     uint64_t getLastRenderUpdateTime() const { return _lastRenderUpdateTime; }
     void setLastRenderUpdateTime(uint64_t time) { _lastRenderUpdateTime = time; }
@@ -592,7 +592,7 @@ public slots:
      * @example <caption>Report the rotation of your avatar's left palm.</caption>
      * print(JSON.stringify(MyAvatar.getLeftPalmRotation()));
      */
-    glm::qua<float,glm::packed_highp> getLeftPalmRotation() const;
+    glm::quat getLeftPalmRotation() const;
 
     /*@jsdoc
      * Gets the position of the right palm in world coordinates.
@@ -610,7 +610,7 @@ public slots:
      * @example <caption>Report the rotation of your avatar's right palm.</caption>
      * print(JSON.stringify(MyAvatar.getRightPalmRotation()));
      */
-    glm::qua<float,glm::packed_highp> getRightPalmRotation() const;
+    glm::quat getRightPalmRotation() const;
 
     /*@jsdoc
      * @function MyAvatar.setModelURLFinished

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -136,7 +136,7 @@ class Avatar : public AvatarData, public scriptable::ModelProvider, public MetaM
      * @property {Vec3} skeletonOffset - Can be used to apply a translation offset between the avatar's position and the
      *     registration point of the 3D model.
      */
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> skeletonOffset READ getSkeletonOffset WRITE setSkeletonOffset)
+    Q_PROPERTY(glm::vec3 skeletonOffset READ getSkeletonOffset WRITE setSkeletonOffset)
 
 public:
     static void setShowAvatars(bool render);
@@ -225,7 +225,7 @@ public:
      * @returns {Vec3} The default translation of the joint (in model coordinates) if the joint index is valid, otherwise
      *     {@link Vec3(0)|Vec3.ZERO}.
      */
-    Q_INVOKABLE virtual glm::vec<3,float,glm::packed_highp> getDefaultJointTranslation(int index) const;
+    Q_INVOKABLE virtual glm::vec3 getDefaultJointTranslation(int index) const;
 
     /*@jsdoc
      * Gets the default joint rotations in avatar coordinates.
@@ -253,7 +253,7 @@ public:
      * var defaultHeadTranslation = MyAvatar.getAbsoluteDefaultJointTranslationInObjectFrame(headIndex);
      * print("Default head translation: " + JSON.stringify(defaultHeadTranslation));
      */
-    Q_INVOKABLE virtual glm::vec<3,float,glm::packed_highp> getAbsoluteDefaultJointTranslationInObjectFrame(int index) const;
+    Q_INVOKABLE virtual glm::vec3 getAbsoluteDefaultJointTranslationInObjectFrame(int index) const;
 
 
     virtual glm::vec3 getAbsoluteJointScaleInObjectFrame(int index) const override;
@@ -291,7 +291,7 @@ public:
      * @param {number} [jointIndex=-1] - The index of the joint.
      * @returns {Vec3} The position in the joint's coordinate system, or avatar coordinate system if no joint is specified.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> worldToJointPoint(const glm::vec<3,float,glm::packed_highp>& position, const int jointIndex = -1) const;
+    Q_INVOKABLE glm::vec3 worldToJointPoint(const glm::vec3& position, const int jointIndex = -1) const;
 
     /*@jsdoc
      * Transforms a direction in world coordinates to a direction in a joint's coordinates, or avatar coordinates if no joint
@@ -301,7 +301,7 @@ public:
      * @param {number} [jointIndex=-1] - The index of the joint.
      * @returns {Vec3} The direction in the joint's coordinate system, or avatar coordinate system if no joint is specified.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> worldToJointDirection(const glm::vec<3,float,glm::packed_highp>& direction, const int jointIndex = -1) const;
+    Q_INVOKABLE glm::vec3 worldToJointDirection(const glm::vec3& direction, const int jointIndex = -1) const;
 
     /*@jsdoc
      * Transforms a rotation in world coordinates to a rotation in a joint's coordinates, or avatar coordinates if no joint is
@@ -321,7 +321,7 @@ public:
      * @param {number} [jointIndex=-1] - The index of the joint.
      * @returns {Vec3} The position in world coordinates.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> jointToWorldPoint(const glm::vec<3,float,glm::packed_highp>& position, const int jointIndex = -1) const;
+    Q_INVOKABLE glm::vec3 jointToWorldPoint(const glm::vec3& position, const int jointIndex = -1) const;
 
     /*@jsdoc
      * Transforms a direction in a joint's coordinates, or avatar coordinates if no joint is specified, to a direction in world
@@ -331,7 +331,7 @@ public:
      * @param {number} [jointIndex=-1] - The index of the joint.
      * @returns {Vec3} The direction in world coordinates.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> jointToWorldDirection(const glm::vec<3,float,glm::packed_highp>& direction, const int jointIndex = -1) const;
+    Q_INVOKABLE glm::vec3 jointToWorldDirection(const glm::vec3& direction, const int jointIndex = -1) const;
 
     /*@jsdoc
      * Transforms a rotation in a joint's coordinates, or avatar coordinates if no joint is specified, to a rotation in world
@@ -364,7 +364,7 @@ public:
      *     MyAvatar.setSkeletonOffset(Vec3.ZERO);
      * }, 5000);
      */
-    Q_INVOKABLE void setSkeletonOffset(const glm::vec<3,float,glm::packed_highp>& offset);
+    Q_INVOKABLE void setSkeletonOffset(const glm::vec3& offset);
 
     /*@jsdoc
      * Gets the offset applied to the current avatar. The offset adjusts the position that the avatar is rendered. For example,
@@ -374,7 +374,7 @@ public:
      * @example <caption>Report your avatar's current skeleton offset.</caption>
      * print(JSON.stringify(MyAvatar.getSkeletonOffset()));
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getSkeletonOffset() { return _skeletonOffset; }
+    Q_INVOKABLE glm::vec3 getSkeletonOffset() { return _skeletonOffset; }
 
     virtual glm::vec3 getSkeletonPosition() const;
 
@@ -384,7 +384,7 @@ public:
      * @param {number} index - The index of the joint.
      * @returns {Vec3} The position of the joint in world coordinates.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getJointPosition(int index) const;
+    Q_INVOKABLE glm::vec3 getJointPosition(int index) const;
 
     /*@jsdoc
      * Gets the position of a joint in the current avatar.
@@ -394,7 +394,7 @@ public:
      * @example <caption>Report the position of your avatar's hips.</caption>
      * print(JSON.stringify(MyAvatar.getJointPosition("Hips")));
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getJointPosition(const QString& name) const;
+    Q_INVOKABLE glm::vec3 getJointPosition(const QString& name) const;
 
     /*@jsdoc
      * Gets the position of the current avatar's neck in world coordinates.
@@ -403,14 +403,14 @@ public:
      * @example <caption>Report the position of your avatar's neck.</caption>
      * print(JSON.stringify(MyAvatar.getNeckPosition()));
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getNeckPosition() const;
+    Q_INVOKABLE glm::vec3 getNeckPosition() const;
 
     /*@jsdoc
      * Gets the current acceleration of the avatar.
      * @function MyAvatar.getAcceleration
      * @returns {Vec3} The current acceleration of the avatar.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getAcceleration() const { return _acceleration; }
+    Q_INVOKABLE glm::vec3 getAcceleration() const { return _acceleration; }
 
     /// Scales a world space position vector relative to the avatar position and scale
     /// \param vector position to be scaled. Will store the result
@@ -436,7 +436,7 @@ public:
      * @function MyAvatar.getWorldFeetPosition
      * @returns {Vec3} The position of the avatar's feet in world coordinates.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getWorldFeetPosition();
+    Q_INVOKABLE glm::vec3 getWorldFeetPosition();
 
     void setPositionViaScript(const glm::vec3& position) override;
     void setOrientationViaScript(const glm::qua<float,glm::packed_highp>& orientation) override;
@@ -583,7 +583,7 @@ public slots:
      * @example <caption>Report the position of your avatar's left palm.</caption>
      * print(JSON.stringify(MyAvatar.getLeftPalmPosition()));
      */
-    glm::vec<3,float,glm::packed_highp> getLeftPalmPosition() const;
+    glm::vec3 getLeftPalmPosition() const;
 
     /*@jsdoc
      * Gets the rotation of the left palm in world coordinates.
@@ -601,7 +601,7 @@ public slots:
      * @example <caption>Report the position of your avatar's right palm.</caption>
      * print(JSON.stringify(MyAvatar.getRightPalmPosition()));
      */
-    glm::vec<3,float,glm::packed_highp> getRightPalmPosition() const;
+    glm::vec3 getRightPalmPosition() const;
 
     /*@jsdoc
      * Get the rotation of the right palm in world coordinates.

--- a/libraries/avatars-renderer/src/avatars-renderer/ScriptAvatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/ScriptAvatar.h
@@ -92,7 +92,7 @@ public slots:
      * @returns {Quat} The default rotation of the joint if avatar data are available and the joint index is valid, otherwise
      *     {@link Quat(0)|Quat.IDENTITY}.
      */
-    glm::qua<float,glm::packed_highp> getDefaultJointRotation(int index) const;
+    glm::quat getDefaultJointRotation(int index) const;
 
     /*@jsdoc
      * Gets the default translation of a joint in the avatar relative to its parent, in model coordinates.
@@ -199,7 +199,7 @@ public slots:
      * @returns {Quat} The rotation of the left palm in world coordinates, or {@link Quat(0)|Quat.IDENTITY} if the avatar data
      *     aren't available.
      */
-    glm::qua<float,glm::packed_highp> getLeftPalmRotation() const;
+    glm::quat getLeftPalmRotation() const;
 
     /*@jsdoc
      * Gets the position of the right palm in world coordinates.
@@ -215,7 +215,7 @@ public slots:
      * @returns {Quat} The rotation of the right palm in world coordinates, or {@link Quat(0)|Quat.IDENTITY} if the avatar data
      *     aren't available.
      */
-    glm::qua<float,glm::packed_highp> getRightPalmRotation() const;
+    glm::quat getRightPalmRotation() const;
 
 private:
     std::shared_ptr<Avatar> lockAvatar() const;

--- a/libraries/avatars-renderer/src/avatars-renderer/ScriptAvatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/ScriptAvatar.h
@@ -76,7 +76,7 @@
 class ScriptAvatar : public ScriptAvatarData {
     Q_OBJECT
 
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> skeletonOffset READ getSkeletonOffset)
+    Q_PROPERTY(glm::vec3 skeletonOffset READ getSkeletonOffset)
 
 public:
     ScriptAvatar(AvatarSharedPointer avatarData);
@@ -104,7 +104,7 @@ public slots:
      * @returns {Vec3} The default translation of the joint (in model coordinates) if avatar data are available and the joint
      *     index is valid, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    glm::vec<3,float,glm::packed_highp> getDefaultJointTranslation(int index) const;
+    glm::vec3 getDefaultJointTranslation(int index) const;
 
 
     /*@jsdoc
@@ -112,7 +112,7 @@ public slots:
      * @function ScriptAvatar.getSkeletonOffset
      * @returns {Vec3} The skeleton offset if avatar data are available, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    glm::vec<3,float,glm::packed_highp> getSkeletonOffset() const;
+    glm::vec3 getSkeletonOffset() const;
 
 
     /*@jsdoc
@@ -122,7 +122,7 @@ public slots:
      * @returns {Vec3} The position of the joint in world coordinates, or {@link Vec3(0)|Vec3.ZERO} if avatar data aren't
      *     available.
      */
-    glm::vec<3,float,glm::packed_highp> getJointPosition(int index) const;
+    glm::vec3 getJointPosition(int index) const;
 
     /*@jsdoc
      * Gets the position of a joint in the current avatar.
@@ -131,7 +131,7 @@ public slots:
      * @returns {Vec3} The position of the joint in world coordinates, or {@link Vec3(0)|Vec3.ZERO} if avatar data aren't
      *     available.
      */
-    glm::vec<3,float,glm::packed_highp> getJointPosition(const QString& name) const;
+    glm::vec3 getJointPosition(const QString& name) const;
 
     /*@jsdoc
      * Gets the position of the current avatar's neck in world coordinates.
@@ -139,7 +139,7 @@ public slots:
      * @returns {Vec3} The position of the neck in world coordinates, or {@link Vec3(0)|Vec3.ZERO} if avatar data aren't
      *     available.
      */
-    glm::vec<3,float,glm::packed_highp> getNeckPosition() const;
+    glm::vec3 getNeckPosition() const;
 
 
     /*@jsdoc
@@ -147,7 +147,7 @@ public slots:
      * @function ScriptAvatar.getAcceleration
      * @returns {Vec3} The current acceleration of the avatar, or {@link Vec3(0)|Vec3.ZERO} if avatar data aren't available..
      */
-    glm::vec<3,float,glm::packed_highp> getAcceleration() const;
+    glm::vec3 getAcceleration() const;
 
 
     /*@jsdoc
@@ -191,7 +191,7 @@ public slots:
      * @returns {Vec3} The position of the left palm in world coordinates, or {@link Vec3(0)|Vec3.ZERO} if avatar data aren't
      *     available.
      */
-    glm::vec<3,float,glm::packed_highp> getLeftPalmPosition() const;
+    glm::vec3 getLeftPalmPosition() const;
 
     /*@jsdoc
      * Gets the rotation of the left palm in world coordinates.
@@ -207,7 +207,7 @@ public slots:
      * @returns {Vec3} The position of the right palm in world coordinates, or {@link Vec3(0)|Vec3.ZERO} if avatar data aren't
      *     available.
      */
-    glm::vec<3,float,glm::packed_highp> getRightPalmPosition() const;
+    glm::vec3 getRightPalmPosition() const;
 
     /*@jsdoc
      * Gets the rotation of the right palm in world coordinates.

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -559,8 +559,8 @@ class AvatarData : public QObject, public SpatiallyNestable {
     Q_PROPERTY(float bodyPitch READ getBodyPitch WRITE setBodyPitch)
     Q_PROPERTY(float bodyRoll READ getBodyRoll WRITE setBodyRoll)
 
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> orientation READ getWorldOrientation WRITE setOrientationViaScript)
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> headOrientation READ getHeadOrientation WRITE setHeadOrientation)
+    Q_PROPERTY(glm::quat orientation READ getWorldOrientation WRITE setOrientationViaScript)
+    Q_PROPERTY(glm::quat headOrientation READ getHeadOrientation WRITE setHeadOrientation)
     Q_PROPERTY(float headPitch READ getHeadPitch WRITE setHeadPitch)
     Q_PROPERTY(float headYaw READ getHeadYaw WRITE setHeadYaw)
     Q_PROPERTY(float headRoll READ getHeadRoll WRITE setHeadRoll)
@@ -805,7 +805,7 @@ public:
      *
      * // Note: If using from the Avatar API, replace all occurrences of "MyAvatar" with "Avatar".
      */
-    Q_INVOKABLE virtual void setJointData(int index, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& translation);
+    Q_INVOKABLE virtual void setJointData(int index, const glm::quat& rotation, const glm::vec3& translation);
 
     /*@jsdoc
      * Sets a specific joint's rotation relative to its parent.
@@ -818,7 +818,7 @@ public:
      * @param {number} index - The index of the joint.
      * @param {Quat} rotation - The rotation of the joint relative to its parent.
      */
-    Q_INVOKABLE virtual void setJointRotation(int index, const glm::qua<float,glm::packed_highp>& rotation);
+    Q_INVOKABLE virtual void setJointRotation(int index, const glm::quat& rotation);
 
     /*@jsdoc
      * Sets a specific joint's translation relative to its parent, in model coordinates.
@@ -858,7 +858,7 @@ public:
      * @param {number} index - The index of the joint.
      * @returns {Quat} The rotation of the joint relative to its parent.
      */
-    Q_INVOKABLE virtual glm::qua<float,glm::packed_highp> getJointRotation(int index) const;
+    Q_INVOKABLE virtual glm::quat getJointRotation(int index) const;
 
     /*@jsdoc
      * Gets the translation of a joint relative to its parent, in model coordinates.
@@ -884,7 +884,7 @@ public:
      * @param {Quat} rotation - The rotation of the joint relative to its parent.
      * @param {Vec3} translation - The translation of the joint relative to its parent, in model coordinates.
      */
-    Q_INVOKABLE virtual void setJointData(const QString& name, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& translation);
+    Q_INVOKABLE virtual void setJointData(const QString& name, const glm::quat& rotation, const glm::vec3& translation);
 
     /*@jsdoc
      * Sets a specific joint's rotation relative to its parent.
@@ -917,7 +917,7 @@ public:
      *
      * // Note: If using from the Avatar API, replace all occurrences of "MyAvatar" with "Avatar".
      */
-    Q_INVOKABLE virtual void setJointRotation(const QString& name, const glm::qua<float,glm::packed_highp>& rotation);
+    Q_INVOKABLE virtual void setJointRotation(const QString& name, const glm::quat& rotation);
 
     /*@jsdoc
      * Sets a specific joint's translation relative to its parent, in model coordinates.
@@ -983,7 +983,7 @@ public:
      *
      * // Note: If using from the Avatar API, replace "MyAvatar" with "Avatar".
      */
-    Q_INVOKABLE virtual glm::qua<float,glm::packed_highp> getJointRotation(const QString& name) const;
+    Q_INVOKABLE virtual glm::quat getJointRotation(const QString& name) const;
 
     /*@jsdoc
      * Gets the translation of a joint relative to its parent, in model coordinates.
@@ -1010,7 +1010,7 @@ public:
      *
      * // Note: If using from the Avatar API, replace all "MyAvatar" with "Avatar".
      */
-    Q_INVOKABLE virtual QVector<glm::qua<float,glm::packed_highp>> getJointRotations() const;
+    Q_INVOKABLE virtual QVector<glm::quat> getJointRotations() const;
 
     /*@jsdoc
      * Gets the translations of all joints in the current avatar. Each joint's translation is relative to its parent joint, in
@@ -1059,7 +1059,7 @@ public:
      *
      * // Note: If using from the Avatar API, replace all occurrences of "MyAvatar" with "Avatar".
      */
-    Q_INVOKABLE virtual void setJointRotations(const QVector<glm::qua<float,glm::packed_highp>>& jointRotations);
+    Q_INVOKABLE virtual void setJointRotations(const QVector<glm::quat>& jointRotations);
 
     /*@jsdoc
      * Sets the translations of all joints in the current avatar. Each joint's translation is relative to its parent joint, in
@@ -1496,7 +1496,7 @@ public slots:
      * @param {number} index - The index of the joint. <em>Not used.</em>
      * @returns {Quat} <code>Quat.IDENTITY</code>.
      */
-    virtual glm::qua<float,glm::packed_highp> getAbsoluteJointRotationInObjectFrame(int index) const override;
+    virtual glm::quat getAbsoluteJointRotationInObjectFrame(int index) const override;
 
     /*@jsdoc
      * Gets the translation of a joint relative to the avatar.
@@ -1515,7 +1515,7 @@ public slots:
      * @param {Quat} rotation - The rotation of the joint relative to the avatar. <em>Not used.</em>
      * @returns {boolean} <code>false</code>.
      */
-    virtual bool setAbsoluteJointRotationInObjectFrame(int index, const glm::qua<float,glm::packed_highp>& rotation) override { return false; }
+    virtual bool setAbsoluteJointRotationInObjectFrame(int index, const glm::quat& rotation) override { return false; }
 
     /*@jsdoc
      * Sets the translation of a joint relative to the avatar.

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -551,10 +551,10 @@ class AvatarData : public QObject, public SpatiallyNestable {
      *     this property to <code>false</code> to fully control the mouth facial blend shapes via the
      *     {@link Avatar.setBlendshape} method.
      */
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> position READ getWorldPosition WRITE setPositionViaScript)
+    Q_PROPERTY(glm::vec3 position READ getWorldPosition WRITE setPositionViaScript)
     Q_PROPERTY(float scale READ getDomainLimitedScale WRITE setTargetScale)
     Q_PROPERTY(float density READ getDensity)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> handPosition READ getHandPosition WRITE setHandPosition)
+    Q_PROPERTY(glm::vec3 handPosition READ getHandPosition WRITE setHandPosition)
     Q_PROPERTY(float bodyYaw READ getBodyYaw WRITE setBodyYaw)
     Q_PROPERTY(float bodyPitch READ getBodyPitch WRITE setBodyPitch)
     Q_PROPERTY(float bodyRoll READ getBodyRoll WRITE setBodyRoll)
@@ -565,8 +565,8 @@ class AvatarData : public QObject, public SpatiallyNestable {
     Q_PROPERTY(float headYaw READ getHeadYaw WRITE setHeadYaw)
     Q_PROPERTY(float headRoll READ getHeadRoll WRITE setHeadRoll)
 
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> velocity READ getWorldVelocity WRITE setWorldVelocity)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> angularVelocity READ getWorldAngularVelocity WRITE setWorldAngularVelocity)
+    Q_PROPERTY(glm::vec3 velocity READ getWorldVelocity WRITE setWorldVelocity)
+    Q_PROPERTY(glm::vec3 angularVelocity READ getWorldAngularVelocity WRITE setWorldAngularVelocity)
 
     Q_PROPERTY(float audioLoudness READ getAudioLoudness WRITE setAudioLoudness)
     Q_PROPERTY(float audioAverageLoudness READ getAudioAverageLoudness WRITE setAudioAverageLoudness)
@@ -612,7 +612,7 @@ public:
 
     const QUuid getSessionUUID() const { return getID(); }
 
-    glm::vec<3,float,glm::packed_highp> getHandPosition() const;
+    glm::vec3 getHandPosition() const;
     void setHandPosition(const glm::vec3& handPosition);
 
     typedef enum {
@@ -805,7 +805,7 @@ public:
      *
      * // Note: If using from the Avatar API, replace all occurrences of "MyAvatar" with "Avatar".
      */
-    Q_INVOKABLE virtual void setJointData(int index, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& translation);
+    Q_INVOKABLE virtual void setJointData(int index, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& translation);
 
     /*@jsdoc
      * Sets a specific joint's rotation relative to its parent.
@@ -832,7 +832,7 @@ public:
      * @param {number} index - The index of the joint.
      * @param {Vec3} translation - The translation of the joint relative to its parent, in model coordinates.
      */
-    Q_INVOKABLE virtual void setJointTranslation(int index, const glm::vec<3,float,glm::packed_highp>& translation);
+    Q_INVOKABLE virtual void setJointTranslation(int index, const glm::vec3& translation);
 
     /*@jsdoc
      * Clears joint translations and rotations set by script for a specific joint. This restores all motion from the default
@@ -869,7 +869,7 @@ public:
      * @param {number} index - The index of the joint.
      * @returns {Vec3} The translation of the joint relative to its parent, in model coordinates.
      */
-    Q_INVOKABLE virtual glm::vec<3,float,glm::packed_highp> getJointTranslation(int index) const;
+    Q_INVOKABLE virtual glm::vec3 getJointTranslation(int index) const;
 
     /*@jsdoc
      * Sets a specific joint's rotation and position relative to its parent, in model coordinates.
@@ -884,7 +884,7 @@ public:
      * @param {Quat} rotation - The rotation of the joint relative to its parent.
      * @param {Vec3} translation - The translation of the joint relative to its parent, in model coordinates.
      */
-    Q_INVOKABLE virtual void setJointData(const QString& name, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& translation);
+    Q_INVOKABLE virtual void setJointData(const QString& name, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& translation);
 
     /*@jsdoc
      * Sets a specific joint's rotation relative to its parent.
@@ -943,7 +943,7 @@ public:
      *
      * // Note: If using from the Avatar API, replace all occurrences of "MyAvatar" with "Avatar".
      */
-    Q_INVOKABLE virtual void setJointTranslation(const QString& name, const glm::vec<3,float,glm::packed_highp>& translation);
+    Q_INVOKABLE virtual void setJointTranslation(const QString& name, const glm::vec3& translation);
 
     /*@jsdoc
      * Clears joint translations and rotations set by script for a specific joint. This restores all motion from the default
@@ -998,7 +998,7 @@ public:
      *
      * // Note: If using from the Avatar API, replace "MyAvatar" with "Avatar".
      */
-    Q_INVOKABLE virtual glm::vec<3,float,glm::packed_highp> getJointTranslation(const QString& name) const;
+    Q_INVOKABLE virtual glm::vec3 getJointTranslation(const QString& name) const;
 
     /*@jsdoc
      * Gets the rotations of all joints in the current avatar. Each joint's rotation is relative to its parent joint.
@@ -1021,7 +1021,7 @@ public:
      *     same order as the array returned by {@link MyAvatar.getJointNames}, or {@link Avatar.getJointNames} if using the
      *     <code>Avatar</code> API.
      */
-    Q_INVOKABLE virtual QVector<glm::vec<3,float,glm::packed_highp>> getJointTranslations() const;
+    Q_INVOKABLE virtual QVector<glm::vec3> getJointTranslations() const;
 
     /*@jsdoc
      * Sets the rotations of all joints in the current avatar. Each joint's rotation is relative to its parent joint.
@@ -1075,7 +1075,7 @@ public:
      *     the same order as the array returned by {@link MyAvatar.getJointNames}, or {@link Avatar.getJointNames} if using the
      *     <code>Avatar</code> API.
      */
-    Q_INVOKABLE virtual void setJointTranslations(const QVector<glm::vec<3,float,glm::packed_highp>>& jointTranslations);
+    Q_INVOKABLE virtual void setJointTranslations(const QVector<glm::vec3>& jointTranslations);
 
     /*@jsdoc
      * Clears all joint translations and rotations that have been set by script. This restores all motion from the default
@@ -1505,7 +1505,7 @@ public slots:
      * @param {number} index - The index of the joint. <em>Not used.</em>
      * @returns {Vec3} <code>Vec3.ZERO</code>.
      */
-    virtual glm::vec<3,float,glm::packed_highp> getAbsoluteJointTranslationInObjectFrame(int index) const override;
+    virtual glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const override;
 
     /*@jsdoc
      * Sets the rotation of a joint relative to the avatar.
@@ -1525,7 +1525,7 @@ public slots:
      * @param {Vec3} translation - The translation of the joint relative to the avatar. <em>Not used.</em>
      * @returns {boolean} <code>false</code>.
      */
-    virtual bool setAbsoluteJointTranslationInObjectFrame(int index, const glm::vec<3,float,glm::packed_highp>& translation) override { return false; }
+    virtual bool setAbsoluteJointTranslationInObjectFrame(int index, const glm::vec3& translation) override { return false; }
 
     /*@jsdoc
      * Gets the target scale of the avatar without any restrictions on permissible values imposed by the domain. In contrast, the

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -582,9 +582,9 @@ class AvatarData : public QObject, public SpatiallyNestable {
 
     Q_PROPERTY(QUuid sessionUUID READ getSessionUUID NOTIFY sessionUUIDChanged)
 
-    Q_PROPERTY(glm::mat<4,4,float,glm::packed_highp> sensorToWorldMatrix READ getSensorToWorldMatrix)
-    Q_PROPERTY(glm::mat<4,4,float,glm::packed_highp> controllerLeftHandMatrix READ getControllerLeftHandMatrix)
-    Q_PROPERTY(glm::mat<4,4,float,glm::packed_highp> controllerRightHandMatrix READ getControllerRightHandMatrix)
+    Q_PROPERTY(glm::mat4 sensorToWorldMatrix READ getSensorToWorldMatrix)
+    Q_PROPERTY(glm::mat4 controllerLeftHandMatrix READ getControllerLeftHandMatrix)
+    Q_PROPERTY(glm::mat4 controllerRightHandMatrix READ getControllerRightHandMatrix)
 
     Q_PROPERTY(float sensorToWorldScale READ getSensorToWorldScale)
 
@@ -1293,7 +1293,7 @@ public:
      * // Note: If using from the Avatar API, replace "MyAvatar" with "Avatar".
      */
     // thread safe
-    Q_INVOKABLE glm::mat<4,4,float,glm::packed_highp> getSensorToWorldMatrix() const;
+    Q_INVOKABLE glm::mat4 getSensorToWorldMatrix() const;
 
     /*@jsdoc
      * Gets the scale that transforms dimensions in the user's real world to the avatar's size in the virtual world.
@@ -1318,7 +1318,7 @@ public:
      * // Note: If using from the Avatar API, replace "MyAvatar" with "Avatar".
      */
     // thread safe
-    Q_INVOKABLE glm::mat<4,4,float,glm::packed_highp> getControllerLeftHandMatrix() const;
+    Q_INVOKABLE glm::mat4 getControllerLeftHandMatrix() const;
 
     /*@jsdoc
      * Gets the rotation and translation of the right hand controller relative to the avatar.
@@ -1326,7 +1326,7 @@ public:
      * @returns {Mat4} The rotation and translation of the right hand controller relative to the avatar.
      */
     // thread safe
-    Q_INVOKABLE glm::mat<4,4,float,glm::packed_highp> getControllerRightHandMatrix() const;
+    Q_INVOKABLE glm::mat4 getControllerRightHandMatrix() const;
 
 
     /*@jsdoc

--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -105,7 +105,7 @@ public:
      * var avatars = AvatarList.getAvatarsInRange(Vec3.ZERO, RANGE);
      * print("Avatars near the origin: " + JSON.stringify(avatars));
      */
-    Q_INVOKABLE QVector<QUuid> getAvatarsInRange(const glm::vec<3,float,glm::packed_highp>& position, float rangeMeters) const;
+    Q_INVOKABLE QVector<QUuid> getAvatarsInRange(const glm::vec3& position, float rangeMeters) const;
 
     /*@jsdoc
      * Gets information about an avatar.
@@ -179,7 +179,7 @@ public slots:
      * @returns {boolean} <code>true</code> if there's an avatar within the specified distance of the point, <code>false</code> 
      *     if not.
      */
-    bool isAvatarInRange(const glm::vec<3,float,glm::packed_highp> & position, const float range);
+    bool isAvatarInRange(const glm::vec3 & position, const float range);
 
 protected slots:
 

--- a/libraries/avatars/src/ScriptAvatarData.h
+++ b/libraries/avatars/src/ScriptAvatarData.h
@@ -29,8 +29,8 @@ class ScriptAvatarData : public QObject {
     Q_PROPERTY(float bodyPitch READ getBodyPitch)
     Q_PROPERTY(float bodyYaw READ getBodyYaw)
     Q_PROPERTY(float bodyRoll READ getBodyRoll)
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> orientation READ getOrientation)
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> headOrientation READ getHeadOrientation)
+    Q_PROPERTY(glm::quat orientation READ getOrientation)
+    Q_PROPERTY(glm::quat headOrientation READ getHeadOrientation)
     Q_PROPERTY(float headPitch READ getHeadPitch)
     Q_PROPERTY(float headYaw READ getHeadYaw)
     Q_PROPERTY(float headRoll READ getHeadRoll)
@@ -82,8 +82,8 @@ public:
     float getBodyPitch() const;
     float getBodyYaw() const;
     float getBodyRoll() const;
-    glm::qua<float,glm::packed_highp> getOrientation() const;
-    glm::qua<float,glm::packed_highp> getHeadOrientation() const;
+    glm::quat getOrientation() const;
+    glm::quat getHeadOrientation() const;
     float getHeadPitch() const;
     float getHeadYaw() const;
     float getHeadRoll() const;
@@ -123,7 +123,7 @@ public:
      * @returns {Quat} The rotation of the joint relative to its parent, or {@link Quat(0)|Quat.IDENTITY} if the avatar data
      *     aren't available.
      */
-    Q_INVOKABLE glm::qua<float,glm::packed_highp> getJointRotation(int index) const;
+    Q_INVOKABLE glm::quat getJointRotation(int index) const;
 
     /*@jsdoc
      * Gets the translation of a joint relative to its parent, in model coordinates.
@@ -145,7 +145,7 @@ public:
      * @returns {Quat} The rotation of the joint relative to its parent, or {@link Quat(0)|Quat.IDENTITY} if the avatar data
      *     aren't available.
      */
-    Q_INVOKABLE glm::qua<float,glm::packed_highp> getJointRotation(const QString& name) const;
+    Q_INVOKABLE glm::quat getJointRotation(const QString& name) const;
 
     /*@jsdoc
      * Gets the translation of a joint relative to its parent, in model coordinates.
@@ -165,7 +165,7 @@ public:
      * @returns {Quat[]} The rotations of all joints relative to each's parent, or <code>[]</code> if the avatar data aren't
      *     available. The values are in the same order as the array returned by {@link ScriptAvatar.getJointNames}.
      */
-    Q_INVOKABLE QVector<glm::qua<float,glm::packed_highp>> getJointRotations() const;
+    Q_INVOKABLE QVector<glm::quat> getJointRotations() const;
 
     /*@jsdoc
      * Gets the translations of all joints in the avatar. Each joint's translation is relative to its parent joint, in
@@ -262,7 +262,7 @@ public slots:
      * @returns {Quat} The rotation of the joint relative to the avatar, or {@link Quat(0)|Quat.IDENTITY} if the avatar data
      *     aren't available.
      */
-    glm::qua<float,glm::packed_highp> getAbsoluteJointRotationInObjectFrame(int index) const;
+    glm::quat getAbsoluteJointRotationInObjectFrame(int index) const;
 
     /*@jsdoc
      * Gets the translation of a joint relative to the avatar.

--- a/libraries/avatars/src/ScriptAvatarData.h
+++ b/libraries/avatars/src/ScriptAvatarData.h
@@ -23,9 +23,9 @@ class ScriptAvatarData : public QObject {
     //
     // PHYSICAL PROPERTIES: POSITION AND ORIENTATION
     //
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> position READ getPosition)
+    Q_PROPERTY(glm::vec3 position READ getPosition)
     Q_PROPERTY(float scale READ getTargetScale)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> handPosition READ getHandPosition)
+    Q_PROPERTY(glm::vec3 handPosition READ getHandPosition)
     Q_PROPERTY(float bodyPitch READ getBodyPitch)
     Q_PROPERTY(float bodyYaw READ getBodyYaw)
     Q_PROPERTY(float bodyRoll READ getBodyRoll)
@@ -37,8 +37,8 @@ class ScriptAvatarData : public QObject {
     //
     // PHYSICAL PROPERTIES: VELOCITY
     //
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> velocity READ getVelocity)
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> angularVelocity READ getAngularVelocity)
+    Q_PROPERTY(glm::vec3 velocity READ getVelocity)
+    Q_PROPERTY(glm::vec3 angularVelocity READ getAngularVelocity)
 
     //
     // IDENTIFIER PROPERTIES
@@ -135,7 +135,7 @@ public:
      * @returns {Vec3} The translation of the joint relative to its parent, in model coordinates, or {@link Vec3(0)|Vec3.ZERO}
      *     if the avatar data aren't available.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getJointTranslation(int index) const;
+    Q_INVOKABLE glm::vec3 getJointTranslation(int index) const;
 
     /*@jsdoc
      * Gets the rotation of a joint relative to its parent. For information on the joint hierarchy used, see
@@ -157,7 +157,7 @@ public:
      * @returns {Vec3} The translation of the joint relative to its parent, in model coordinates, or {@link Vec3(0)|Vec3.ZERO}
      *     if the avatar data aren't available.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getJointTranslation(const QString& name) const;
+    Q_INVOKABLE glm::vec3 getJointTranslation(const QString& name) const;
 
     /*@jsdoc
      * Gets the rotations of all joints in the avatar. Each joint's rotation is relative to its parent joint.
@@ -176,7 +176,7 @@ public:
      *     the avatar data aren't available. The values are in the same order as the array returned by
      *     {@link ScriptAvatar.getJointNames}.
      */
-    Q_INVOKABLE QVector<glm::vec<3,float,glm::packed_highp>> getJointTranslations() const;
+    Q_INVOKABLE QVector<glm::vec3> getJointTranslations() const;
 
     /*@jsdoc
      * Checks that the data for a joint are valid.
@@ -271,7 +271,7 @@ public slots:
      * @returns {Vec3} The translation of the joint relative to the avatar, or {@link Vec3(0)|Vec3.ZERO} if the avatar data
      *     aren't available.
      */
-    glm::vec<3,float,glm::packed_highp> getAbsoluteJointTranslationInObjectFrame(int index) const;
+    glm::vec3 getAbsoluteJointTranslationInObjectFrame(int index) const;
 
 protected:
     std::weak_ptr<AvatarData> _avatarData;

--- a/libraries/avatars/src/ScriptAvatarData.h
+++ b/libraries/avatars/src/ScriptAvatarData.h
@@ -64,9 +64,9 @@ class ScriptAvatarData : public QObject {
     //
     // MATRIX PROPERTIES
     //
-    Q_PROPERTY(glm::mat<4,4,float,glm::packed_highp> sensorToWorldMatrix READ getSensorToWorldMatrix)
-    Q_PROPERTY(glm::mat<4,4,float,glm::packed_highp> controllerLeftHandMatrix READ getControllerLeftHandMatrix)
-    Q_PROPERTY(glm::mat<4,4,float,glm::packed_highp> controllerRightHandMatrix READ getControllerRightHandMatrix)
+    Q_PROPERTY(glm::mat4 sensorToWorldMatrix READ getSensorToWorldMatrix)
+    Q_PROPERTY(glm::mat4 controllerLeftHandMatrix READ getControllerLeftHandMatrix)
+    Q_PROPERTY(glm::mat4 controllerRightHandMatrix READ getControllerRightHandMatrix)
 
     Q_PROPERTY(bool hasPriority READ getHasPriority)
 
@@ -216,9 +216,9 @@ public:
     //
     // MATRIX PROPERTIES
     //
-    glm::mat<4,4,float,glm::packed_highp> getSensorToWorldMatrix() const;
-    glm::mat<4,4,float,glm::packed_highp> getControllerLeftHandMatrix() const;
-    glm::mat<4,4,float,glm::packed_highp> getControllerRightHandMatrix() const;
+    glm::mat4 getSensorToWorldMatrix() const;
+    glm::mat4 getControllerLeftHandMatrix() const;
+    glm::mat4 getControllerRightHandMatrix() const;
 
     bool getHasPriority() const;
 

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -53,9 +53,9 @@ namespace controller {
     public slots:
         virtual bool isActive() const = 0;
         virtual glm::vec3 getAbsTranslation() const = 0;
-        virtual glm::qua<float,glm::packed_highp> getAbsRotation() const = 0;
+        virtual glm::quat getAbsRotation() const = 0;
         virtual glm::vec3 getLocTranslation() const = 0;
-        virtual glm::qua<float,glm::packed_highp> getLocRotation() const = 0;
+        virtual glm::quat getLocRotation() const = 0;
 
     signals:
         //void spatialEvent(const SpatialEvent& event);

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -52,9 +52,9 @@ namespace controller {
 
     public slots:
         virtual bool isActive() const = 0;
-        virtual glm::vec<3,float,glm::packed_highp> getAbsTranslation() const = 0;
+        virtual glm::vec3 getAbsTranslation() const = 0;
         virtual glm::qua<float,glm::packed_highp> getAbsRotation() const = 0;
-        virtual glm::vec<3,float,glm::packed_highp> getLocTranslation() const = 0;
+        virtual glm::vec3 getLocTranslation() const = 0;
         virtual glm::qua<float,glm::packed_highp> getLocRotation() const = 0;
 
     signals:

--- a/libraries/controllers/src/controllers/impl/RouteBuilderProxy.h
+++ b/libraries/controllers/src/controllers/impl/RouteBuilderProxy.h
@@ -376,7 +376,7 @@ class RouteBuilderProxy : public QObject {
          * @returns {RouteObject} The <code>RouteObject</code> with the pre-translation applied.
          */
         // No JSDoc example because filter not currently used.
-        Q_INVOKABLE QObject* translate(glm::vec<3,float,glm::packed_highp> translate);
+        Q_INVOKABLE QObject* translate(glm::vec3 translate);
 
         /*@jsdoc
          * Filters {@link Pose} route values to have a pre-transform applied.

--- a/libraries/controllers/src/controllers/impl/RouteBuilderProxy.h
+++ b/libraries/controllers/src/controllers/impl/RouteBuilderProxy.h
@@ -403,7 +403,7 @@ class RouteBuilderProxy : public QObject {
          * @returns {RouteObject} The <code>RouteObject</code> with the pre-rotation applied.
          */
         // No JSDoc example because filter not currently used.
-        Q_INVOKABLE QObject* rotate(glm::qua<float,glm::packed_highp> rotation);
+        Q_INVOKABLE QObject* rotate(glm::quat rotation);
 
         /*@jsdoc
          * Filters {@link Pose} route values to be smoothed by a low velocity filter. The filter's rotation and translation 

--- a/libraries/controllers/src/controllers/impl/RouteBuilderProxy.h
+++ b/libraries/controllers/src/controllers/impl/RouteBuilderProxy.h
@@ -385,7 +385,7 @@ class RouteBuilderProxy : public QObject {
          * @returns {RouteObject} The <code>RouteObject</code> with the pre-transform applied.
          */
         // No JSDoc example because filter not currently used.
-        Q_INVOKABLE QObject* transform(glm::mat<4,4,float,glm::packed_highp> transform);
+        Q_INVOKABLE QObject* transform(glm::mat4 transform);
 
         /*@jsdoc
          * Filters {@link Pose} route values to have a post-transform applied.
@@ -394,7 +394,7 @@ class RouteBuilderProxy : public QObject {
          * @returns {RouteObject} The <code>RouteObject</code> with the post-transform applied.
          */
         // No JSDoc example because filter not currently used.
-        Q_INVOKABLE QObject* postTransform(glm::mat<4,4,float,glm::packed_highp> transform);
+        Q_INVOKABLE QObject* postTransform(glm::mat4 transform);
 
         /*@jsdoc
          * Filters {@link Pose} route values to have a pre-rotation applied.

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.h
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.h
@@ -215,7 +215,7 @@ class ReticleInterface : public QObject {
     Q_PROPERTY(bool visible READ getVisible WRITE setVisible)
     Q_PROPERTY(float depth READ getDepth WRITE setDepth)
     Q_PROPERTY(float scale READ getScale WRITE setScale)
-    Q_PROPERTY(glm::vec<2,float,glm::packed_highp> maximumPosition READ getMaximumPosition)
+    Q_PROPERTY(glm::vec2 maximumPosition READ getMaximumPosition)
     Q_PROPERTY(bool mouseCaptured READ isMouseCaptured)
     Q_PROPERTY(bool allowMouseCapture READ getAllowMouseCapture WRITE setAllowMouseCapture)
     Q_PROPERTY(bool pointingAtSystemOverlay READ isPointingAtSystemOverlay)
@@ -333,7 +333,7 @@ public:
      * @function Reticle.getMaximumPosition
      * @returns {Vec2} The maximum reticle coordinates on the display device in desktop mode or the HUD surface in HMD mode.
      */
-    Q_INVOKABLE glm::vec<2,float,glm::packed_highp> getMaximumPosition() { return _compositor->getReticleMaximumPosition(); }
+    Q_INVOKABLE glm::vec2 getMaximumPosition() { return _compositor->getReticleMaximumPosition(); }
 
 private:
     CompositorHelper* _compositor;

--- a/libraries/entities-renderer/src/ModelScriptingInterface.h
+++ b/libraries/entities-renderer/src/ModelScriptingInterface.h
@@ -82,8 +82,8 @@ public:
      * @param {MeshFace[]} faces - The faces in the mesh.
      * @returns {MeshProxy} A new mesh.
      */
-    Q_INVOKABLE ScriptValue newMesh(const QVector<glm::vec<3,float,glm::packed_highp>>& vertices,
-                                     const QVector<glm::vec<3,float,glm::packed_highp>>& normals,
+    Q_INVOKABLE ScriptValue newMesh(const QVector<glm::vec3>& vertices,
+                                     const QVector<glm::vec3>& normals,
                                      const QVector<MeshFace>& faces);
 
     /*@jsdoc

--- a/libraries/entities-renderer/src/ModelScriptingInterface.h
+++ b/libraries/entities-renderer/src/ModelScriptingInterface.h
@@ -72,7 +72,7 @@ public:
      * @param {MeshProxy} mesh - The mesh to apply the transform to.
      * @returns {MeshProxy|boolean} The transformed mesh, if valid. <code>false</code> if an error.
      */
-    Q_INVOKABLE ScriptValue transformMesh(glm::mat<4,4,float,glm::packed_highp> transform, MeshProxy* meshProxy);
+    Q_INVOKABLE ScriptValue transformMesh(glm::mat4 transform, MeshProxy* meshProxy);
 
     /*@jsdoc
      * Creates a new mesh.

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -1477,7 +1477,7 @@ public slots:
      * }, 2000);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE glm::qua<float,glm::packed_highp> getAbsoluteJointRotationInObjectFrame(const QUuid& entityID, int jointIndex);
+    Q_INVOKABLE glm::quat getAbsoluteJointRotationInObjectFrame(const QUuid& entityID, int jointIndex);
 
     /*@jsdoc
      * Sets the translation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's 
@@ -1522,7 +1522,7 @@ public slots:
      * }, 2000);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setAbsoluteJointRotationInObjectFrame(const QUuid& entityID, int jointIndex, glm::qua<float,glm::packed_highp> rotation);
+    Q_INVOKABLE bool setAbsoluteJointRotationInObjectFrame(const QUuid& entityID, int jointIndex, glm::quat rotation);
 
 
     /*@jsdoc
@@ -1560,7 +1560,7 @@ public slots:
      * }, 2000);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE glm::qua<float,glm::packed_highp> getLocalJointRotation(const QUuid& entityID, int jointIndex);
+    Q_INVOKABLE glm::quat getLocalJointRotation(const QUuid& entityID, int jointIndex);
 
     /*@jsdoc
      * Sets the local translation of a joint in a {@link Entities.EntityProperties-Model|Model} entity.
@@ -1602,7 +1602,7 @@ public slots:
      * }, 2000);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setLocalJointRotation(const QUuid& entityID, int jointIndex, glm::qua<float,glm::packed_highp> rotation);
+    Q_INVOKABLE bool setLocalJointRotation(const QUuid& entityID, int jointIndex, glm::quat rotation);
 
 
     /*@jsdoc
@@ -1657,7 +1657,7 @@ public slots:
      * }, 2000);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setLocalJointRotations(const QUuid& entityID, const QVector<glm::qua<float,glm::packed_highp>>& rotations);
+    Q_INVOKABLE bool setLocalJointRotations(const QUuid& entityID, const QVector<glm::quat>& rotations);
 
     /*@jsdoc
      * Sets the local rotations and translations of joints in a {@link Entities.EntityProperties-Model|Model} entity. This is 
@@ -1673,7 +1673,7 @@ public slots:
      */
     // FIXME move to a renderable entity interface
     Q_INVOKABLE bool setLocalJointsData(const QUuid& entityID,
-                                        const QVector<glm::qua<float,glm::packed_highp>>& rotations,
+                                        const QVector<glm::quat>& rotations,
                                         const QVector<glm::vec3>& translations);
 
 
@@ -2192,7 +2192,7 @@ public slots:
      * @param {boolean} [scalesWithParent=false] - <em>Not used in the calculation.</em>
      * @returns {Quat} The rotation converted to local coordinates if successful, otherwise {@link Quat(0)|Quat.IDENTITY}.
      */
-    Q_INVOKABLE glm::qua<float,glm::packed_highp> worldToLocalRotation(glm::qua<float,glm::packed_highp> worldRotation, const QUuid& parentID,
+    Q_INVOKABLE glm::quat worldToLocalRotation(glm::quat worldRotation, const QUuid& parentID,
                                                int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts a velocity in world coordinates to a velocity in an avatar, entity, or joint's local coordinates.
@@ -2256,7 +2256,7 @@ public slots:
      * @param {boolean} [scalesWithParent= false] - <em>Not used in the calculation.</em>
      * @returns {Quat} The rotation converted to local coordinates if successful, otherwise {@link Quat(0)|Quat.IDENTITY}.
      */
-    Q_INVOKABLE glm::qua<float,glm::packed_highp> localToWorldRotation(glm::qua<float,glm::packed_highp> localRotation, const QUuid& parentID,
+    Q_INVOKABLE glm::quat localToWorldRotation(glm::quat localRotation, const QUuid& parentID,
                                                int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts a velocity in an avatar, entity, or joint's local coordinate to a velocity in world coordinates.

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -366,7 +366,7 @@ public slots:
     /// Deliberately not adding jsdoc, only used internally.
     // FIXME: Deprecate and remove from the API.
     Q_INVOKABLE QUuid addModelEntity(const QString& name, const QString& modelUrl, const QString& textures, const QString& shapeType, bool dynamic,
-                                     bool collisionless, bool grabbable, const glm::vec<3,float,glm::packed_highp>& position, const glm::vec<3,float,glm::packed_highp>& gravity);
+                                     bool collisionless, bool grabbable, const glm::vec3& position, const glm::vec3& gravity);
 
     /*@jsdoc
      * Creates a clone of an entity. The clone has the same properties as the original except that: it has a modified
@@ -780,7 +780,7 @@ public slots:
      * print("Closest entity: " + entityID);
      */
     /// this function will not find any models in script engine contexts which don't have access to models
-    Q_INVOKABLE QUuid findClosestEntity(const glm::vec<3,float,glm::packed_highp>& center, float radius, uint filter = ENTITY_PICK_FILTER) const;
+    Q_INVOKABLE QUuid findClosestEntity(const glm::vec3& center, float radius, uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
      * Finds all entities that intersect a sphere, according to <code>filter</code>.
@@ -799,7 +799,7 @@ public slots:
      * print("Number of entities within 10m: " + entityIDs.length);
      */
     /// this function will not find any models in script engine contexts which don't have access to models
-    Q_INVOKABLE QVector<QUuid> findEntities(const glm::vec<3,float,glm::packed_highp>& center,
+    Q_INVOKABLE QVector<QUuid> findEntities(const glm::vec3& center,
                                             float radius, uint filter = ENTITY_PICK_FILTER) const;
 
     /*@jsdoc
@@ -816,7 +816,7 @@ public slots:
      *     could be found.
      */
     /// this function will not find any models in script engine contexts which don't have access to models
-    Q_INVOKABLE QVector<QUuid> findEntitiesInBox(const glm::vec<3,float,glm::packed_highp>& corner,
+    Q_INVOKABLE QVector<QUuid> findEntitiesInBox(const glm::vec3& corner,
                                                  const glm::vec3& dimensions,
                                                  uint filter = ENTITY_PICK_FILTER) const;
 
@@ -859,7 +859,7 @@ public slots:
      */
     /// this function will not find any entities in script engine contexts which don't have access to entities
     Q_INVOKABLE QVector<QUuid> findEntitiesByType(const QString entityType,
-                                                  const glm::vec<3,float,glm::packed_highp>& center,
+                                                  const glm::vec3& center,
                                                   float radius,
                                                   uint filter = ENTITY_PICK_FILTER) const;
 
@@ -882,7 +882,7 @@ public slots:
      * var entityIDs = Entities.findEntitiesByName("Light-Target", MyAvatar.position, 10, false);
      * print("Number of entities with the name Light-Target: " + entityIDs.length);
      */
-    Q_INVOKABLE QVector<QUuid> findEntitiesByName(const QString entityName, const glm::vec<3,float,glm::packed_highp>& center, float radius,
+    Q_INVOKABLE QVector<QUuid> findEntitiesByName(const QString entityName, const glm::vec3& center, float radius,
                                                   bool caseSensitiveSearch = false,
                                                   uint filter = ENTITY_PICK_FILTER) const;
 
@@ -905,7 +905,7 @@ public slots:
      * var entityIDs = Entities.findEntitiesByTags(["Light-Target"], MyAvatar.position, 10, false);
      * print("Number of entities with the tag Light-Target: " + entityIDs.length);
      */
-    Q_INVOKABLE QVector<QUuid> findEntitiesByTags(const QVector<QString> entityTags, const glm::vec<3,float,glm::packed_highp>& center, float radius,
+    Q_INVOKABLE QVector<QUuid> findEntitiesByTags(const QVector<QString> entityTags, const glm::vec3& center, float radius,
                                                   bool caseSensitiveSearch = false,
                                                   uint filter = ENTITY_PICK_FILTER) const;
 
@@ -1086,7 +1086,7 @@ public slots:
      * Entities.setVoxelSphere(polyVox, position, 0.9, 255);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setVoxelSphere(const QUuid& entityID, const glm::vec<3,float,glm::packed_highp>& center, float radius, int value);
+    Q_INVOKABLE bool setVoxelSphere(const QUuid& entityID, const glm::vec3& center, float radius, int value);
     
     /*@jsdoc
      * Sets the values of all voxels in a capsule-shaped portion of a {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
@@ -1110,7 +1110,7 @@ public slots:
      * Entities.setVoxelCapsule(polyVox, startPosition, endPosition, 0.5, 255);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setVoxelCapsule(const QUuid& entityID, const glm::vec<3,float,glm::packed_highp>& start, const glm::vec<3,float,glm::packed_highp>& end, float radius, int value);
+    Q_INVOKABLE bool setVoxelCapsule(const QUuid& entityID, const glm::vec3& start, const glm::vec3& end, float radius, int value);
 
     /*@jsdoc
      * Sets the value of a particular voxel in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
@@ -1132,7 +1132,7 @@ public slots:
      * Entities.setVoxel(entity, { x: 0, y: 0, z: 0 }, 0);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setVoxel(const QUuid& entityID, const glm::vec<3,float,glm::packed_highp>& position, int value);
+    Q_INVOKABLE bool setVoxel(const QUuid& entityID, const glm::vec3& position, int value);
 
     /*@jsdoc
      * Sets the values of all voxels in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity.
@@ -1175,7 +1175,7 @@ public slots:
      * Entities.setVoxelsInCuboid(polyVox, cuboidPosition, cuboidSize, 0);
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setVoxelsInCuboid(const QUuid& entityID, const glm::vec<3,float,glm::packed_highp>& lowPosition, const glm::vec<3,float,glm::packed_highp>& cuboidSize, int value);
+    Q_INVOKABLE bool setVoxelsInCuboid(const QUuid& entityID, const glm::vec3& lowPosition, const glm::vec3& cuboidSize, int value);
 
     /*@jsdoc
      * Converts voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity to world coordinates. Voxel 
@@ -1210,7 +1210,7 @@ public slots:
      * });
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> voxelCoordsToWorldCoords(const QUuid& entityID, glm::vec<3,float,glm::packed_highp> voxelCoords);
+    Q_INVOKABLE glm::vec3 voxelCoordsToWorldCoords(const QUuid& entityID, glm::vec3 voxelCoords);
 
     /*@jsdoc
      * Converts world coordinates to voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity. Voxel 
@@ -1224,7 +1224,7 @@ public slots:
      *     fractional and outside the entity's bounding box.
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> worldCoordsToVoxelCoords(const QUuid& entityID, glm::vec<3,float,glm::packed_highp> worldCoords);
+    Q_INVOKABLE glm::vec3 worldCoordsToVoxelCoords(const QUuid& entityID, glm::vec3 worldCoords);
 
     /*@jsdoc
      * Converts voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity to local coordinates. Local 
@@ -1248,7 +1248,7 @@ public slots:
      * print("Voxel dimensions: " + JSON.stringify(voxelDimensions));
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> voxelCoordsToLocalCoords(const QUuid& entityID, glm::vec<3,float,glm::packed_highp> voxelCoords);
+    Q_INVOKABLE glm::vec3 voxelCoordsToLocalCoords(const QUuid& entityID, glm::vec3 voxelCoords);
 
     /*@jsdoc
      * Converts local coordinates to voxel coordinates in a {@link Entities.EntityProperties-PolyVox|PolyVox} entity. Local 
@@ -1263,7 +1263,7 @@ public slots:
      *     fractional and outside the entity's bounding box.
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> localCoordsToVoxelCoords(const QUuid& entityID, glm::vec<3,float,glm::packed_highp> localCoords);
+    Q_INVOKABLE glm::vec3 localCoordsToVoxelCoords(const QUuid& entityID, glm::vec3 localCoords);
 
     /*@jsdoc
      * Sets all the points in a {@link Entities.EntityProperties-Line|Line} entity.
@@ -1299,7 +1299,7 @@ public slots:
      *     ]);
      * }, 2000);
      */
-    Q_INVOKABLE bool setAllPoints(const QUuid& entityID, const QVector<glm::vec<3,float,glm::packed_highp>>& points);
+    Q_INVOKABLE bool setAllPoints(const QUuid& entityID, const QVector<glm::vec3>& points);
     
     /*@jsdoc
      * Appends a point to a {@link Entities.EntityProperties-Line|Line} entity.
@@ -1331,7 +1331,7 @@ public slots:
      *     Entities.appendPoint(entity, { x: 1, y: 1, z: 0 });
      * }, 50); // Wait for the entity to be created.
      */
-    Q_INVOKABLE bool appendPoint(const QUuid& entityID, const glm::vec<3,float,glm::packed_highp>& point);
+    Q_INVOKABLE bool appendPoint(const QUuid& entityID, const glm::vec3& point);
 
     /*@jsdoc
      * Restart a {@link Entities.EntityProperties-Sound|Sound} entity, locally only.  It must also be <code>localOnly</code>.
@@ -1438,7 +1438,7 @@ public slots:
      *     <code>{@link Vec3(0)|Vec3.ZERO}</code>.
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getAbsoluteJointTranslationInObjectFrame(const QUuid& entityID, int jointIndex);
+    Q_INVOKABLE glm::vec3 getAbsoluteJointTranslationInObjectFrame(const QUuid& entityID, int jointIndex);
     
     /*@jsdoc
      * Gets the index of the parent joint of a joint in a {@link Entities.EntityProperties-Model|Model} entity.
@@ -1491,7 +1491,7 @@ public slots:
      *     <code>false</code>.
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setAbsoluteJointTranslationInObjectFrame(const QUuid& entityID, int jointIndex, glm::vec<3,float,glm::packed_highp> translation);
+    Q_INVOKABLE bool setAbsoluteJointTranslationInObjectFrame(const QUuid& entityID, int jointIndex, glm::vec3 translation);
 
     /*@jsdoc
      * Sets the rotation of a joint in a {@link Entities.EntityProperties-Model|Model} entity relative to the entity's position 
@@ -1534,7 +1534,7 @@ public slots:
      *     entity, the entity is loaded, and the joint index is valid; otherwise <code>{@link Vec3(0)|Vec3.ZERO}</code>.
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> getLocalJointTranslation(const QUuid& entityID, int jointIndex);
+    Q_INVOKABLE glm::vec3 getLocalJointTranslation(const QUuid& entityID, int jointIndex);
 
     /*@jsdoc
      * Gets the local rotation of a joint in a {@link Entities.EntityProperties-Model|Model} entity.
@@ -1573,7 +1573,7 @@ public slots:
      *     <code>false</code>.
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setLocalJointTranslation(const QUuid& entityID, int jointIndex, glm::vec<3,float,glm::packed_highp> translation);
+    Q_INVOKABLE bool setLocalJointTranslation(const QUuid& entityID, int jointIndex, glm::vec3 translation);
 
     /*@jsdoc
      * Sets the local rotation of a joint in a {@link Entities.EntityProperties-Model|Model} entity.
@@ -1615,7 +1615,7 @@ public slots:
      *     translations; otherwise <code>false</code>.
      */
     // FIXME move to a renderable entity interface
-    Q_INVOKABLE bool setLocalJointTranslations(const QUuid& entityID, const QVector<glm::vec<3,float,glm::packed_highp>>& translations);
+    Q_INVOKABLE bool setLocalJointTranslations(const QUuid& entityID, const QVector<glm::vec3>& translations);
 
     /*@jsdoc
      * Sets the local rotations of joints in a {@link Entities.EntityProperties-Model|Model} entity.
@@ -1674,7 +1674,7 @@ public slots:
     // FIXME move to a renderable entity interface
     Q_INVOKABLE bool setLocalJointsData(const QUuid& entityID,
                                         const QVector<glm::qua<float,glm::packed_highp>>& rotations,
-                                        const QVector<glm::vec<3,float,glm::packed_highp>>& translations);
+                                        const QVector<glm::vec3>& translations);
 
 
     /*@jsdoc
@@ -2057,8 +2057,8 @@ public slots:
      * @param {number} radius - The radius of the capsule.
      * @returns {boolean} <code>true</code> if the AA box and capsule intersect, otherwise <code>false</code>.
      */
-    Q_INVOKABLE bool AABoxIntersectsCapsule(const glm::vec<3,float,glm::packed_highp>& low, const glm::vec<3,float,glm::packed_highp>& dimensions,
-                                            const glm::vec<3,float,glm::packed_highp>& start, const glm::vec<3,float,glm::packed_highp>& end, float radius);
+    Q_INVOKABLE bool AABoxIntersectsCapsule(const glm::vec3& low, const glm::vec3& dimensions,
+                                            const glm::vec3& start, const glm::vec3& end, float radius);
 
     /*@jsdoc
      * Gets the meshes in a {@link Entities.EntityProperties-Model|Model} or {@link Entities.EntityProperties-PolyVox|PolyVox} 
@@ -2180,7 +2180,7 @@ public slots:
      * localPosition = Entities.getEntityProperties(childEntity, "localPosition").localPosition;
      * print("Local position: " + JSON.stringify(localPosition));  // The same.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> worldToLocalPosition(glm::vec<3,float,glm::packed_highp> worldPosition, const QUuid& parentID,
+    Q_INVOKABLE glm::vec3 worldToLocalPosition(glm::vec3 worldPosition, const QUuid& parentID,
                                                int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts a rotation or orientation in world coordinates to rotation in an avatar, entity, or joint's local coordinates.
@@ -2205,7 +2205,7 @@ public slots:
      *     <code>false</code> for the local velocity to be at world scale.
      * @returns {Vec3} The velocity converted to local coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> worldToLocalVelocity(glm::vec<3,float,glm::packed_highp> worldVelocity, const QUuid& parentID,
+    Q_INVOKABLE glm::vec3 worldToLocalVelocity(glm::vec3 worldVelocity, const QUuid& parentID,
                                                int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts a Euler angular velocity in world coordinates to an angular velocity in an avatar, entity, or joint's local 
@@ -2219,7 +2219,7 @@ public slots:
      * @param {boolean} [scalesWithParent=false] - <em>Not used in the calculation.</em>
      * @returns {Vec3} The angular velocity converted to local coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> worldToLocalAngularVelocity(glm::vec<3,float,glm::packed_highp> worldAngularVelocity, const QUuid& parentID,
+    Q_INVOKABLE glm::vec3 worldToLocalAngularVelocity(glm::vec3 worldAngularVelocity, const QUuid& parentID,
                                                       int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts dimensions in world coordinates to dimensions in an avatar or entity's local coordinates.
@@ -2231,7 +2231,7 @@ public slots:
      *     <code>false</code> for the local dimensions to be at world scale.
      * @returns {Vec3} The dimensions converted to local coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> worldToLocalDimensions(glm::vec<3,float,glm::packed_highp> worldDimensions, const QUuid& parentID,
+    Q_INVOKABLE glm::vec3 worldToLocalDimensions(glm::vec3 worldDimensions, const QUuid& parentID,
                                                  int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts a position in an avatar, entity, or joint's local coordinate to a position in world coordinates.
@@ -2244,7 +2244,7 @@ public slots:
      *     <code>false</code> if the local dimensions are at world scale.
      * @returns {Vec3} The position converted to world coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> localToWorldPosition(glm::vec<3,float,glm::packed_highp> localPosition, const QUuid& parentID,
+    Q_INVOKABLE glm::vec3 localToWorldPosition(glm::vec3 localPosition, const QUuid& parentID,
                                                int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts a rotation or orientation in an avatar, entity, or joint's local coordinate to a rotation in world coordinates.
@@ -2269,7 +2269,7 @@ public slots:
      *     <code>false</code> if the local velocity is at world scale.
      * @returns {Vec3} The velocity converted to world coordinates it successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> localToWorldVelocity(glm::vec<3,float,glm::packed_highp> localVelocity, const QUuid& parentID,
+    Q_INVOKABLE glm::vec3 localToWorldVelocity(glm::vec3 localVelocity, const QUuid& parentID,
                                                int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts a Euler angular velocity in an avatar, entity, or joint's local coordinate to an angular velocity in world 
@@ -2283,7 +2283,7 @@ public slots:
      * @param {boolean} [scalesWithParent= false] - <em>Not used in the calculation.</em>
      * @returns {Vec3} The angular velocity converted to world coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> localToWorldAngularVelocity(glm::vec<3,float,glm::packed_highp> localAngularVelocity, const QUuid& parentID,
+    Q_INVOKABLE glm::vec3 localToWorldAngularVelocity(glm::vec3 localAngularVelocity, const QUuid& parentID,
                                                       int parentJointIndex = -1, bool scalesWithParent = false);
     /*@jsdoc
      * Converts dimensions in an avatar or entity's local coordinates to dimensions in world coordinates.
@@ -2295,7 +2295,7 @@ public slots:
      *     scale, <code>false</code> if the local dimensions are at world scale.
      * @returns {Vec3} The dimensions converted to world coordinates if successful, otherwise {@link Vec3(0)|Vec3.ZERO}.
      */
-    Q_INVOKABLE glm::vec<3,float,glm::packed_highp> localToWorldDimensions(glm::vec<3,float,glm::packed_highp> localDimensions, const QUuid& parentID,
+    Q_INVOKABLE glm::vec3 localToWorldDimensions(glm::vec3 localDimensions, const QUuid& parentID,
                                                  int parentJointIndex = -1, bool scalesWithParent = false);
 
 

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -2108,7 +2108,7 @@ public slots:
      * print("Rotation: " + JSON.stringify(Mat4.extractRotation(transform)));  // Same as orientation.
      * print("Scale: " + JSON.stringify(Mat4.extractScale(transform)));  // { x: 1, y: 1, z: 1 }
      */
-    Q_INVOKABLE glm::mat<4,4,float,glm::packed_highp> getEntityTransform(const QUuid& entityID);
+    Q_INVOKABLE glm::mat4 getEntityTransform(const QUuid& entityID);
 
     /*@jsdoc
      * Gets the object to parent transform, excluding scale, of an entity.
@@ -2143,7 +2143,7 @@ public slots:
      * print("Translation: " + JSON.stringify(Mat4.extractTranslation(transform)));  // childTranslation
      * print("Rotation: " + JSON.stringify(Quat.safeEulerAngles(Mat4.extractRotation(transform))));  // childRotation
      * print("Scale: " + JSON.stringify(Mat4.extractScale(transform)));  // { x: 1, y: 1, z: 1 }     */
-    Q_INVOKABLE glm::mat<4,4,float,glm::packed_highp> getEntityLocalTransform(const QUuid& entityID);
+    Q_INVOKABLE glm::mat4 getEntityLocalTransform(const QUuid& entityID);
 
 
     /*@jsdoc

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -40,7 +40,7 @@ public:
 
 class SendEntitiesOperationArgs {
 public:
-    glm::vec<3,float,glm::packed_highp> root;
+    glm::vec3 root;
     QString entityHostType;
     EntityTree* ourTree;
     EntityTreePointer otherTree;

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.h
@@ -133,7 +133,7 @@ namespace scriptable {
          *    <code>origin</code> it is considered to be "nearby".
          * @returns {number[]} The indices of nearby vertices.
          */
-        QVector<glm::uint32> findNearbyVertexIndices(const glm::vec<3,float,glm::packed_highp>& origin, float epsilon = 1e-6) const;
+        QVector<glm::uint32> findNearbyVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
 
         /*@jsdoc
          * Adds an attribute for all vertices.

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
@@ -112,7 +112,7 @@ namespace scriptable {
          *    <code>origin</code> it is considered to be "nearby".
          * @returns {number[]} The indices of nearby vertices.
          */
-        QVector<glm::uint32> findNearbyPartVertexIndices(const glm::vec<3,float,glm::packed_highp>& origin, float epsilon = 1e-6) const;
+        QVector<glm::uint32> findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
 
         /*@jsdoc
          * Gets the value of an attribute for all vertices in the <em>whole</em> mesh (i.e., parent and mesh parts).
@@ -174,7 +174,7 @@ namespace scriptable {
          * @param {Vec3} translation - The translation to apply, in model coordinates.
          * @returns {Graphics.MeshExtents} The rseulting mesh extents, in model coordinates.
          */
-        QVariantMap translate(const glm::vec<3,float,glm::packed_highp>& translation);
+        QVariantMap translate(const glm::vec3& translation);
 
         /*@jsdoc
          * Scales the mesh part.
@@ -183,7 +183,7 @@ namespace scriptable {
          * @param {Vec3} [origin] - The origin to scale about. If not specified, the center of the mesh part is used.
          * @returns {Graphics.MeshExtents} The resulting mesh extents, in model coordinates.
          */
-        QVariantMap scale(const glm::vec<3,float,glm::packed_highp>& scale, const glm::vec<3,float,glm::packed_highp>& origin = glm::vec<3,float,glm::packed_highp>(NAN));
+        QVariantMap scale(const glm::vec3& scale, const glm::vec3& origin = glm::vec3(NAN));
 
         /*@jsdoc
          * Rotates the mesh part, using Euler angles.
@@ -193,7 +193,7 @@ namespace scriptable {
          *     <p><strong>Warning:</strong> Currently doesn't work as expected.</p>
          * @returns {Graphics.MeshExtents} The resulting mesh extents, in model coordinates.
          */
-        QVariantMap rotateDegrees(const glm::vec<3,float,glm::packed_highp>& eulerAngles, const glm::vec<3,float,glm::packed_highp>& origin = glm::vec<3,float,glm::packed_highp>(NAN));
+        QVariantMap rotateDegrees(const glm::vec3& eulerAngles, const glm::vec3& origin = glm::vec3(NAN));
 
         /*@jsdoc
          * Rotates the mesh part, using a quaternion.
@@ -203,7 +203,7 @@ namespace scriptable {
          *     <p><strong>Warning:</strong> Currently doesn't work as expected.</p>
          * @returns {Graphics.MeshExtents} The resulting mesh extents, in model coordinates.
          */
-        QVariantMap rotate(const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& origin = glm::vec<3,float,glm::packed_highp>(NAN));
+        QVariantMap rotate(const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& origin = glm::vec3(NAN));
 
         /*@jsdoc
          * Scales, rotates, and translates the mesh.

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
@@ -211,7 +211,7 @@ namespace scriptable {
          * @param {Mat4} transform - The scale, rotate, and translate transform to apply.
          * @returns {Graphics.MeshExtents} The resulting mesh extents, in model coordinates.
          */
-        QVariantMap transform(const glm::mat<4,4,float,glm::packed_highp>& transform);
+        QVariantMap transform(const glm::mat4& transform);
 
         // @borrows jsdoc from GraphicsMesh.
         glm::uint32 addAttribute(const QString& attributeName, const QVariant& defaultValue = QVariant());

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
@@ -203,7 +203,7 @@ namespace scriptable {
          *     <p><strong>Warning:</strong> Currently doesn't work as expected.</p>
          * @returns {Graphics.MeshExtents} The resulting mesh extents, in model coordinates.
          */
-        QVariantMap rotate(const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& origin = glm::vec3(NAN));
+        QVariantMap rotate(const glm::quat& rotation, const glm::vec3& origin = glm::vec3(NAN));
 
         /*@jsdoc
          * Scales, rotates, and translates the mesh.

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -435,7 +435,7 @@ signals:
      *
      * location.locationChangeRequired.connect(onLocationChangeRequired);
      */
-    void locationChangeRequired(const glm::vec<3,float,glm::packed_highp>& newPosition,
+    void locationChangeRequired(const glm::vec3& newPosition,
                                 bool hasOrientationChange, const glm::quat& newOrientation,
                                 bool shouldFaceLocation);
 

--- a/libraries/render-utils/src/AmbientOcclusionEffect.h
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.h
@@ -248,7 +248,7 @@ class DebugAmbientOcclusionConfig : public render::Job::Config {
     Q_OBJECT
 
     Q_PROPERTY(bool showCursorPixel MEMBER showCursorPixel NOTIFY dirty)
-    Q_PROPERTY(glm::vec<2,float,glm::packed_highp> debugCursorTexcoord MEMBER debugCursorTexcoord NOTIFY dirty)
+    Q_PROPERTY(glm::vec2 debugCursorTexcoord MEMBER debugCursorTexcoord NOTIFY dirty)
 public:
     DebugAmbientOcclusionConfig() : render::Job::Config(false) {}
 

--- a/libraries/render-utils/src/AntialiasingEffect.h
+++ b/libraries/render-utils/src/AntialiasingEffect.h
@@ -146,7 +146,7 @@ class AntialiasingConfig : public render::Job::Config {
     Q_PROPERTY(bool fxaaOnOff READ debugFXAA WRITE setDebugFXAA NOTIFY dirty)
     Q_PROPERTY(float debugShowVelocityThreshold MEMBER debugShowVelocityThreshold NOTIFY dirty)
     Q_PROPERTY(bool showCursorPixel MEMBER showCursorPixel NOTIFY dirty)
-    Q_PROPERTY(glm::vec<2,float,glm::packed_highp> debugCursorTexcoord MEMBER debugCursorTexcoord NOTIFY dirty)
+    Q_PROPERTY(glm::vec2 debugCursorTexcoord MEMBER debugCursorTexcoord NOTIFY dirty)
     Q_PROPERTY(float debugOrbZoom MEMBER debugOrbZoom NOTIFY dirty)
 
     Q_PROPERTY(bool showClosestFragment MEMBER showClosestFragment NOTIFY dirty)

--- a/libraries/render-utils/src/HazeStage.h
+++ b/libraries/render-utils/src/HazeStage.h
@@ -28,10 +28,10 @@ public:
 class FetchHazeConfig : public render::Job::Config {
     Q_OBJECT
 
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> hazeColor MEMBER hazeColor WRITE setHazeColor NOTIFY dirty);
+    Q_PROPERTY(glm::vec3 hazeColor MEMBER hazeColor WRITE setHazeColor NOTIFY dirty);
     Q_PROPERTY(float hazeGlareAngle MEMBER hazeGlareAngle WRITE setHazeGlareAngle NOTIFY dirty);
 
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> hazeGlareColor MEMBER hazeGlareColor WRITE setHazeGlareColor NOTIFY dirty);
+    Q_PROPERTY(glm::vec3 hazeGlareColor MEMBER hazeGlareColor WRITE setHazeGlareColor NOTIFY dirty);
     Q_PROPERTY(float hazeBaseReference MEMBER hazeBaseReference WRITE setHazeBaseReference NOTIFY dirty);
 
     Q_PROPERTY(bool isHazeActive MEMBER isHazeActive WRITE setHazeActive NOTIFY dirty);

--- a/libraries/script-engine/src/Mat4.h
+++ b/libraries/script-engine/src/Mat4.h
@@ -72,7 +72,7 @@ public slots:
      * //                 (0.739199, 0.280330, 0.612372, 0.000000),
      * //                 (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat4 createFromRotAndTrans(const glm::qua<float,glm::packed_highp>& rot, const glm::vec3& trans) const;
+    glm::mat4 createFromRotAndTrans(const glm::quat& rot, const glm::vec3& trans) const;
 
     /*@jsdoc
      * Creates a matrix that represents a scale, rotation, and translation.
@@ -92,7 +92,7 @@ public slots:
      * //                 (1.478398, 0.560660, 1.224745, 0.000000),
      * //                 (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat4 createFromScaleRotAndTrans(const glm::vec3& scale, const glm::qua<float,glm::packed_highp>& rot, const glm::vec3& trans) const;
+    glm::mat4 createFromScaleRotAndTrans(const glm::vec3& scale, const glm::quat& rot, const glm::vec3& trans) const;
 
     /*@jsdoc
      * Creates a matrix from columns of values.
@@ -170,7 +170,7 @@ public slots:
      * print("Rotation: " + JSON.stringify(Quat.safeEulerAngles(rot)));
      * // Rotation: {"x":29.999998092651367,"y":45.00000762939453,"z":60.000003814697266}
      */
-    glm::qua<float,glm::packed_highp> extractRotation(const glm::mat4& m) const;
+    glm::quat extractRotation(const glm::mat4& m) const;
 
     /*@jsdoc
      * Extracts the scale from a matrix.

--- a/libraries/script-engine/src/Mat4.h
+++ b/libraries/script-engine/src/Mat4.h
@@ -72,7 +72,7 @@ public slots:
      * //                 (0.739199, 0.280330, 0.612372, 0.000000),
      * //                 (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat4 createFromRotAndTrans(const glm::qua<float,glm::packed_highp>& rot, const glm::vec<3,float,glm::packed_highp>& trans) const;
+    glm::mat4 createFromRotAndTrans(const glm::qua<float,glm::packed_highp>& rot, const glm::vec3& trans) const;
 
     /*@jsdoc
      * Creates a matrix that represents a scale, rotation, and translation.
@@ -92,7 +92,7 @@ public slots:
      * //                 (1.478398, 0.560660, 1.224745, 0.000000),
      * //                 (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat4 createFromScaleRotAndTrans(const glm::vec<3,float,glm::packed_highp>& scale, const glm::qua<float,glm::packed_highp>& rot, const glm::vec<3,float,glm::packed_highp>& trans) const;
+    glm::mat4 createFromScaleRotAndTrans(const glm::vec3& scale, const glm::qua<float,glm::packed_highp>& rot, const glm::vec3& trans) const;
 
     /*@jsdoc
      * Creates a matrix from columns of values.
@@ -153,7 +153,7 @@ public slots:
      * print("Translation: " + JSON.stringify(trans));
      * // Translation: {"x":10,"y":11,"z":12}
      */
-    glm::vec<3,float,glm::packed_highp> extractTranslation(const glm::mat4& m) const;
+    glm::vec3 extractTranslation(const glm::mat4& m) const;
 
     /*@jsdoc
      * Extracts the rotation from a matrix.
@@ -187,7 +187,7 @@ public slots:
      * print("Scale: " + JSON.stringify(scale));
      * // Scale: {"x":1.9999998807907104,"y":1.9999998807907104,"z":1.9999998807907104}
      */
-    glm::vec<3,float,glm::packed_highp> extractScale(const glm::mat4& m) const;
+    glm::vec3 extractScale(const glm::mat4& m) const;
 
 
     /*@jsdoc
@@ -207,7 +207,7 @@ public slots:
      * print("Transformed point: " + JSON.stringify(transformedPoint));
      * // Transformed point: { "x": 2.8284270763397217, "y": 12, "z": -2.384185791015625e-7 }
      */
-    glm::vec<3,float,glm::packed_highp> transformPoint(const glm::mat4& m, const glm::vec<3,float,glm::packed_highp>& point) const;
+    glm::vec3 transformPoint(const glm::mat4& m, const glm::vec3& point) const;
 
     /*@jsdoc
      * Transforms a vector into a new coordinate system: the vector is scaled and rotated.
@@ -226,7 +226,7 @@ public slots:
      * print("Transformed vector: " + JSON.stringify(transformedVector));
      * // Transformed vector: { "x": 2.8284270763397217, "y": 2, "z": -2.384185791015625e-7 }
      */
-    glm::vec<3,float,glm::packed_highp> transformVector(const glm::mat4& m, const glm::vec<3,float,glm::packed_highp>& vector) const;
+    glm::vec3 transformVector(const glm::mat4& m, const glm::vec3& vector) const;
 
 
     /*@jsdoc
@@ -259,7 +259,7 @@ public slots:
      * @returns {Vec3} The negative z-axis rotated by orientation.
      */
     // redundant, calls getForward which better describes the returned vector as a direction
-    glm::vec<3,float,glm::packed_highp> getFront(const glm::mat4& m) const { return getForward(m); }
+    glm::vec3 getFront(const glm::mat4& m) const { return getForward(m); }
 
     /*@jsdoc
      * Gets the "forward" direction that the camera would face if its orientation was set to the rotation contained in a
@@ -275,7 +275,7 @@ public slots:
      * print("Forward: " + JSON.stringify(forward));
      * // Forward: {"x":0,"y":0,"z":-1}
      */
-    glm::vec<3,float,glm::packed_highp> getForward(const glm::mat4& m) const;
+    glm::vec3 getForward(const glm::mat4& m) const;
 
     /*@jsdoc
      * Gets the "right" direction that the camera would have if its orientation was set to the rotation contained in a matrix. 
@@ -284,7 +284,7 @@ public slots:
      * @param {Mat4} m - The matrix.
      * @returns {Vec3} The x-axis rotated by the rotation in the matrix.
      */
-    glm::vec<3,float,glm::packed_highp> getRight(const glm::mat4& m) const;
+    glm::vec3 getRight(const glm::mat4& m) const;
 
     /*@jsdoc
      * Gets the "up" direction that the camera would have if its orientation was set to the rotation contained in a matrix. The 
@@ -293,7 +293,7 @@ public slots:
      * @param {Mat4} m - The matrix.
      * @returns {Vec3} The y-axis rotated by the rotation in the matrix.
      */
-    glm::vec<3,float,glm::packed_highp> getUp(const glm::mat4& m) const;
+    glm::vec3 getUp(const glm::mat4& m) const;
 
 
     /*@jsdoc

--- a/libraries/script-engine/src/Mat4.h
+++ b/libraries/script-engine/src/Mat4.h
@@ -53,7 +53,7 @@ public slots:
      * @param {Mat4} m2 - The second matrix.
      * @returns {Mat4} <code>m1</code> multiplied with <code>m2</code>.
      */
-    glm::mat<4,4,float,glm::packed_highp> multiply(const glm::mat<4,4,float,glm::packed_highp>& m1, const glm::mat<4,4,float,glm::packed_highp>& m2) const;
+    glm::mat4 multiply(const glm::mat4& m1, const glm::mat4& m2) const;
 
 
     /*@jsdoc
@@ -72,7 +72,7 @@ public slots:
      * //                 (0.739199, 0.280330, 0.612372, 0.000000),
      * //                 (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat<4,4,float,glm::packed_highp> createFromRotAndTrans(const glm::qua<float,glm::packed_highp>& rot, const glm::vec<3,float,glm::packed_highp>& trans) const;
+    glm::mat4 createFromRotAndTrans(const glm::qua<float,glm::packed_highp>& rot, const glm::vec<3,float,glm::packed_highp>& trans) const;
 
     /*@jsdoc
      * Creates a matrix that represents a scale, rotation, and translation.
@@ -92,7 +92,7 @@ public slots:
      * //                 (1.478398, 0.560660, 1.224745, 0.000000),
      * //                 (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat<4,4,float,glm::packed_highp> createFromScaleRotAndTrans(const glm::vec<3,float,glm::packed_highp>& scale, const glm::qua<float,glm::packed_highp>& rot, const glm::vec<3,float,glm::packed_highp>& trans) const;
+    glm::mat4 createFromScaleRotAndTrans(const glm::vec<3,float,glm::packed_highp>& scale, const glm::qua<float,glm::packed_highp>& rot, const glm::vec<3,float,glm::packed_highp>& trans) const;
 
     /*@jsdoc
      * Creates a matrix from columns of values.
@@ -114,7 +114,7 @@ public slots:
      * //                (1.478398, 0.560660, 1.224745, 0.000000),
      * //                (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat<4,4,float,glm::packed_highp> createFromColumns(const glm::vec4& col0, const glm::vec4& col1, const glm::vec4& col2, const glm::vec4& col3) const;
+    glm::mat4 createFromColumns(const glm::vec4& col0, const glm::vec4& col1, const glm::vec4& col2, const glm::vec4& col3) const;
 
     /*@jsdoc
      * Creates a matrix from an array of values.
@@ -135,7 +135,7 @@ public slots:
      * //                (1.478398, 0.560660, 1.224745, 0.000000),
      * //                (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat<4,4,float,glm::packed_highp> createFromArray(const QVector<float>& floats) const;
+    glm::mat4 createFromArray(const QVector<float>& floats) const;
 
 
     /*@jsdoc
@@ -153,7 +153,7 @@ public slots:
      * print("Translation: " + JSON.stringify(trans));
      * // Translation: {"x":10,"y":11,"z":12}
      */
-    glm::vec<3,float,glm::packed_highp> extractTranslation(const glm::mat<4,4,float,glm::packed_highp>& m) const;
+    glm::vec<3,float,glm::packed_highp> extractTranslation(const glm::mat4& m) const;
 
     /*@jsdoc
      * Extracts the rotation from a matrix.
@@ -170,7 +170,7 @@ public slots:
      * print("Rotation: " + JSON.stringify(Quat.safeEulerAngles(rot)));
      * // Rotation: {"x":29.999998092651367,"y":45.00000762939453,"z":60.000003814697266}
      */
-    glm::qua<float,glm::packed_highp> extractRotation(const glm::mat<4,4,float,glm::packed_highp>& m) const;
+    glm::qua<float,glm::packed_highp> extractRotation(const glm::mat4& m) const;
 
     /*@jsdoc
      * Extracts the scale from a matrix.
@@ -187,7 +187,7 @@ public slots:
      * print("Scale: " + JSON.stringify(scale));
      * // Scale: {"x":1.9999998807907104,"y":1.9999998807907104,"z":1.9999998807907104}
      */
-    glm::vec<3,float,glm::packed_highp> extractScale(const glm::mat<4,4,float,glm::packed_highp>& m) const;
+    glm::vec<3,float,glm::packed_highp> extractScale(const glm::mat4& m) const;
 
 
     /*@jsdoc
@@ -207,7 +207,7 @@ public slots:
      * print("Transformed point: " + JSON.stringify(transformedPoint));
      * // Transformed point: { "x": 2.8284270763397217, "y": 12, "z": -2.384185791015625e-7 }
      */
-    glm::vec<3,float,glm::packed_highp> transformPoint(const glm::mat<4,4,float,glm::packed_highp>& m, const glm::vec<3,float,glm::packed_highp>& point) const;
+    glm::vec<3,float,glm::packed_highp> transformPoint(const glm::mat4& m, const glm::vec<3,float,glm::packed_highp>& point) const;
 
     /*@jsdoc
      * Transforms a vector into a new coordinate system: the vector is scaled and rotated.
@@ -226,7 +226,7 @@ public slots:
      * print("Transformed vector: " + JSON.stringify(transformedVector));
      * // Transformed vector: { "x": 2.8284270763397217, "y": 2, "z": -2.384185791015625e-7 }
      */
-    glm::vec<3,float,glm::packed_highp> transformVector(const glm::mat<4,4,float,glm::packed_highp>& m, const glm::vec<3,float,glm::packed_highp>& vector) const;
+    glm::vec<3,float,glm::packed_highp> transformVector(const glm::mat4& m, const glm::vec<3,float,glm::packed_highp>& vector) const;
 
 
     /*@jsdoc
@@ -247,7 +247,7 @@ public slots:
      * //                    (0.000000, 0.000000, 1.000000, 0.000000),
      * //                    (0.000000, 0.000000, 0.000001, 1.000000))
      */
-    glm::mat<4,4,float,glm::packed_highp> inverse(const glm::mat<4,4,float,glm::packed_highp>& m) const;
+    glm::mat4 inverse(const glm::mat4& m) const;
 
 
     /*@jsdoc
@@ -259,7 +259,7 @@ public slots:
      * @returns {Vec3} The negative z-axis rotated by orientation.
      */
     // redundant, calls getForward which better describes the returned vector as a direction
-    glm::vec<3,float,glm::packed_highp> getFront(const glm::mat<4,4,float,glm::packed_highp>& m) const { return getForward(m); }
+    glm::vec<3,float,glm::packed_highp> getFront(const glm::mat4& m) const { return getForward(m); }
 
     /*@jsdoc
      * Gets the "forward" direction that the camera would face if its orientation was set to the rotation contained in a
@@ -275,7 +275,7 @@ public slots:
      * print("Forward: " + JSON.stringify(forward));
      * // Forward: {"x":0,"y":0,"z":-1}
      */
-    glm::vec<3,float,glm::packed_highp> getForward(const glm::mat<4,4,float,glm::packed_highp>& m) const;
+    glm::vec<3,float,glm::packed_highp> getForward(const glm::mat4& m) const;
 
     /*@jsdoc
      * Gets the "right" direction that the camera would have if its orientation was set to the rotation contained in a matrix. 
@@ -284,7 +284,7 @@ public slots:
      * @param {Mat4} m - The matrix.
      * @returns {Vec3} The x-axis rotated by the rotation in the matrix.
      */
-    glm::vec<3,float,glm::packed_highp> getRight(const glm::mat<4,4,float,glm::packed_highp>& m) const;
+    glm::vec<3,float,glm::packed_highp> getRight(const glm::mat4& m) const;
 
     /*@jsdoc
      * Gets the "up" direction that the camera would have if its orientation was set to the rotation contained in a matrix. The 
@@ -293,7 +293,7 @@ public slots:
      * @param {Mat4} m - The matrix.
      * @returns {Vec3} The y-axis rotated by the rotation in the matrix.
      */
-    glm::vec<3,float,glm::packed_highp> getUp(const glm::mat<4,4,float,glm::packed_highp>& m) const;
+    glm::vec<3,float,glm::packed_highp> getUp(const glm::mat4& m) const;
 
 
     /*@jsdoc
@@ -321,7 +321,7 @@ public slots:
      * //          "r0c2": 1.4783978462219238, "r1c2": 0.5606603026390076, "r2c2": 1.2247447967529297, "r3c2": 0,
      * //          "r0c3": 10, "r1c3": 11, "r2c3": 12, "r3c3": 1}
      */
-    void print(const QString& label, const glm::mat<4,4,float,glm::packed_highp>& m, bool transpose = false) const;
+    void print(const QString& label, const glm::mat4& m, bool transpose = false) const;
 };
 
 #endif // hifi_Mat4_h

--- a/libraries/script-engine/src/Mat4.h
+++ b/libraries/script-engine/src/Mat4.h
@@ -114,7 +114,7 @@ public slots:
      * //                (1.478398, 0.560660, 1.224745, 0.000000),
      * //                (10.000000, 11.000000, 12.000000, 1.000000))
      */
-    glm::mat<4,4,float,glm::packed_highp> createFromColumns(const glm::vec<4,float,glm::packed_highp>& col0, const glm::vec<4,float,glm::packed_highp>& col1, const glm::vec<4,float,glm::packed_highp>& col2, const glm::vec<4,float,glm::packed_highp>& col3) const;
+    glm::mat<4,4,float,glm::packed_highp> createFromColumns(const glm::vec4& col0, const glm::vec4& col1, const glm::vec4& col2, const glm::vec4& col3) const;
 
     /*@jsdoc
      * Creates a matrix from an array of values.

--- a/libraries/script-engine/src/Quat.h
+++ b/libraries/script-engine/src/Quat.h
@@ -127,7 +127,7 @@ public slots:
      * Camera.mode = "independent";
      * Camera.orientation = Quat.lookAt(Camera.position, Vec3.ZERO, Vec3.UNIT_NEG_Y);
      */
-    glm::qua<float,glm::packed_highp> lookAt(const glm::vec<3,float,glm::packed_highp>& eye, const glm::vec<3,float,glm::packed_highp>& center, const glm::vec<3,float,glm::packed_highp>& up);
+    glm::qua<float,glm::packed_highp> lookAt(const glm::vec3& eye, const glm::vec3& center, const glm::vec3& up);
 
     /*@jsdoc
     * Calculates a camera orientation given an eye position and point of interest. The camera's negative z-axis is the forward 
@@ -143,7 +143,7 @@ public slots:
     * Camera.mode = "independent";
     * Camera.orientation = Quat.lookAtSimple(Camera.position, Vec3.ZERO);
     */
-    glm::qua<float,glm::packed_highp> lookAtSimple(const glm::vec<3,float,glm::packed_highp>& eye, const glm::vec<3,float,glm::packed_highp>& center);
+    glm::qua<float,glm::packed_highp> lookAtSimple(const glm::vec3& eye, const glm::vec3& center);
 
     /*@jsdoc
     * Calculates the shortest rotation from a first vector onto a second.
@@ -160,7 +160,7 @@ public slots:
     * Entities.editEntity(entityID, properties);
     * entityVelocity = newVelocity;
     */
-    glm::qua<float,glm::packed_highp> rotationBetween(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2);
+    glm::qua<float,glm::packed_highp> rotationBetween(const glm::vec3& v1, const glm::vec3& v2);
 
     /*@jsdoc
      * Generates a quaternion from a {@link Vec3} of Euler angles in degrees.
@@ -174,7 +174,7 @@ public slots:
      * eulerAngles.z = 0;
      * var newOrientation = Quat.fromVec3Degrees(eulerAngles);
      */
-    glm::qua<float,glm::packed_highp> fromVec3Degrees(const glm::vec<3,float,glm::packed_highp>& vec3);
+    glm::qua<float,glm::packed_highp> fromVec3Degrees(const glm::vec3& vec3);
 
     /*@jsdoc
      * Generates a quaternion from a {@link Vec3} of Euler angles in radians.
@@ -185,7 +185,7 @@ public slots:
      * @example <caption>Create a rotation of 180 degrees about the y axis.</caption>
      * var rotation = Quat.fromVec3Radians({ x: 0, y: Math.PI, z: 0 });
      */
-    glm::qua<float,glm::packed_highp> fromVec3Radians(const glm::vec<3,float,glm::packed_highp>& vec3);
+    glm::qua<float,glm::packed_highp> fromVec3Radians(const glm::vec3& vec3);
 
     /*@jsdoc
     * Generates a quaternion from pitch, yaw, and roll values in degrees.
@@ -235,7 +235,7 @@ public slots:
      * @param {Quat} orientation - A quaternion representing an orientation.
      * @returns {Vec3} The negative z-axis rotated by <code>orientation</code>.
      */
-    glm::vec<3,float,glm::packed_highp> getFront(const glm::qua<float,glm::packed_highp>& orientation) { return getForward(orientation); }
+    glm::vec3 getFront(const glm::qua<float,glm::packed_highp>& orientation) { return getForward(orientation); }
 
     /*@jsdoc
      * Gets the "forward" direction that the camera would face if its orientation was set to the quaternion value.
@@ -248,7 +248,7 @@ public slots:
      * var forward = Quat.getForward(Quat.IDENTITY);
      * print(JSON.stringify(forward)); // {"x":0,"y":0,"z":-1}
      */
-    glm::vec<3,float,glm::packed_highp> getForward(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 getForward(const glm::qua<float,glm::packed_highp>& orientation);
 
     /*@jsdoc
      * Gets the "right" direction that the camera would have if its orientation was set to the quaternion value.
@@ -257,7 +257,7 @@ public slots:
      * @param {Quat} orientation - A quaternion representing an orientation.
      * @returns {Vec3} The x-axis rotated by <code>orientation</code>.
      */
-    glm::vec<3,float,glm::packed_highp> getRight(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 getRight(const glm::qua<float,glm::packed_highp>& orientation);
 
     /*@jsdoc
      * Gets the "up" direction that the camera would have if its orientation was set to the quaternion value.
@@ -266,7 +266,7 @@ public slots:
      * @param {Quat} orientation - A quaternion representing an orientation.
      * @returns {Vec3} The y-axis rotated by <code>orientation</code>.
      */
-    glm::vec<3,float,glm::packed_highp> getUp(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 getUp(const glm::qua<float,glm::packed_highp>& orientation);
 
     /*@jsdoc
      * Calculates the Euler angles for the quaternion, in degrees. (The "safe" in the name signifies that the angle results 
@@ -279,7 +279,7 @@ public slots:
      * var eulerAngles = Quat.safeEulerAngles(Camera.orientation);
      * print("Camera yaw: " + eulerAngles.y);
      */
-    glm::vec<3,float,glm::packed_highp> safeEulerAngles(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 safeEulerAngles(const glm::qua<float,glm::packed_highp>& orientation);
 
     /*@jsdoc
      * Generates a quaternion given an angle to rotate through and an axis to rotate about.
@@ -292,7 +292,7 @@ public slots:
      * @example <caption>Calculate a rotation of 90 degrees about the direction your camera is looking.</caption>
      * var rotation = Quat.angleAxis(90, Quat.getForward(Camera.orientation));
      */
-    glm::qua<float,glm::packed_highp> angleAxis(float angle, const glm::vec<3,float,glm::packed_highp>& v);
+    glm::qua<float,glm::packed_highp> angleAxis(float angle, const glm::vec3& v);
 
     /*@jsdoc
      * Gets the rotation axis for a quaternion.
@@ -306,7 +306,7 @@ public slots:
      * print("Forward: " + JSON.stringify(forward));
      * print("Axis: " + JSON.stringify(axis)); // Same value as forward.
      */
-    glm::vec<3,float,glm::packed_highp> axis(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 axis(const glm::qua<float,glm::packed_highp>& orientation);
 
     /*@jsdoc
      * Gets the rotation angle for a quaternion.

--- a/libraries/script-engine/src/Quat.h
+++ b/libraries/script-engine/src/Quat.h
@@ -62,7 +62,7 @@
 /// Provides the <code><a href="https://apidocs.overte.org/Quat.html">Quat</a></code> scripting interface
 class Quat : public QObject, protected Scriptable {
     Q_OBJECT
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> IDENTITY READ IDENTITY CONSTANT)
+    Q_PROPERTY(glm::quat IDENTITY READ IDENTITY CONSTANT)
 
 public slots:
 
@@ -79,7 +79,7 @@ public slots:
      *     var handOrientation = Quat.multiply(MyAvatar.orientation, handPose.rotation);
      * }
      */
-    glm::qua<float,glm::packed_highp> multiply(const glm::qua<float,glm::packed_highp>& q1, const glm::qua<float,glm::packed_highp>& q2);
+    glm::quat multiply(const glm::quat& q1, const glm::quat& q2);
 
     /*@jsdoc
      * Normalizes a quaternion.
@@ -95,7 +95,7 @@ public slots:
      *     // Use currentRotatation for something.
      * }
      */
-    glm::qua<float,glm::packed_highp> normalize(const glm::qua<float,glm::packed_highp>& q);
+    glm::quat normalize(const glm::quat& q);
 
     /*@jsdoc
     * Calculates the conjugate of a quaternion. For a unit quaternion, its conjugate is the same as its 
@@ -111,7 +111,7 @@ public slots:
     * var identity = Quat.multiply(conjugate, quaternion);
     * Quat.print("identity", identity, true); // dvec3(0.000000, 0.000000, 0.000000)
     */
-    glm::qua<float,glm::packed_highp> conjugate(const glm::qua<float,glm::packed_highp>& q);
+    glm::quat conjugate(const glm::quat& q);
 
     /*@jsdoc
      * Calculates a camera orientation given an eye position, point of interest, and "up" direction. The camera's negative 
@@ -127,7 +127,7 @@ public slots:
      * Camera.mode = "independent";
      * Camera.orientation = Quat.lookAt(Camera.position, Vec3.ZERO, Vec3.UNIT_NEG_Y);
      */
-    glm::qua<float,glm::packed_highp> lookAt(const glm::vec3& eye, const glm::vec3& center, const glm::vec3& up);
+    glm::quat lookAt(const glm::vec3& eye, const glm::vec3& center, const glm::vec3& up);
 
     /*@jsdoc
     * Calculates a camera orientation given an eye position and point of interest. The camera's negative z-axis is the forward 
@@ -143,7 +143,7 @@ public slots:
     * Camera.mode = "independent";
     * Camera.orientation = Quat.lookAtSimple(Camera.position, Vec3.ZERO);
     */
-    glm::qua<float,glm::packed_highp> lookAtSimple(const glm::vec3& eye, const glm::vec3& center);
+    glm::quat lookAtSimple(const glm::vec3& eye, const glm::vec3& center);
 
     /*@jsdoc
     * Calculates the shortest rotation from a first vector onto a second.
@@ -160,7 +160,7 @@ public slots:
     * Entities.editEntity(entityID, properties);
     * entityVelocity = newVelocity;
     */
-    glm::qua<float,glm::packed_highp> rotationBetween(const glm::vec3& v1, const glm::vec3& v2);
+    glm::quat rotationBetween(const glm::vec3& v1, const glm::vec3& v2);
 
     /*@jsdoc
      * Generates a quaternion from a {@link Vec3} of Euler angles in degrees.
@@ -174,7 +174,7 @@ public slots:
      * eulerAngles.z = 0;
      * var newOrientation = Quat.fromVec3Degrees(eulerAngles);
      */
-    glm::qua<float,glm::packed_highp> fromVec3Degrees(const glm::vec3& vec3);
+    glm::quat fromVec3Degrees(const glm::vec3& vec3);
 
     /*@jsdoc
      * Generates a quaternion from a {@link Vec3} of Euler angles in radians.
@@ -185,7 +185,7 @@ public slots:
      * @example <caption>Create a rotation of 180 degrees about the y axis.</caption>
      * var rotation = Quat.fromVec3Radians({ x: 0, y: Math.PI, z: 0 });
      */
-    glm::qua<float,glm::packed_highp> fromVec3Radians(const glm::vec3& vec3);
+    glm::quat fromVec3Radians(const glm::vec3& vec3);
 
     /*@jsdoc
     * Generates a quaternion from pitch, yaw, and roll values in degrees.
@@ -197,7 +197,7 @@ public slots:
     * @example <caption>Create a rotation of 180 degrees about the y axis.</caption>
     * var rotation = Quat.fromPitchYawRollDegrees(0, 180, 0 );
     */
-    glm::qua<float,glm::packed_highp> fromPitchYawRollDegrees(float pitch, float yaw, float roll);
+    glm::quat fromPitchYawRollDegrees(float pitch, float yaw, float roll);
 
     /*@jsdoc
     * Generates a quaternion from pitch, yaw, and roll values in radians.
@@ -209,7 +209,7 @@ public slots:
     * @example <caption>Create a rotation of 180 degrees about the y axis.</caption>
     * var rotation = Quat.fromPitchYawRollRadians(0, Math.PI, 0);
     */
-    glm::qua<float,glm::packed_highp> fromPitchYawRollRadians(float pitch, float yaw, float roll);
+    glm::quat fromPitchYawRollRadians(float pitch, float yaw, float roll);
 
     /*@jsdoc
      * Calculates the inverse of a quaternion. For a unit quaternion, its inverse is the same as its
@@ -225,7 +225,7 @@ public slots:
      * var identity = Quat.multiply(inverse, quaternion);
      * Quat.print("identity", identity, true); // dvec3(0.000000, 0.000000, 0.000000)
      */
-    glm::qua<float,glm::packed_highp> inverse(const glm::qua<float,glm::packed_highp>& q);
+    glm::quat inverse(const glm::quat& q);
 
     /*@jsdoc
      * Gets the "front" direction that the camera would face if its orientation was set to the quaternion value.
@@ -235,7 +235,7 @@ public slots:
      * @param {Quat} orientation - A quaternion representing an orientation.
      * @returns {Vec3} The negative z-axis rotated by <code>orientation</code>.
      */
-    glm::vec3 getFront(const glm::qua<float,glm::packed_highp>& orientation) { return getForward(orientation); }
+    glm::vec3 getFront(const glm::quat& orientation) { return getForward(orientation); }
 
     /*@jsdoc
      * Gets the "forward" direction that the camera would face if its orientation was set to the quaternion value.
@@ -248,7 +248,7 @@ public slots:
      * var forward = Quat.getForward(Quat.IDENTITY);
      * print(JSON.stringify(forward)); // {"x":0,"y":0,"z":-1}
      */
-    glm::vec3 getForward(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 getForward(const glm::quat& orientation);
 
     /*@jsdoc
      * Gets the "right" direction that the camera would have if its orientation was set to the quaternion value.
@@ -257,7 +257,7 @@ public slots:
      * @param {Quat} orientation - A quaternion representing an orientation.
      * @returns {Vec3} The x-axis rotated by <code>orientation</code>.
      */
-    glm::vec3 getRight(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 getRight(const glm::quat& orientation);
 
     /*@jsdoc
      * Gets the "up" direction that the camera would have if its orientation was set to the quaternion value.
@@ -266,7 +266,7 @@ public slots:
      * @param {Quat} orientation - A quaternion representing an orientation.
      * @returns {Vec3} The y-axis rotated by <code>orientation</code>.
      */
-    glm::vec3 getUp(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 getUp(const glm::quat& orientation);
 
     /*@jsdoc
      * Calculates the Euler angles for the quaternion, in degrees. (The "safe" in the name signifies that the angle results 
@@ -279,7 +279,7 @@ public slots:
      * var eulerAngles = Quat.safeEulerAngles(Camera.orientation);
      * print("Camera yaw: " + eulerAngles.y);
      */
-    glm::vec3 safeEulerAngles(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 safeEulerAngles(const glm::quat& orientation);
 
     /*@jsdoc
      * Generates a quaternion given an angle to rotate through and an axis to rotate about.
@@ -292,7 +292,7 @@ public slots:
      * @example <caption>Calculate a rotation of 90 degrees about the direction your camera is looking.</caption>
      * var rotation = Quat.angleAxis(90, Quat.getForward(Camera.orientation));
      */
-    glm::qua<float,glm::packed_highp> angleAxis(float angle, const glm::vec3& v);
+    glm::quat angleAxis(float angle, const glm::vec3& v);
 
     /*@jsdoc
      * Gets the rotation axis for a quaternion.
@@ -306,7 +306,7 @@ public slots:
      * print("Forward: " + JSON.stringify(forward));
      * print("Axis: " + JSON.stringify(axis)); // Same value as forward.
      */
-    glm::vec3 axis(const glm::qua<float,glm::packed_highp>& orientation);
+    glm::vec3 axis(const glm::quat& orientation);
 
     /*@jsdoc
      * Gets the rotation angle for a quaternion.
@@ -320,7 +320,7 @@ public slots:
      * var angle = Quat.angle(rotation);
      * print("Angle: " + angle * 180 / Math.PI);  // 90 degrees.
      */
-    float angle(const glm::qua<float,glm::packed_highp>& orientation);
+    float angle(const glm::quat& orientation);
 
     // spherical linear interpolation
     // alpha: 0.0 to 1.0?
@@ -342,7 +342,7 @@ public slots:
      * }
      * var newRotation = Quat.mix(startRotation, endRotation, mixFactor);
      */
-    glm::qua<float,glm::packed_highp> mix(const glm::qua<float,glm::packed_highp>& q1, const glm::qua<float,glm::packed_highp>& q2, float alpha);
+    glm::quat mix(const glm::quat& q1, const glm::quat& q2, float alpha);
 
     /*@jsdoc
      * Computes a spherical linear interpolation between two rotations, for rotations that are not very similar.
@@ -355,7 +355,7 @@ public slots:
      *     <code>q1</code>'s value; <code>1.0</code> returns <code>q2s</code>'s value.
      * @returns {Quat} A spherical linear interpolation between rotations <code>q1</code> and <code>q2</code>.
      */
-    glm::qua<float,glm::packed_highp> slerp(const glm::qua<float,glm::packed_highp>& q1, const glm::qua<float,glm::packed_highp>& q2, float alpha);
+    glm::quat slerp(const glm::quat& q1, const glm::quat& q2, float alpha);
 
     /*@jsdoc
      * Computes a spherical quadrangle interpolation between two rotations along a path oriented toward two other rotations.
@@ -370,7 +370,7 @@ public slots:
      * @returns {Quat} A spherical quadrangle interpolation between rotations <code>q1</code> and <code>q2</code> using control
      *     points <code>s1</code> and <code>s2</code>.
      */
-    glm::qua<float,glm::packed_highp> squad(const glm::qua<float,glm::packed_highp>& q1, const glm::qua<float,glm::packed_highp>& q2, const glm::qua<float,glm::packed_highp>& s1, const glm::qua<float,glm::packed_highp>& s2, float h);
+    glm::quat squad(const glm::quat& q1, const glm::quat& q2, const glm::quat& s1, const glm::quat& s2, float h);
 
     /*@jsdoc
      * Calculates the dot product of two quaternions. The closer the quaternions are to each other the more non-zero the value 
@@ -391,7 +391,7 @@ public slots:
      * var equal = Math.abs(1 - Math.abs(dot)) < 0.000001;
      * print(equal); // true
      */
-    float dot(const glm::qua<float,glm::packed_highp>& q1, const glm::qua<float,glm::packed_highp>& q2);
+    float dot(const glm::quat& q1, const glm::quat& q2);
     
     /*@jsdoc
      * Prints to the program log a text label followed by a quaternion's pitch, yaw, and roll Euler angles.
@@ -409,7 +409,7 @@ public slots:
      * // Quaternion: {"x":0,"y":45.000003814697266,"z":0}
      * print("Quaternion: " + JSON.stringify(Quat.safeEulerAngles(quaternion)));
      */
-    void print(const QString& label, const glm::qua<float,glm::packed_highp>& q, bool asDegrees = false);
+    void print(const QString& label, const glm::quat& q, bool asDegrees = false);
 
     /*@jsdoc
      * Tests whether two quaternions are equal.
@@ -431,7 +431,7 @@ public slots:
      * var equal = Math.abs(1 - Math.abs(dot)) < 0.000001;
      * print(equal); // true
      */
-    bool equal(const glm::qua<float,glm::packed_highp>& q1, const glm::qua<float,glm::packed_highp>& q2);
+    bool equal(const glm::quat& q1, const glm::quat& q2);
 
     /*@jsdoc
      * Cancels out the roll and pitch component of a quaternion so that its completely horizontal with a yaw pointing in the 
@@ -451,7 +451,7 @@ public slots:
      * Quat.print("", lookAt, true); // dvec3(0.000000, 22.245996, 0.000000)
      *
      */
-    glm::qua<float,glm::packed_highp> cancelOutRollAndPitch(const glm::qua<float,glm::packed_highp>& q);
+    glm::quat cancelOutRollAndPitch(const glm::quat& q);
 
     /*@jsdoc
     * Cancels out the roll component of a quaternion so that its horizontal axis is level.
@@ -469,10 +469,10 @@ public slots:
     * var lookAt = Quat.lookAtSimple(Vec3.ZERO, front);
     * Quat.print("", lookAt, true); // dvec3(-1.033004, 22.245996, -0.000000)
     */
-    glm::qua<float,glm::packed_highp> cancelOutRoll(const glm::qua<float,glm::packed_highp>& q);
+    glm::quat cancelOutRoll(const glm::quat& q);
 
 private:
-    const glm::qua<float,glm::packed_highp>& IDENTITY() const { return Quaternions::IDENTITY; }
+    const glm::quat& IDENTITY() const { return Quaternions::IDENTITY; }
 
 };
 

--- a/libraries/script-engine/src/ScriptValueUtils.h
+++ b/libraries/script-engine/src/ScriptValueUtils.h
@@ -148,9 +148,9 @@ bool u8vec3FromScriptValue(const ScriptValue& object, glm::u8vec3& vec3);
  * @property {number} z - Z-coordinate of the vector.
  * @property {number} w - W-coordinate of the vector.
  */
-ScriptValue vec4toScriptValue(ScriptEngine* engine, const glm::vec<4,float,glm::packed_highp>& vec4);
-ScriptValue vec4ColorToScriptValue(ScriptEngine* engine, const glm::vec<4,float,glm::packed_highp>& vec4);
-bool vec4FromScriptValue(const ScriptValue& object, glm::vec<4,float,glm::packed_highp>& vec4);
+ScriptValue vec4toScriptValue(ScriptEngine* engine, const glm::vec4& vec4);
+ScriptValue vec4ColorToScriptValue(ScriptEngine* engine, const glm::vec4& vec4);
+bool vec4FromScriptValue(const ScriptValue& object, glm::vec4& vec4);
 
 // Quaternions
 ScriptValue quatToScriptValue(ScriptEngine* engine, const glm::quat& quat);

--- a/libraries/script-engine/src/ScriptValueUtils.h
+++ b/libraries/script-engine/src/ScriptValueUtils.h
@@ -53,8 +53,8 @@ void registerMetaTypes(ScriptEngine* engine);
  * @property {number} r2c3 - Row 2, column 3 value.
  * @property {number} r3c3 - Row 3, column 3 value.
  */
-ScriptValue mat4toScriptValue(ScriptEngine* engine, const glm::mat<4,4,float,glm::packed_highp>& mat4);
-bool mat4FromScriptValue(const ScriptValue& object, glm::mat<4,4,float,glm::packed_highp>& mat4);
+ScriptValue mat4toScriptValue(ScriptEngine* engine, const glm::mat4& mat4);
+bool mat4FromScriptValue(const ScriptValue& object, glm::mat4& mat4);
 
 /*@jsdoc
 * A 2-dimensional vector.

--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -113,7 +113,7 @@ public slots:
      * var reflected = Vec3.reflect(v, normal);
      * print(JSON.stringify(reflected));  // {"x":1,"y":-2,"z":3}
      */
-    glm::vec<3,float,glm::packed_highp> reflect(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2) { return glm::reflect(v1, v2); }
+    glm::vec3 reflect(const glm::vec3& v1, const glm::vec3& v2) { return glm::reflect(v1, v2); }
     
     /*@jsdoc
      * Calculates the cross product of two vectors.
@@ -127,7 +127,7 @@ public slots:
      * var crossProduct = Vec3.cross(v1, v2);
      * print(JSON.stringify(crossProduct)); // {"x":0,"y":0,"z":1}
      */
-    glm::vec<3,float,glm::packed_highp> cross(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2) { return glm::cross(v1, v2); }
+    glm::vec3 cross(const glm::vec3& v1, const glm::vec3& v2) { return glm::cross(v1, v2); }
     
     /*@jsdoc
      * Calculates the dot product of two vectors.
@@ -141,7 +141,7 @@ public slots:
      * var dotProduct = Vec3.dot(v1, v2);
      * print(dotProduct); // 0
      */
-    float dot(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2) { return glm::dot(v1, v2); }
+    float dot(const glm::vec3& v1, const glm::vec3& v2) { return glm::dot(v1, v2); }
     
     /*@jsdoc
      * Multiplies a vector by a scale factor.
@@ -150,7 +150,7 @@ public slots:
      * @param {number} scale - The scale factor.
      * @returns {Vec3} The vector with each ordinate value multiplied by the <code>scale</code>.
      */
-    glm::vec<3,float,glm::packed_highp> multiply(const glm::vec<3,float,glm::packed_highp>& v1, float f) { return v1 * f; }
+    glm::vec3 multiply(const glm::vec3& v1, float f) { return v1 * f; }
     
     /*@jsdoc
      * Multiplies a vector by a scale factor.
@@ -159,7 +159,7 @@ public slots:
      * @param {Vec3} v - The vector.
      * @returns {Vec3} The vector with each ordinate value multiplied by the <code>scale</code>.
      */
-    glm::vec<3,float,glm::packed_highp> multiply(float f, const glm::vec<3,float,glm::packed_highp>& v1) { return v1 * f; }
+    glm::vec3 multiply(float f, const glm::vec3& v1) { return v1 * f; }
     
     /*@jsdoc
      * Multiplies two vectors.
@@ -174,7 +174,7 @@ public slots:
      * var multiplied = Vec3.multiplyVbyV(v1, v2);
      * print(JSON.stringify(multiplied));  // {"x":1,"y":4,"z":9}
      */
-    glm::vec<3,float,glm::packed_highp> multiplyVbyV(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2) { return v1 * v2; }
+    glm::vec3 multiplyVbyV(const glm::vec3& v1, const glm::vec3& v2) { return v1 * v2; }
     
     /*@jsdoc
      * Rotates a vector.
@@ -188,7 +188,7 @@ public slots:
      * var result = Vec3.multiplyQbyV(q, v);
      * print(JSON.stringify(result));  // {"x":0,"y":1.000,"z":1.19e-7}
      */
-    glm::vec<3,float,glm::packed_highp> multiplyQbyV(const glm::qua<float,glm::packed_highp>& q, const glm::vec<3,float,glm::packed_highp>& v) { return q * v; }
+    glm::vec3 multiplyQbyV(const glm::quat& q, const glm::vec3& v) { return q * v; }
     
     /*@jsdoc
      * Calculates the sum of two vectors.
@@ -197,7 +197,7 @@ public slots:
      * @param {Vec3} v2 - The second vector.
      * @returns {Vec3} The sum of the two vectors.
      */
-    glm::vec<3,float,glm::packed_highp> sum(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2) { return v1 + v2; }
+    glm::vec3 sum(const glm::vec3& v1, const glm::vec3& v2) { return v1 + v2; }
     
     /*@jsdoc
      * Calculates one vector subtracted from another.
@@ -206,7 +206,7 @@ public slots:
      * @param {Vec3} v2 - The second vector.
      * @returns {Vec3} The second vector subtracted from the first.
      */
-    glm::vec<3,float,glm::packed_highp> subtract(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2) { return v1 - v2; }
+    glm::vec3 subtract(const glm::vec3& v1, const glm::vec3& v2) { return v1 - v2; }
     
     /*@jsdoc
      * Calculates the length of a vector
@@ -214,7 +214,7 @@ public slots:
      * @param {Vec3} v - The vector.
      * @returns {number} The length of the vector.
      */
-    float length(const glm::vec<3,float,glm::packed_highp>& v) { return glm::length(v); }
+    float length(const glm::vec3& v) { return glm::length(v); }
     
     /*@jsdoc
      * Calculates the distance between two points.
@@ -232,7 +232,7 @@ public slots:
      * distance = Vec3.distance(p1, p2);
      * print(distance); // 10
      */
-    float distance(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2) { return glm::distance(v1, v2); }
+    float distance(const glm::vec3& v1, const glm::vec3& v2) { return glm::distance(v1, v2); }
     
     /*@jsdoc
      * Calculates the angle of rotation from one vector onto another, with the sign depending on a reference vector.
@@ -254,7 +254,7 @@ public slots:
      * print(Vec3.orientedAngle(v1, v2, { x: 1, y: 2, z: -1 }));  // -45
      * print(Vec3.orientedAngle(v1, v2, { x: 1, y: -2, z: -1 }));  // 45
      */
-    float orientedAngle(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2, const glm::vec<3,float,glm::packed_highp>& v3);
+    float orientedAngle(const glm::vec3& v1, const glm::vec3& v2, const glm::vec3& v3);
     
     /*@jsdoc
      * Normalizes a vector so that its length is <code>1</code>.
@@ -267,7 +267,7 @@ public slots:
      * print(JSON.stringify(normalized));  // {"x":0.7071,"y":0.7071,"z":0}
      * print(Vec3.length(normalized));  // 1
      */
-    glm::vec<3,float,glm::packed_highp> normalize(const glm::vec<3,float,glm::packed_highp>& v) { return glm::normalize(v); };
+    glm::vec3 normalize(const glm::vec3& v) { return glm::normalize(v); };
     
     /*@jsdoc
      * Calculates a linear interpolation between two vectors.
@@ -282,7 +282,7 @@ public slots:
      * var interpolated = Vec3.mix(v1, v2, 0.75);  // 1/4 of v1 and 3/4 of v2.
      * print(JSON.stringify(interpolated));  // {"x":2.5,"y":7.5","z":0}
      */
-    glm::vec<3,float,glm::packed_highp> mix(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2, float m) { return glm::mix(v1, v2, m); }
+    glm::vec3 mix(const glm::vec3& v1, const glm::vec3& v2, float m) { return glm::mix(v1, v2, m); }
     
     /*@jsdoc
      * Prints the vector to the program log, as a text label followed by the vector value.
@@ -294,7 +294,7 @@ public slots:
      * Vec3.print("Vector: ", v);  // dvec3(1.000000, 2.000000, 3.000000)
      * print("Vector: " + JSON.stringify(v));  // {"x":1,"y":2,"z":3}
      */
-    void print(const QString& label, const glm::vec<3,float,glm::packed_highp>& v);
+    void print(const QString& label, const glm::vec3& v);
     
     /*@jsdoc
      * Tests whether two vectors are equal.
@@ -315,7 +315,7 @@ public slots:
      * equal = Vec3.equal(v1, v2);
      * print(equal);  // false
      */
-    bool equal(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2) { return v1 == v2; }
+    bool equal(const glm::vec3& v1, const glm::vec3& v2) { return v1 == v2; }
     
     /*@jsdoc
      * Tests whether two vectors are equal within a tolerance.
@@ -336,7 +336,7 @@ public slots:
      * equal = Vec3.withinEpsilon(v1, v2, 0.001);
      * print(equal);  // true
      */
-    bool withinEpsilon(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2, float epsilon);
+    bool withinEpsilon(const glm::vec3& v1, const glm::vec3& v2, float epsilon);
     
     /*@jsdoc
      * Calculates polar coordinates (elevation, azimuth, radius) that transform the unit z-axis vector onto a point.
@@ -352,7 +352,7 @@ public slots:
      * print("Radius: " + polar.z);  // 7.5
      */
     // FIXME misnamed, should be 'spherical' or 'euler' depending on the implementation
-    glm::vec<3,float,glm::packed_highp> toPolar(const glm::vec<3,float,glm::packed_highp>& v);
+    glm::vec3 toPolar(const glm::vec3& v);
     
     /*@jsdoc
      * Calculates the coordinates of a point from polar coordinate transformation of the unit z-axis vector.
@@ -366,7 +366,7 @@ public slots:
      * print(JSON.stringify(p));  // {"x":5,"y":2.5,"z":5}
      */
     // FIXME misnamed, should be 'spherical' or 'euler' depending on the implementation
-    glm::vec<3,float,glm::packed_highp> fromPolar(const glm::vec<3,float,glm::packed_highp>& polar);
+    glm::vec3 fromPolar(const glm::vec3& polar);
     
     /*@jsdoc
      * Calculates the unit vector corresponding to polar coordinates elevation and azimuth transformation of the unit z-axis 
@@ -384,7 +384,7 @@ public slots:
      * print(JSON.stringify(p));  // {"x":5,"y":2.5,"z":5}
      */
     // FIXME misnamed, should be 'spherical' or 'euler' depending on the implementation
-    glm::vec<3,float,glm::packed_highp> fromPolar(float elevation, float azimuth);
+    glm::vec3 fromPolar(float elevation, float azimuth);
     
     /*@jsdoc
      * Calculates the angle between two vectors.
@@ -398,28 +398,28 @@ public slots:
      * var angle = Vec3.getAngle(v1, v2);
      * print(angle * 180 / Math.PI);  // 90
      */
-    float getAngle(const glm::vec<3,float,glm::packed_highp>& v1, const glm::vec<3,float,glm::packed_highp>& v2);
+    float getAngle(const glm::vec3& v1, const glm::vec3& v2);
 
 private:
-    const glm::vec<3,float,glm::packed_highp>& UNIT_X() { return Vectors::UNIT_X; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_Y() { return Vectors::UNIT_Y; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_Z() { return Vectors::UNIT_Z; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_NEG_X() { return Vectors::UNIT_NEG_X; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_NEG_Y() { return Vectors::UNIT_NEG_Y; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_NEG_Z() { return Vectors::UNIT_NEG_Z; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_XY() { return Vectors::UNIT_XY; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_XZ() { return Vectors::UNIT_XZ; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_YZ() { return Vectors::UNIT_YZ; }
-    const glm::vec<3,float,glm::packed_highp>& UNIT_XYZ() { return Vectors::UNIT_XYZ; }
-    const glm::vec<3,float,glm::packed_highp>& FLOAT_MAX() { return Vectors::MAX; }
-    const glm::vec<3,float,glm::packed_highp>& FLOAT_MIN() { return Vectors::MIN; }
-    const glm::vec<3,float,glm::packed_highp>& ZERO() { return Vectors::ZERO; }
-    const glm::vec<3,float,glm::packed_highp>& ONE() { return Vectors::ONE; }
-    const glm::vec<3,float,glm::packed_highp>& TWO() { return Vectors::TWO; }
-    const glm::vec<3,float,glm::packed_highp>& HALF() { return Vectors::HALF; }
-    const glm::vec<3,float,glm::packed_highp>& RIGHT() { return Vectors::RIGHT; }
-    const glm::vec<3,float,glm::packed_highp>& UP() { return Vectors::UP; }
-    const glm::vec<3,float,glm::packed_highp>& FRONT() { return Vectors::FRONT; }
+    const glm::vec3& UNIT_X() { return Vectors::UNIT_X; }
+    const glm::vec3& UNIT_Y() { return Vectors::UNIT_Y; }
+    const glm::vec3& UNIT_Z() { return Vectors::UNIT_Z; }
+    const glm::vec3& UNIT_NEG_X() { return Vectors::UNIT_NEG_X; }
+    const glm::vec3& UNIT_NEG_Y() { return Vectors::UNIT_NEG_Y; }
+    const glm::vec3& UNIT_NEG_Z() { return Vectors::UNIT_NEG_Z; }
+    const glm::vec3& UNIT_XY() { return Vectors::UNIT_XY; }
+    const glm::vec3& UNIT_XZ() { return Vectors::UNIT_XZ; }
+    const glm::vec3& UNIT_YZ() { return Vectors::UNIT_YZ; }
+    const glm::vec3& UNIT_XYZ() { return Vectors::UNIT_XYZ; }
+    const glm::vec3& FLOAT_MAX() { return Vectors::MAX; }
+    const glm::vec3& FLOAT_MIN() { return Vectors::MIN; }
+    const glm::vec3& ZERO() { return Vectors::ZERO; }
+    const glm::vec3& ONE() { return Vectors::ONE; }
+    const glm::vec3& TWO() { return Vectors::TWO; }
+    const glm::vec3& HALF() { return Vectors::HALF; }
+    const glm::vec3& RIGHT() { return Vectors::RIGHT; }
+    const glm::vec3& UP() { return Vectors::UP; }
+    const glm::vec3& FRONT() { return Vectors::FRONT; }
 
 public:
     virtual ~Vec3();

--- a/libraries/script-engine/src/v8/ScriptObjectV8Proxy.cpp
+++ b/libraries/script-engine/src/v8/ScriptObjectV8Proxy.cpp
@@ -1033,10 +1033,21 @@ void ScriptMethodV8Proxy::call(const v8::FunctionCallbackInfo<v8::Value>& argume
         // This check is needed for catching issues caused by a bug in Qt6 that causes metamethod invocations to fail when typedefs are used in header files.
 #if !defined(QT_NO_DEBUG) || defined(QT_FORCE_ASSERTS)
          for (int parameterIndex = 0; parameterIndex < meta.parameterCount(); parameterIndex++) {
-             if (std::string(meta.parameterTypeName(parameterIndex)) != std::string(meta.parameterMetaType(parameterIndex).name())) {
+            const auto parameterTypeName = std::string(meta.parameterTypeName(parameterIndex));
+            const auto parameterMetatypeName = std::string(meta.parameterMetaType(parameterIndex).name());
+
+            // GLM types will always trigger this, there's a workaround below
+            if (
+                parameterTypeName.starts_with("glm::") ||
+                parameterMetatypeName.starts_with("glm::")
+            ) {
+                continue;
+            }
+
+            if (parameterTypeName != parameterMetatypeName) {
                  qCritical() << "ScriptMethodV8Proxy::call: " << fullName() << " parameter " << parameterIndex
-                     << " has a broken type " << meta.parameterTypeName(parameterIndex)
-                     << " Correct type is " << meta.parameterMetaType(parameterIndex).name();
+                     << " has a broken type " << parameterTypeName
+                     << " Correct type is " << parameterMetatypeName;
                  Q_ASSERT(false);
              }
          }
@@ -1078,10 +1089,35 @@ void ScriptMethodV8Proxy::call(const v8::FunctionCallbackInfo<v8::Value>& argume
                     const QVariant& converted = qVarArgLists[i].back();
                     conversionPenaltyScore += _engine->computeCastPenalty(V8ScriptValue(_engine, argVal), methodArgTypeId);
 
+                    // QT6TODO: FIXME: Qt 6.5 changed the metatype system a lot. It now uses fully
+                    // qualified type names, ignoring typedefs/usings/the qRegisterMetaType alias.
+                    // Silently replace the GLM types with their typedef names to satisfy Qt.
+                    // In the future we should move away from using Qt metamethods, since they
+                    // might be basically useless for us when Qt 7 arrives.
+                    // FIXME: GCC and Clang have different names for these, we'll need to check
+                    // both of them. MSVC likely has its own name for them too. Maybe we should
+                    // have a map rather than this if-else table if that's the case?
+                    // NOTE: These have to be static or nearly-static lifetime strings (i.e.
+                    // the metatype's name field, which lives for the app's whole lifetime),
+                    // QGenericArgument doesn't copy them.
+                    const char *staticTypeName = QMetaType(converted.userType()).name();
+                    auto typeName = std::string(staticTypeName);
+                    if (typeName == "glm::vec<2,float,glm::packed_highp>") {
+                        staticTypeName = "glm::vec2";
+                    } else if (typeName == "glm::vec<3,float,glm::packed_highp>") {
+                        staticTypeName = "glm::vec3";
+                    } else if (typeName == "glm::vec<4,float,glm::packed_highp>") {
+                        staticTypeName = "glm::vec4";
+                    } else if (typeName == "glm::qua<float,glm::packed_highp>") {
+                        staticTypeName = "glm::quat";
+                    } else if (typeName == "glm::mat4") {
+                        staticTypeName = "glm::mat<4,4,float,glm::packed_highp>";
+                    }
+
                     // a lot of type conversion assistance thanks to https://stackoverflow.com/questions/28457819/qt-invoke-method-with-qvariant
                     // A const_cast is needed because calling data() would detach the QVariant.
                     qGenArgsVectors[i][arg] =
-                        QGenericArgument(QMetaType(converted.userType()).name(), const_cast<void*>(converted.constData()));
+                        QGenericArgument(staticTypeName, const_cast<void*>(converted.constData()));
                 }
             }
         }

--- a/libraries/shared/src/DebugDraw.h
+++ b/libraries/shared/src/DebugDraw.h
@@ -61,7 +61,7 @@ public:
      *     DebugDraw.drawRay(start, end, color);
      * });
      */
-    Q_INVOKABLE void drawRay(const glm::vec<3,float,glm::packed_highp>& start, const glm::vec<3,float,glm::packed_highp>& end, const glm::vec<4,float,glm::packed_highp>& color);
+    Q_INVOKABLE void drawRay(const glm::vec<3,float,glm::packed_highp>& start, const glm::vec<3,float,glm::packed_highp>& end, const glm::vec4& color);
     
     /*@jsdoc
      * Draws lines in world space, visible for a single frame. To make the lines visually persist, you need to repeatedly draw 
@@ -86,7 +86,7 @@ public:
      *     DebugDraw.drawRays(lines, color, translation, rotation);
      * });
      */
-    Q_INVOKABLE void drawRays(const std::vector<std::pair<glm::vec<3,float,glm::packed_highp>, glm::vec<3,float,glm::packed_highp>>>& lines, const glm::vec<4,float,glm::packed_highp>& color,
+    Q_INVOKABLE void drawRays(const std::vector<std::pair<glm::vec<3,float,glm::packed_highp>, glm::vec<3,float,glm::packed_highp>>>& lines, const glm::vec4& color,
                               const glm::vec<3,float,glm::packed_highp>& translation = glm::vec<3,float,glm::packed_highp>(0.0f, 0.0f, 0.0f), const glm::qua<float,glm::packed_highp>& rotation = glm::qua<float,glm::packed_highp>(1.0f, 0.0f, 0.0f, 0.0f));
 
     /*@jsdoc
@@ -113,7 +113,7 @@ public:
      * }, 5000);
      */
     Q_INVOKABLE void addMarker(const QString& key, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& position,
-                               const glm::vec<4,float,glm::packed_highp>& color, float size = 1.0f);
+                               const glm::vec4& color, float size = 1.0f);
 
     /*@jsdoc
      * Removes a debug marker that was added in world coordinates.
@@ -146,7 +146,7 @@ public:
      * }, 5000);
      */
     Q_INVOKABLE void addMyAvatarMarker(const QString& key, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& position,
-                                       const glm::vec<4,float,glm::packed_highp>& color, float size = 1.0f);
+                                       const glm::vec4& color, float size = 1.0f);
 
     /*@jsdoc
      * Removes a debug marker that was added in avatar coordinates.

--- a/libraries/shared/src/DebugDraw.h
+++ b/libraries/shared/src/DebugDraw.h
@@ -87,7 +87,7 @@ public:
      * });
      */
     Q_INVOKABLE void drawRays(const std::vector<std::pair<glm::vec3, glm::vec3>>& lines, const glm::vec4& color,
-                              const glm::vec3& translation = glm::vec3(0.0f, 0.0f, 0.0f), const glm::qua<float,glm::packed_highp>& rotation = glm::qua<float,glm::packed_highp>(1.0f, 0.0f, 0.0f, 0.0f));
+                              const glm::vec3& translation = glm::vec3(0.0f, 0.0f, 0.0f), const glm::quat& rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
 
     /*@jsdoc
      * Adds or updates a debug marker in world coordinates. This marker is drawn every frame until it is removed using  
@@ -112,7 +112,7 @@ public:
      *     DebugDraw.removeMarker(MARKER_NAME);
      * }, 5000);
      */
-    Q_INVOKABLE void addMarker(const QString& key, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& position,
+    Q_INVOKABLE void addMarker(const QString& key, const glm::quat& rotation, const glm::vec3& position,
                                const glm::vec4& color, float size = 1.0f);
 
     /*@jsdoc
@@ -145,7 +145,7 @@ public:
      *     DebugDraw.removeMyAvatarMarker(MARKER_NAME);
      * }, 5000);
      */
-    Q_INVOKABLE void addMyAvatarMarker(const QString& key, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& position,
+    Q_INVOKABLE void addMyAvatarMarker(const QString& key, const glm::quat& rotation, const glm::vec3& position,
                                        const glm::vec4& color, float size = 1.0f);
 
     /*@jsdoc
@@ -155,7 +155,7 @@ public:
      */
     Q_INVOKABLE void removeMyAvatarMarker(const QString& key);
 
-    using MarkerInfo = std::tuple<glm::qua<float,glm::packed_highp>, glm::vec3, glm::vec4, float>;
+    using MarkerInfo = std::tuple<glm::quat, glm::vec3, glm::vec4, float>;
     using MarkerMap = std::map<QString, MarkerInfo>;
     using Ray = std::tuple<glm::vec3, glm::vec3, glm::vec4>;
     using Rays = std::vector<Ray>;
@@ -168,8 +168,8 @@ public:
     MarkerMap getMyAvatarMarkerMap() const;
     void updateMyAvatarPos(const glm::vec3& pos) { _myAvatarPos = pos; }
     const glm::vec3& getMyAvatarPos() const { return _myAvatarPos; }
-    void updateMyAvatarRot(const glm::qua<float,glm::packed_highp>& rot) { _myAvatarRot = rot; }
-    const glm::qua<float,glm::packed_highp>& getMyAvatarRot() const { return _myAvatarRot; }
+    void updateMyAvatarRot(const glm::quat& rot) { _myAvatarRot = rot; }
+    const glm::quat& getMyAvatarRot() const { return _myAvatarRot; }
     Rays getRays() const;
     void clearRays();
 

--- a/libraries/shared/src/DebugDraw.h
+++ b/libraries/shared/src/DebugDraw.h
@@ -61,7 +61,7 @@ public:
      *     DebugDraw.drawRay(start, end, color);
      * });
      */
-    Q_INVOKABLE void drawRay(const glm::vec<3,float,glm::packed_highp>& start, const glm::vec<3,float,glm::packed_highp>& end, const glm::vec4& color);
+    Q_INVOKABLE void drawRay(const glm::vec3& start, const glm::vec3& end, const glm::vec4& color);
     
     /*@jsdoc
      * Draws lines in world space, visible for a single frame. To make the lines visually persist, you need to repeatedly draw 
@@ -86,8 +86,8 @@ public:
      *     DebugDraw.drawRays(lines, color, translation, rotation);
      * });
      */
-    Q_INVOKABLE void drawRays(const std::vector<std::pair<glm::vec<3,float,glm::packed_highp>, glm::vec<3,float,glm::packed_highp>>>& lines, const glm::vec4& color,
-                              const glm::vec<3,float,glm::packed_highp>& translation = glm::vec<3,float,glm::packed_highp>(0.0f, 0.0f, 0.0f), const glm::qua<float,glm::packed_highp>& rotation = glm::qua<float,glm::packed_highp>(1.0f, 0.0f, 0.0f, 0.0f));
+    Q_INVOKABLE void drawRays(const std::vector<std::pair<glm::vec3, glm::vec3>>& lines, const glm::vec4& color,
+                              const glm::vec3& translation = glm::vec3(0.0f, 0.0f, 0.0f), const glm::qua<float,glm::packed_highp>& rotation = glm::qua<float,glm::packed_highp>(1.0f, 0.0f, 0.0f, 0.0f));
 
     /*@jsdoc
      * Adds or updates a debug marker in world coordinates. This marker is drawn every frame until it is removed using  
@@ -112,7 +112,7 @@ public:
      *     DebugDraw.removeMarker(MARKER_NAME);
      * }, 5000);
      */
-    Q_INVOKABLE void addMarker(const QString& key, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& position,
+    Q_INVOKABLE void addMarker(const QString& key, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& position,
                                const glm::vec4& color, float size = 1.0f);
 
     /*@jsdoc
@@ -145,7 +145,7 @@ public:
      *     DebugDraw.removeMyAvatarMarker(MARKER_NAME);
      * }, 5000);
      */
-    Q_INVOKABLE void addMyAvatarMarker(const QString& key, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec<3,float,glm::packed_highp>& position,
+    Q_INVOKABLE void addMyAvatarMarker(const QString& key, const glm::qua<float,glm::packed_highp>& rotation, const glm::vec3& position,
                                        const glm::vec4& color, float size = 1.0f);
 
     /*@jsdoc
@@ -155,7 +155,7 @@ public:
      */
     Q_INVOKABLE void removeMyAvatarMarker(const QString& key);
 
-    using MarkerInfo = std::tuple<glm::quat, glm::vec3, glm::vec4, float>;
+    using MarkerInfo = std::tuple<glm::qua<float,glm::packed_highp>, glm::vec3, glm::vec4, float>;
     using MarkerMap = std::map<QString, MarkerInfo>;
     using Ray = std::tuple<glm::vec3, glm::vec3, glm::vec4>;
     using Rays = std::vector<Ray>;

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -42,7 +42,7 @@ class Camera : public QObject {
     Q_OBJECT
 
     Q_PROPERTY(glm::vec3 position READ getPosition WRITE setPosition)
-    Q_PROPERTY(glm::qua<float,glm::packed_highp> orientation READ getOrientation WRITE setOrientation)
+    Q_PROPERTY(glm::quat orientation READ getOrientation WRITE setOrientation)
     Q_PROPERTY(QString mode READ getModeString WRITE setModeString NOTIFY modeUpdated)
     Q_PROPERTY(QVariantMap frustum READ getViewFrustum CONSTANT)
     Q_PROPERTY(bool captureMouse READ getCaptureMouse WRITE setCaptureMouse NOTIFY captureMouseChanged)
@@ -104,7 +104,7 @@ public slots:
      * @function Camera.getOrientation
      * @returns {Quat} The current camera orientation.
      */
-    glm::qua<float,glm::packed_highp> getOrientation() const { return _orientation; }
+    glm::quat getOrientation() const { return _orientation; }
 
     /*@jsdoc
      * Sets the camera orientation. You can also set the orientation using the {@link Camera|Camera.orientation} property. Only
@@ -112,7 +112,7 @@ public slots:
      * @function Camera.setOrientation
      * @param {Quat} orientation - The orientation to set the camera to.
      */
-    void setOrientation(const glm::qua<float,glm::packed_highp>& orientation);
+    void setOrientation(const glm::quat& orientation);
 
     /*@jsdoc
      * Gets the current mouse capture state.

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -41,7 +41,7 @@ static int cameraModeId = qRegisterMetaType<CameraMode>();
 class Camera : public QObject {
     Q_OBJECT
 
-    Q_PROPERTY(glm::vec<3,float,glm::packed_highp> position READ getPosition WRITE setPosition)
+    Q_PROPERTY(glm::vec3 position READ getPosition WRITE setPosition)
     Q_PROPERTY(glm::qua<float,glm::packed_highp> orientation READ getOrientation WRITE setOrientation)
     Q_PROPERTY(QString mode READ getModeString WRITE setModeString NOTIFY modeUpdated)
     Q_PROPERTY(QVariantMap frustum READ getViewFrustum CONSTANT)
@@ -88,7 +88,7 @@ public slots:
      * @function Camera.getPosition
      * @returns {Vec3} The current camera position.
      */
-    glm::vec<3,float,glm::packed_highp> getPosition() const { return _position; }
+    glm::vec3 getPosition() const { return _position; }
 
     /*@jsdoc
      * Sets the camera position. You can also set the position using the {@link Camera|Camera.position} property. Only works if 
@@ -96,7 +96,7 @@ public slots:
      * @function Camera.setPosition
      * @param {Vec3} position - The position to set the camera at.
      */
-    void setPosition(const glm::vec<3,float,glm::packed_highp>& position);
+    void setPosition(const glm::vec3& position);
 
     /*@jsdoc
      * Gets the current camera orientation. You can also get the orientation using the {@link Camera|Camera.orientation} 
@@ -202,7 +202,7 @@ public slots:
      *
      * Controller.mousePressEvent.connect(onMousePressEvent);
      */
-    void lookAt(const glm::vec<3,float,glm::packed_highp>& position);
+    void lookAt(const glm::vec3& position);
 
     /*@jsdoc
      * Sets the camera to continue looking at the specified <code>position</code> even while the camera moves. Only works if 
@@ -210,7 +210,7 @@ public slots:
      * @function Camera.keepLookingAt
      * @param {Vec3} position - The position to keep looking at.
      */
-    void keepLookingAt(const glm::vec<3,float,glm::packed_highp>& position);
+    void keepLookingAt(const glm::vec3& position);
 
     /*@jsdoc
      * Stops the camera from continually looking at the position that was set with {@link Camera.keepLookingAt}.

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -50,8 +50,8 @@ class ScriptEngine;
 // FIXME refactor this class to be a QQuickItem derived type and eliminate the needless wrapping 
 class QmlWindowClass : public QObject {
     Q_OBJECT
-    Q_PROPERTY(glm::vec<2,float,glm::packed_highp> position READ getPosition WRITE setPosition NOTIFY positionChanged)
-    Q_PROPERTY(glm::vec<2,float,glm::packed_highp> size READ getSize WRITE setSize NOTIFY sizeChanged)
+    Q_PROPERTY(glm::vec2 position READ getPosition WRITE setPosition NOTIFY positionChanged)
+    Q_PROPERTY(glm::vec2 size READ getSize WRITE setSize NOTIFY sizeChanged)
     Q_PROPERTY(bool visible READ isVisible WRITE setVisible NOTIFY visibleChanged)
 
 private:
@@ -102,14 +102,14 @@ public slots:
      * @function OverlayWindow.getPosition
      * @returns {Vec2} The position of the window, in pixels.
      */
-    glm::vec<2,float,glm::packed_highp> getPosition();
+    glm::vec2 getPosition();
 
     /*@jsdoc
      * Sets the position of the window, from a {@link Vec2}.
      * @function OverlayWindow.setPosition
      * @param {Vec2} position - The position of the window, in pixels.
      */
-    void setPosition(const glm::vec<2,float,glm::packed_highp>& position);
+    void setPosition(const glm::vec2& position);
 
     /*@jsdoc
      * Sets the position of the window, from a pair of numbers.
@@ -125,14 +125,14 @@ public slots:
      * @function OverlayWindow.getSize
      * @returns {Vec2} The size of the window interior, in pixels.
      */
-    glm::vec<2,float,glm::packed_highp> getSize();
+    glm::vec2 getSize();
 
     /*@jsdoc
      * Sets the size of the window interior, from a {@link Vec2}.
      * @function OverlayWindow.setSize
      * @param {Vec2} size - The size of the window interior, in pixels.
      */
-    void setSize(const glm::vec<2,float,glm::packed_highp>& size);
+    void setSize(const glm::vec2& size);
 
     /*@jsdoc
      * Sets the size of the window interior, from a pair of numbers.
@@ -275,7 +275,7 @@ signals:
      * @param {Vec2} position - The position of the window, in pixels.
      * @returns {Signal}
      */
-    void moved(glm::vec<2,float,glm::packed_highp> position);
+    void moved(glm::vec2 position);
 
     /*@jsdoc
      * Triggered when the window changes size.

--- a/tests/script-engine/src/ScriptEngineTests.cpp
+++ b/tests/script-engine/src/ScriptEngineTests.cpp
@@ -334,7 +334,7 @@ void ScriptEngineTests::testQuat() {
     });
 
     connect(sm.get(), &ScriptManager::unhandledException, [](std::shared_ptr<ScriptException> exception){
-        QVERIFY(exception->errorMessage.contains("undefined to glm::qua"));
+        QVERIFY(exception->errorMessage.contains("undefined to glm::quat"));
     });
 
 


### PR DESCRIPTION
The final commit is the relevant one. The others are just reverts.